### PR TITLE
implement channel password management at local and /pass command hand…

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChannelManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChannelManager.kt
@@ -284,9 +284,21 @@ class ChannelManager(
         state.setShowPasswordPrompt(false)
         state.setPasswordPromptChannel(null)
     }
-    
-    fun setChannelPassword(channel: String, password: String): Boolean {
-        return verifyChannelPassword(channel, password)
+
+    fun setChannelPassword(channel: String, password: String) {
+
+        channelPasswords[channel] = password
+
+        channelKeys[channel] = deriveChannelKey(password, channel)
+
+        state.setPasswordProtectedChannels(
+            state.getPasswordProtectedChannelsValue().toMutableSet().apply { add(channel) }
+        )
+
+        dataManager.saveChannelData(
+            state.getJoinedChannelsValue(),
+            state.getPasswordProtectedChannelsValue()
+        )
     }
     
     // MARK: - Emergency Clear

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -39,6 +39,7 @@ class CommandProcessor(
             "/m", "/msg" -> handleMessageCommand(parts, meshService)
             "/w" -> handleWhoCommand()
             "/clear" -> handleClearCommand()
+            "/pass" -> handlePassCommand(parts, myPeerID)
             "/block" -> handleBlockCommand(parts, meshService)
             "/unblock" -> handleUnblockCommand(parts, meshService)
             "/hug" -> handleActionCommand(parts, "gives", "a warm hug 🫂", meshService, myPeerID, onSendMessage)
@@ -54,7 +55,8 @@ class CommandProcessor(
         if (parts.size > 1) {
             val channelName = parts[1]
             val channel = if (channelName.startsWith("#")) channelName else "#$channelName"
-            val success = channelManager.joinChannel(channel, null, myPeerID)
+            val password = if (parts.size > 2) parts[2] else null
+            val success = channelManager.joinChannel(channel, password, myPeerID)
             if (success) {
                 val systemMessage = BitchatMessage(
                     sender = "system",
@@ -163,6 +165,52 @@ class CommandProcessor(
                 // Clear main messages
                 messageManager.clearMessages()
             }
+        }
+    }
+
+    private fun handlePassCommand(parts: List<String>, peerID: String) {
+        val currentChannel = state.getCurrentChannelValue()
+
+        if (currentChannel == null) {
+            val systemMessage = BitchatMessage(
+                sender = "system",
+                content = "you must be in a channel to set a password.",
+                timestamp = Date(),
+                isRelay = false
+            )
+            messageManager.addMessage(systemMessage)
+            return
+        }
+
+        if (parts.size == 2){
+            if(!channelManager.isChannelCreator(channel = currentChannel, peerID = peerID)){
+                val systemMessage = BitchatMessage(
+                    sender = "system",
+                    content = "you must be the channel creator to set a password.",
+                    timestamp = Date(),
+                    isRelay = false
+                )
+                channelManager.addChannelMessage(currentChannel,systemMessage,null)
+                return
+            }
+            val newPassword = parts[1]
+            channelManager.setChannelPassword(currentChannel, newPassword)
+            val systemMessage = BitchatMessage(
+                sender = "system",
+                content = "password changed for channel $currentChannel",
+                timestamp = Date(),
+                isRelay = false
+            )
+            channelManager.addChannelMessage(currentChannel,systemMessage,null)
+        }
+        else{
+            val systemMessage = BitchatMessage(
+                sender = "system",
+                content = "usage: /pass <password>",
+                timestamp = Date(),
+                isRelay = false
+            )
+            channelManager.addChannelMessage(currentChannel,systemMessage,null)
         }
     }
     


### PR DESCRIPTION
Description
This PR implements support for the /pass command handling.

Currently, when a user tries to use the /pass command, it is not recognized or handled in the business logic. This feature allows a user to set or announce a password for the current channel.

The logic is designed to parse and validate the /pass command and then store the channel with it's password locally -> to announce this "channel has password from now" to other connected users we need to implement a logic like IOS project. (The IOS project has announce method inside mesh service class)

Closes: #37

How it works
Parses messages starting with /pass
Extracts the password string
Applies necessary validation (e.g., minimum length)
Triggers the appropriate logic to store the password but not for share this event other connected users

Checklist

- [ ] Command parsing logic implemented

- [ ]  Secure handling of the password

- [ ]   Linked to Issue #37

feature is not intended to broadcast the "this channel has password"  to everyone . Open to feedback on business rules here.