### PR TITLE
fixes vertical padding in permission explanation

### DIFF
--- a/app/src/main/java/com/bitchat/android/onboarding/PermissionExplanationScreen.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/PermissionExplanationScreen.kt
@@ -30,10 +30,11 @@ fun PermissionExplanationScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(24.dp)
+            .padding(horizontal = 24.dp)
             .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        Spacer(modifier = Modifier.height(24.dp))
         // Header
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -164,6 +165,7 @@ fun PermissionExplanationScreen(
                 )
             }
         }
+        Spacer(modifier = Modifier.height(24.dp))
     }
 }
 


### PR DESCRIPTION
# Description

fixes #41 
<img width="200" height="690" alt="Screenshot 2025-07-10 at 11 19 24 PM" src="https://github.com/user-attachments/assets/d39767cd-2b10-4508-88e4-92239ffaab7a" />


## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/callebtc/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x] If it is a core feature, I have added automated tests
