### PR TITLE
Automatic versionName and versionCode generation from git tags

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.ByteArrayOutputStream
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -12,8 +14,9 @@ android {
         applicationId = "com.bitchat.android"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "1.0"
+        val tag = getGitTag()
+        versionName = tag
+        versionCode = getVersionCodeFromTag(tag)
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -98,3 +101,22 @@ dependencies {
     androidTestImplementation(libs.bundles.compose.testing)
     debugImplementation(libs.androidx.compose.ui.tooling)
 }
+
+fun getGitTag(): String {
+    return try {
+        val stdout = ByteArrayOutputStream()
+        exec {
+            commandLine = listOf("git", "describe", "--tags", "--abbrev=0")
+            standardOutput = stdout
+            isIgnoreExitValue = true
+        }
+        stdout.toString().trim().removePrefix("v")
+    } catch (e: Exception) {
+        "0.0.0"
+    }
+}
+
+fun getVersionCodeFromTag(tag: String): Int {
+    return tag.replace(".", "").toIntOrNull() ?: 1
+}
+


### PR DESCRIPTION
# Description
Automatic versionName and versionCode assignment has been implemented using the git tag and a versionCode derived from versionName. Now, when a new release tag is created and pushed, versionName and versionCode will be set automatically.
This eliminates the need for manual version updates and ensures consistent version management with CI/CD.
While this approach is a practical and effective solution for now, it can be replaced with a more robust or advanced versioning strategy in the future if project requirements evolve.       
Closes: https://github.com/permissionlesstech/bitchat-android/issues/52                       
## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/callebtc/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
