### PR TITLE
Prompt for nickname after onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved README documentation with updated clone URLs
 - Enhanced logging throughout the application for better debugging
 
-### Known Issues
-- Reinstallation via APK does not work in all cases; it is recommended to uninstall the previous version first.
-    - Root cause: [See issue #92, comment](https://github.com/permissionlesstech/bitchat-android/issues/92#issuecomment-3066035548)
-
 ## [0.5.1] - 2025-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved README documentation with updated clone URLs
 - Enhanced logging throughout the application for better debugging
 
+### Known Issues
+- Reinstallation via APK does not work in all cases; it is recommended to uninstall the previous version first.
+    - Root cause: [See issue #92, comment](https://github.com/permissionlesstech/bitchat-android/issues/92#issuecomment-3066035548)
+
 ## [0.5.1] - 2025-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7]
+
+### Added
+- Location services check during app startup with educational UI
+- Message text selection functionality in chat interface
+- Enhanced RSSI tracking and unread message indicators
+- Major Bluetooth connection architecture refactoring with dedicated managers
 
 ### Fixed
-- Permission onboarding screen UX: removed "Exit App" button and fixed "Grant Permissions" button positioning to always be visible
+- **Critical**: Android-iOS message fragmentation compatibility issues
+  - Fixed fragment size (500→150 bytes) and ID generation for cross-platform messaging
+  - Ensures Android can properly communicate with iOS devices
+- DirectMessage notifications and text copying functionality
+- Smart routing optimizations (no relay loops, targeted delivery)
+- Build system compilation issues and null pointer exceptions
+
+### Changed
+- Comprehensive dependency updates (AGP 8.10.1, Kotlin 2.2.0, Compose 2025.06.01)
+- Optimized BLE scan intervals for better battery performance
+- Reduced excessive logging output
+
+### Improved
+- Cross-platform compatibility with iOS and Rust implementations
+- Connection stability through architectural improvements
+- Battery performance via scan duty cycling
+- User onboarding with location services education
 
 ## [0.6]
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.kotlin.compose)
 }
 
 android {
@@ -40,9 +41,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
     packaging {
         resources {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.bitchat.android"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 2
-        versionName = "0.6"
+        versionCode = 3
+        versionName = "0.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -33,6 +33,7 @@ class MainActivity : ComponentActivity() {
     private lateinit var permissionManager: PermissionManager
     private lateinit var onboardingCoordinator: OnboardingCoordinator
     private lateinit var bluetoothStatusManager: BluetoothStatusManager
+    private lateinit var locationStatusManager: LocationStatusManager
     
     // Core mesh service - managed at app level
     private lateinit var meshService: BluetoothMeshService
@@ -48,12 +49,15 @@ class MainActivity : ComponentActivity() {
     // UI state for onboarding flow
     private var onboardingState by mutableStateOf(OnboardingState.CHECKING)
     private var bluetoothStatus by mutableStateOf(BluetoothStatus.ENABLED)
+    private var locationStatus by mutableStateOf(LocationStatus.ENABLED)
     private var errorMessage by mutableStateOf("")
     private var isBluetoothLoading by mutableStateOf(false)
+    private var isLocationLoading by mutableStateOf(false)
     
     enum class OnboardingState {
         CHECKING,
         BLUETOOTH_CHECK,
+        LOCATION_CHECK,
         PERMISSION_EXPLANATION,
         PERMISSION_REQUESTING,
         INITIALIZING,
@@ -74,6 +78,12 @@ class MainActivity : ComponentActivity() {
             context = this,
             onBluetoothEnabled = ::handleBluetoothEnabled,
             onBluetoothDisabled = ::handleBluetoothDisabled
+        )
+        locationStatusManager = LocationStatusManager(
+            activity = this,
+            context = this,
+            onLocationEnabled = ::handleLocationEnabled,
+            onLocationDisabled = ::handleLocationDisabled
         )
         onboardingCoordinator = OnboardingCoordinator(
             activity = this,
@@ -115,6 +125,20 @@ class MainActivity : ComponentActivity() {
                         checkBluetoothAndProceed()
                     },
                     isLoading = isBluetoothLoading
+                )
+            }
+            
+            OnboardingState.LOCATION_CHECK -> {
+                LocationCheckScreen(
+                    status = locationStatus,
+                    onEnableLocation = {
+                        isLocationLoading = true
+                        locationStatusManager.requestEnableLocation()
+                    },
+                    onRetry = {
+                        checkLocationAndProceed()
+                    },
+                    isLoading = isLocationLoading
                 )
             }
             
@@ -189,7 +213,7 @@ class MainActivity : ComponentActivity() {
      * Check Bluetooth status and proceed with onboarding flow
      */
     private fun checkBluetoothAndProceed() {
-        android.util.Log.d("MainActivity", "Checking Bluetooth status")
+        // android.util.Log.d("MainActivity", "Checking Bluetooth status")
         
         // For first-time users, skip Bluetooth check and go straight to permissions
         // We'll check Bluetooth after permissions are granted
@@ -205,8 +229,8 @@ class MainActivity : ComponentActivity() {
         
         when (bluetoothStatus) {
             BluetoothStatus.ENABLED -> {
-                // Bluetooth is enabled, proceed with permission/onboarding check
-                proceedWithPermissionCheck()
+                // Bluetooth is enabled, check location services next
+                checkLocationAndProceed()
             }
             BluetoothStatus.DISABLED -> {
                 // Show Bluetooth enable screen (should have permissions as existing user)
@@ -253,7 +277,76 @@ class MainActivity : ComponentActivity() {
         android.util.Log.d("MainActivity", "Bluetooth enabled by user")
         isBluetoothLoading = false
         bluetoothStatus = BluetoothStatus.ENABLED
+        checkLocationAndProceed()
+    }
+
+    /**
+     * Check Location services status and proceed with onboarding flow
+     */
+    private fun checkLocationAndProceed() {
+        android.util.Log.d("MainActivity", "Checking location services status")
+        
+        // For first-time users, skip location check and go straight to permissions
+        // We'll check location after permissions are granted
+        if (permissionManager.isFirstTimeLaunch()) {
+            android.util.Log.d("MainActivity", "First-time launch, skipping location check - will check after permissions")
+            proceedWithPermissionCheck()
+            return
+        }
+        
+        // For existing users, check location status
+        locationStatusManager.logLocationStatus()
+        locationStatus = locationStatusManager.checkLocationStatus()
+        
+        when (locationStatus) {
+            LocationStatus.ENABLED -> {
+                // Location services enabled, proceed with permission/onboarding check
+                proceedWithPermissionCheck()
+            }
+            LocationStatus.DISABLED -> {
+                // Show location enable screen (should have permissions as existing user)
+                android.util.Log.d("MainActivity", "Location services disabled, showing enable screen")
+                onboardingState = OnboardingState.LOCATION_CHECK
+                isLocationLoading = false
+            }
+            LocationStatus.NOT_AVAILABLE -> {
+                // Device doesn't support location services (very unusual)
+                android.util.Log.e("MainActivity", "Location services not available")
+                onboardingState = OnboardingState.LOCATION_CHECK
+                isLocationLoading = false
+            }
+        }
+    }
+
+    /**
+     * Handle Location enabled callback
+     */
+    private fun handleLocationEnabled() {
+        android.util.Log.d("MainActivity", "Location services enabled by user")
+        isLocationLoading = false
+        locationStatus = LocationStatus.ENABLED
         proceedWithPermissionCheck()
+    }
+
+    /**
+     * Handle Location disabled callback
+     */
+    private fun handleLocationDisabled(message: String) {
+        android.util.Log.w("MainActivity", "Location services disabled or failed: $message")
+        isLocationLoading = false
+        locationStatus = locationStatusManager.checkLocationStatus()
+        
+        when {
+            locationStatus == LocationStatus.NOT_AVAILABLE -> {
+                // Show permanent error for devices without location services
+                errorMessage = message
+                onboardingState = OnboardingState.ERROR
+            }
+            else -> {
+                // Stay on location check screen for retry
+                onboardingState = OnboardingState.LOCATION_CHECK
+            }
+        }
     }
     
     /**
@@ -289,20 +382,33 @@ class MainActivity : ComponentActivity() {
     }
     
     private fun handleOnboardingComplete() {
-        android.util.Log.d("MainActivity", "Onboarding completed, checking Bluetooth again before initializing app")
+        android.util.Log.d("MainActivity", "Onboarding completed, checking Bluetooth and Location before initializing app")
         
-        // After permissions are granted, re-check Bluetooth status
+        // After permissions are granted, re-check both Bluetooth and Location status
         val currentBluetoothStatus = bluetoothStatusManager.checkBluetoothStatus()
-        if (currentBluetoothStatus == BluetoothStatus.ENABLED) {
-            // Bluetooth is enabled, proceed to app initialization
-            onboardingState = OnboardingState.INITIALIZING
-            initializeApp()
-        } else {
-            // Bluetooth still disabled, but now we have permissions to enable it
-            android.util.Log.d("MainActivity", "Permissions granted, but Bluetooth still disabled. Showing Bluetooth enable screen.")
-            bluetoothStatus = currentBluetoothStatus
-            onboardingState = OnboardingState.BLUETOOTH_CHECK
-            isBluetoothLoading = false
+        val currentLocationStatus = locationStatusManager.checkLocationStatus()
+        
+        when {
+            currentBluetoothStatus != BluetoothStatus.ENABLED -> {
+                // Bluetooth still disabled, but now we have permissions to enable it
+                android.util.Log.d("MainActivity", "Permissions granted, but Bluetooth still disabled. Showing Bluetooth enable screen.")
+                bluetoothStatus = currentBluetoothStatus
+                onboardingState = OnboardingState.BLUETOOTH_CHECK
+                isBluetoothLoading = false
+            }
+            currentLocationStatus != LocationStatus.ENABLED -> {
+                // Location services still disabled, but now we have permissions to enable it
+                android.util.Log.d("MainActivity", "Permissions granted, but Location services still disabled. Showing Location enable screen.")
+                locationStatus = currentLocationStatus
+                onboardingState = OnboardingState.LOCATION_CHECK
+                isLocationLoading = false
+            }
+            else -> {
+                // Both are enabled, proceed to app initialization
+                android.util.Log.d("MainActivity", "Both Bluetooth and Location services are enabled, proceeding to initialization")
+                onboardingState = OnboardingState.INITIALIZING
+                initializeApp()
+            }
         }
     }
     
@@ -363,7 +469,7 @@ class MainActivity : ComponentActivity() {
     
     override fun onResume() {
         super.onResume()
-        // Check Bluetooth status on resume and handle accordingly
+        // Check Bluetooth and Location status on resume and handle accordingly
         if (onboardingState == OnboardingState.COMPLETE) {
             // Set app foreground state
             meshService.connectionManager.setAppBackgroundState(false)
@@ -376,6 +482,16 @@ class MainActivity : ComponentActivity() {
                 bluetoothStatus = currentBluetoothStatus
                 onboardingState = OnboardingState.BLUETOOTH_CHECK
                 isBluetoothLoading = false
+                return
+            }
+            
+            // Check if location services were disabled while app was backgrounded
+            val currentLocationStatus = locationStatusManager.checkLocationStatus()
+            if (currentLocationStatus != LocationStatus.ENABLED) {
+                android.util.Log.w("MainActivity", "Location services disabled while app was backgrounded")
+                locationStatus = currentLocationStatus
+                onboardingState = OnboardingState.LOCATION_CHECK
+                isLocationLoading = false
             }
         }
     }
@@ -436,6 +552,15 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        
+        // Cleanup location status manager
+        try {
+            locationStatusManager.cleanup()
+            android.util.Log.d("MainActivity", "Location status manager cleaned up successfully")
+        } catch (e: Exception) {
+            android.util.Log.w("MainActivity", "Error cleaning up location status manager: ${e.message}")
+        }
+        
         // Stop mesh services if app was fully initialized
         if (onboardingState == OnboardingState.COMPLETE) {
             try {

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -353,11 +353,11 @@ class MainActivity : ComponentActivity() {
         }
     }
     
-    override fun onNewIntent(intent: Intent?) {
+    override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         // Handle notification intents when app is already running
         if (onboardingState == OnboardingState.COMPLETE) {
-            intent?.let { handleNotificationIntent(it) }
+            handleNotificationIntent(intent)
         }
     }
     

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -1,27 +1,34 @@
 package com.bitchat.android
 
-import android.Manifest
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.activity.viewModels
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.ViewModelProvider
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.addCallback
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import com.bitchat.android.mesh.BluetoothMeshService
-import com.bitchat.android.onboarding.*
+import com.bitchat.android.onboarding.BluetoothCheckScreen
+import com.bitchat.android.onboarding.BluetoothStatus
+import com.bitchat.android.onboarding.BluetoothStatusManager
+import com.bitchat.android.onboarding.InitializationErrorScreen
+import com.bitchat.android.onboarding.InitializingScreen
+import com.bitchat.android.onboarding.LocationCheckScreen
+import com.bitchat.android.onboarding.LocationStatus
+import com.bitchat.android.onboarding.LocationStatusManager
+import com.bitchat.android.onboarding.NicknamePromptScreen
+import com.bitchat.android.onboarding.OnboardingCoordinator
+import com.bitchat.android.onboarding.PermissionExplanationScreen
+import com.bitchat.android.onboarding.PermissionManager
 import com.bitchat.android.ui.ChatScreen
 import com.bitchat.android.ui.ChatViewModel
 import com.bitchat.android.ui.theme.BitchatTheme
@@ -46,7 +53,6 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private val chatViewModel: ChatViewModel by viewModels()
 
     // UI state for onboarding flow
     private var onboardingState by mutableStateOf(OnboardingState.CHECKING)
@@ -494,9 +500,8 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    override fun onNewIntent(intent: Intent?) {
+    override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        // Handle notification intents when app is already running
         if (onboardingState == OnboardingState.COMPLETE) {
             handleNotificationIntent(intent)
         }

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -478,8 +478,12 @@ class MainActivity : ComponentActivity() {
 
                 android.util.Log.d("MainActivity", "App initialization complete")
                 // Show nickname prompt instead of directly completing onboarding
-                onboardingState = OnboardingState.NICKNAME_PROMPT
-
+                val savedNickname = chatViewModel.nickname.value
+                onboardingState = if (savedNickname.isNullOrBlank()) {
+                    OnboardingState.NICKNAME_PROMPT
+                } else {
+                    OnboardingState.COMPLETE
+                }
             } catch (e: Exception) {
                 android.util.Log.e("MainActivity", "Failed to initialize app", e)
                 handleOnboardingFailed("Failed to initialize the app: ${e.message}")

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -45,7 +45,7 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
-    
+
     private val chatViewModel: ChatViewModel by viewModels()
 
     // UI state for onboarding flow
@@ -54,6 +54,7 @@ class MainActivity : ComponentActivity() {
     private var locationStatus by mutableStateOf(LocationStatus.ENABLED)
     private var errorMessage by mutableStateOf("")
     private var isBluetoothLoading by mutableStateOf(false)
+
     private var isLocationLoading by mutableStateOf(false)
 
 
@@ -160,11 +161,11 @@ class MainActivity : ComponentActivity() {
             OnboardingState.PERMISSION_REQUESTING -> {
                 InitializingScreen()
             }
-
+            
             OnboardingState.INITIALIZING -> {
                 InitializingScreen()
             }
-
+            
             OnboardingState.COMPLETE -> {
                 // Set up back navigation handling for the chat screen
                 val backCallback = object : OnBackPressedCallback(true) {
@@ -187,7 +188,7 @@ class MainActivity : ComponentActivity() {
                 ChatScreen(viewModel = chatViewModel)
 
             }
-
+            
             OnboardingState.ERROR -> {
                 InitializationErrorScreen(
                     errorMessage = errorMessage,
@@ -211,27 +212,27 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
-
+    
     private fun checkOnboardingStatus() {
         android.util.Log.d("MainActivity", "Checking onboarding status")
-
+        
         lifecycleScope.launch {
             // Small delay to show the checking state
             delay(500)
-
+            
             // First check Bluetooth status (always required)
             checkBluetoothAndProceed()
         }
     }
-
+    
     /**
      * Check Bluetooth status and proceed with onboarding flow
      */
     private fun checkBluetoothAndProceed() {
         // android.util.Log.d("MainActivity", "Checking Bluetooth status")
-        
-        android.util.Log.d("MainActivity", "Checking Bluetooth status")
 
+        android.util.Log.d("MainActivity", "Checking Bluetooth status")
+        
         // For first-time users, skip Bluetooth check and go straight to permissions
         // We'll check Bluetooth after permissions are granted
         if (permissionManager.isFirstTimeLaunch()) {
@@ -392,11 +393,13 @@ class MainActivity : ComponentActivity() {
                 android.util.Log.d("MainActivity", "Bluetooth enable requires permissions, proceeding to permission explanation")
                 proceedWithPermissionCheck()
             }
+
             message.contains("Permission") -> {
                 // For existing users, redirect to permission explanation to grant missing permissions
                 android.util.Log.d("MainActivity", "Bluetooth enable requires permissions, showing permission explanation")
                 onboardingState = OnboardingState.PERMISSION_EXPLANATION
             }
+
             else -> {
                 // Stay on Bluetooth check screen for retry
                 onboardingState = OnboardingState.BLUETOOTH_CHECK
@@ -465,14 +468,14 @@ class MainActivity : ComponentActivity() {
                 meshService.startServices()
 
                 android.util.Log.d("MainActivity", "Mesh service started successfully")
-                
+
 
                 // Initialize chat view model - this will start the mesh service
                 chatViewModel.meshService.startServices()
 
                 // Handle any notification intent
                 handleNotificationIntent(intent)
-
+                
                 // Small delay to ensure mesh service is fully initialized
                 delay(500)
 
@@ -498,7 +501,7 @@ class MainActivity : ComponentActivity() {
             handleNotificationIntent(intent)
         }
     }
-    
+
     override fun onResume() {
         super.onResume()
         // Check Bluetooth and Location status on resume and handle accordingly
@@ -537,7 +540,7 @@ class MainActivity : ComponentActivity() {
             chatViewModel.setAppBackgroundState(true)
         }
     }
-
+    
     /**
      * Handle intents from notification clicks - open specific private chat
      */
@@ -546,7 +549,7 @@ class MainActivity : ComponentActivity() {
             com.bitchat.android.ui.NotificationManager.EXTRA_OPEN_PRIVATE_CHAT,
             false
         )
-        
+
         if (shouldOpenPrivateChat) {
             val peerID =
                 intent.getStringExtra(com.bitchat.android.ui.NotificationManager.EXTRA_PEER_ID)
@@ -555,10 +558,10 @@ class MainActivity : ComponentActivity() {
 
             if (peerID != null) {
                 android.util.Log.d("MainActivity", "Opening private chat with $senderNickname (peerID: $peerID) from notification")
-                
+
                 // Open the private chat with this peer
                 chatViewModel.startPrivateChat(peerID)
-                
+
                 // Clear notifications for this sender since user is now viewing the chat
                 chatViewModel.clearNotificationsForSender(peerID)
             }
@@ -601,7 +604,10 @@ class MainActivity : ComponentActivity() {
                 meshService.stopServices()
                 android.util.Log.d("MainActivity", "Mesh services stopped successfully")
             } catch (e: Exception) {
-                android.util.Log.w("MainActivity", "Error stopping mesh services in onDestroy: ${e.message}")
+                android.util.Log.w(
+                    "MainActivity",
+                    "Error stopping mesh services in onDestroy: ${e.message}"
+                )
             }
         }
     }

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
@@ -14,7 +14,8 @@ import kotlinx.coroutines.*
  */
 class BluetoothConnectionManager(
     private val context: Context, 
-    private val myPeerID: String
+    private val myPeerID: String,
+    private val fragmentManager: FragmentManager? = null
 ) : PowerManagerDelegate {
     
     companion object {
@@ -35,7 +36,7 @@ class BluetoothConnectionManager(
     // Component managers
     private val permissionManager = BluetoothPermissionManager(context)
     private val connectionTracker = BluetoothConnectionTracker(connectionScope, powerManager)
-    private val packetBroadcaster = BluetoothPacketBroadcaster(connectionScope, connectionTracker)
+    private val packetBroadcaster = BluetoothPacketBroadcaster(connectionScope, connectionTracker, fragmentManager)
     
     // Delegate for component managers to call back to main manager
     private val componentDelegate = object : BluetoothConnectionManagerDelegate {
@@ -156,6 +157,7 @@ class BluetoothConnectionManager(
 
     /**
      * Broadcast packet to connected devices with connection limit enforcement
+     * Automatically fragments large packets to fit within BLE MTU limits
      */
     fun broadcastPacket(routed: RoutedPacket) {
         if (!isActive) return

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
@@ -41,11 +41,22 @@ class BluetoothConnectionManager(
     // Delegate for component managers to call back to main manager
     private val componentDelegate = object : BluetoothConnectionManagerDelegate {
         override fun onPacketReceived(packet: BitchatPacket, peerID: String, device: BluetoothDevice?) {
+            device?.let { bluetoothDevice ->
+                // Get current RSSI for this device and update if available
+                val currentRSSI = connectionTracker.getBestRSSI(bluetoothDevice.address)
+                if (currentRSSI != null) {
+                    delegate?.onRSSIUpdated(bluetoothDevice.address, currentRSSI)
+                }
+            }
             delegate?.onPacketReceived(packet, peerID, device)
         }
         
         override fun onDeviceConnected(device: BluetoothDevice) {
             delegate?.onDeviceConnected(device)
+        }
+        
+        override fun onRSSIUpdated(deviceAddress: String, rssi: Int) {
+            delegate?.onRSSIUpdated(deviceAddress, rssi)
         }
     }
     
@@ -231,4 +242,5 @@ class BluetoothConnectionManager(
 interface BluetoothConnectionManagerDelegate {
     fun onPacketReceived(packet: BitchatPacket, peerID: String, device: BluetoothDevice?)
     fun onDeviceConnected(device: BluetoothDevice)
+    fun onRSSIUpdated(deviceAddress: String, rssi: Int)
 }

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
@@ -1,24 +1,16 @@
 package com.bitchat.android.mesh
 
-import android.Manifest
 import android.bluetooth.*
-import android.bluetooth.le.*
 import android.content.Context
-import android.content.pm.PackageManager
-import android.os.ParcelUuid
 import android.util.Log
-import androidx.core.app.ActivityCompat
-import com.bitchat.android.protocol.BitchatPacket
-import com.bitchat.android.protocol.SpecialRecipients
 import com.bitchat.android.model.RoutedPacket
+import com.bitchat.android.protocol.BitchatPacket
 import kotlinx.coroutines.*
-import java.util.*
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Power-optimized Bluetooth connection manager with comprehensive memory management
  * Integrates with PowerManager for adaptive power consumption
+ * Coordinates smaller, focused components for better maintainability
  */
 class BluetoothConnectionManager(
     private val context: Context, 
@@ -27,82 +19,50 @@ class BluetoothConnectionManager(
     
     companion object {
         private const val TAG = "BluetoothConnectionManager"
-        // Use exact same UUIDs as iOS version
-        private val SERVICE_UUID = UUID.fromString("F47B5E2D-4A9E-4C5A-9B3F-8E1D2C3A4B5C")
-        private val CHARACTERISTIC_UUID = UUID.fromString("A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D")
-        
-        // Connection management constants
-        private const val CONNECTION_RETRY_DELAY = 5000L
-        private const val MAX_CONNECTION_ATTEMPTS = 3
-        private const val CLEANUP_DELAY = 500L
-        private const val CLEANUP_INTERVAL = 30000L // 30 seconds
     }
     
     // Core Bluetooth components
     private val bluetoothManager: BluetoothManager = 
         context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
     private val bluetoothAdapter: BluetoothAdapter? = bluetoothManager.adapter
-    private val bleScanner: BluetoothLeScanner? = bluetoothAdapter?.bluetoothLeScanner
-    private val bleAdvertiser: BluetoothLeAdvertiser? = bluetoothAdapter?.bluetoothLeAdvertiser
     
     // Power management
     private val powerManager = PowerManager(context)
     
-    // GATT server for peripheral mode
-    private var gattServer: BluetoothGattServer? = null
-    private var characteristic: BluetoothGattCharacteristic? = null
+    // Coroutines
+    private val connectionScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     
-    // Simplified connection tracking - reduced memory footprint
-    private val connectedDevices = ConcurrentHashMap<String, DeviceConnection>()
-    private val subscribedDevices = CopyOnWriteArrayList<BluetoothDevice>()
-    public val addressPeerMap = ConcurrentHashMap<String, String>()
+    // Component managers
+    private val permissionManager = BluetoothPermissionManager(context)
+    private val connectionTracker = BluetoothConnectionTracker(connectionScope, powerManager)
+    private val packetBroadcaster = BluetoothPacketBroadcaster(connectionScope, connectionTracker)
     
-    // Connection attempt tracking with automatic cleanup
-    private val pendingConnections = ConcurrentHashMap<String, ConnectionAttempt>()
+    // Delegate for component managers to call back to main manager
+    private val componentDelegate = object : BluetoothConnectionManagerDelegate {
+        override fun onPacketReceived(packet: BitchatPacket, peerID: String, device: BluetoothDevice?) {
+            delegate?.onPacketReceived(packet, peerID, device)
+        }
+        
+        override fun onDeviceConnected(device: BluetoothDevice) {
+            delegate?.onDeviceConnected(device)
+        }
+    }
+    
+    private val serverManager = BluetoothGattServerManager(
+        context, connectionScope, connectionTracker, permissionManager, powerManager, componentDelegate
+    )
+    private val clientManager = BluetoothGattClientManager(
+        context, connectionScope, connectionTracker, permissionManager, powerManager, componentDelegate
+    )
     
     // Service state
     private var isActive = false
-    private var scanCallback: ScanCallback? = null
-    private var advertiseCallback: AdvertiseCallback? = null
-    
-    // CRITICAL FIX: Scan rate limiting to prevent "scanning too frequently" errors
-    private var lastScanStartTime = 0L
-    private var lastScanStopTime = 0L
-    private var isCurrentlyScanning = false
-    private val scanRateLimit = 5000L // Minimum 5 seconds between scan start attempts
     
     // Delegate for callbacks
     var delegate: BluetoothConnectionManagerDelegate? = null
     
-    // Coroutines
-    private val connectionScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    
-    /**
-     * Consolidated device connection information
-     */
-    private data class DeviceConnection(
-        val device: BluetoothDevice,
-        val gatt: BluetoothGatt? = null,
-        val characteristic: BluetoothGattCharacteristic? = null,
-        val rssi: Int = Int.MIN_VALUE,
-        val isClient: Boolean = false,
-        val connectedAt: Long = System.currentTimeMillis()
-    )
-    
-    /**
-     * Connection attempt tracking with automatic expiry
-     */
-    private data class ConnectionAttempt(
-        val attempts: Int,
-        val lastAttempt: Long = System.currentTimeMillis()
-    ) {
-        fun isExpired(): Boolean = 
-            System.currentTimeMillis() - lastAttempt > CONNECTION_RETRY_DELAY * 2
-        
-        fun shouldRetry(): Boolean = 
-            attempts < MAX_CONNECTION_ATTEMPTS && 
-            System.currentTimeMillis() - lastAttempt > CONNECTION_RETRY_DELAY
-    }
+    // Public property for address-peer mapping
+    val addressPeerMap get() = connectionTracker.addressPeerMap
     
     init {
         powerManager.delegate = this
@@ -114,7 +74,7 @@ class BluetoothConnectionManager(
     fun startServices(): Boolean {
         Log.i(TAG, "Starting power-optimized Bluetooth services...")
         
-        if (!hasBluetoothPermissions()) {
+        if (!permissionManager.hasBluetoothPermissions()) {
             Log.e(TAG, "Missing Bluetooth permissions")
             return false
         }
@@ -124,32 +84,30 @@ class BluetoothConnectionManager(
             return false
         }
         
-        if (bleScanner == null || bleAdvertiser == null) {
-            Log.e(TAG, "BLE scanner or advertiser not available")
-            return false
-        }
-        
         try {
             isActive = true
             
-            // Setup GATT server first
-            setupGattServer()
-            
-            // Start power manager and services
+            // Start all component managers
             connectionScope.launch {
+                // Start connection tracker first
+                connectionTracker.start()
+                
+                // Start power manager
                 powerManager.start()
-                delay(300) // Brief delay to ensure GATT server is ready
                 
-                startAdvertising()
-                delay(100)
-                
-                if (powerManager.shouldUseDutyCycle()) {
-                    Log.i(TAG, "Using power-aware duty cycling")
-                } else {
-                    startScanning()
+                // Start server manager
+                if (!serverManager.start()) {
+                    Log.e(TAG, "Failed to start server manager")
+                    this@BluetoothConnectionManager.isActive = false
+                    return@launch
                 }
                 
-                startPeriodicCleanup()
+                // Start client manager
+                if (!clientManager.start()) {
+                    Log.e(TAG, "Failed to start client manager")
+                    this@BluetoothConnectionManager.isActive = false
+                    return@launch
+                }
                 
                 Log.i(TAG, "Bluetooth services started successfully")
             }
@@ -172,23 +130,17 @@ class BluetoothConnectionManager(
         isActive = false
         
         connectionScope.launch {
-            // Stop power manager first
+            // Stop component managers
+            clientManager.stop()
+            serverManager.stop()
+            
+            // Stop power manager
             powerManager.stop()
             
-            // Stop scanning and advertising  
-            stopScanning()
-            stopAdvertising()
+            // Stop connection tracker
+            connectionTracker.stop()
             
-            // Cleanup all GATT connections with delay
-            cleanupAllConnections()
-            
-            // Close GATT server
-            gattServer?.close()
-            gattServer = null
-            
-            // Clear tracking
-            clearAllConnections()
-            
+            // Cancel the coroutine scope
             connectionScope.cancel()
             
             Log.i(TAG, "All Bluetooth services stopped")
@@ -201,115 +153,24 @@ class BluetoothConnectionManager(
     fun setAppBackgroundState(inBackground: Boolean) {
         powerManager.setAppBackgroundState(inBackground)
     }
-    
-    // Function to send data to a single device (server side)
-    private fun notifyDevice(device: BluetoothDevice, data: ByteArray): Boolean {
-        return try {
-            characteristic?.let { char ->
-                char.value = data
-                val result = gattServer?.notifyCharacteristicChanged(device, char, false) ?: false
-                result
-            } ?: false
-        } catch (e: Exception) {
-            Log.w(TAG, "Error sending to server connection ${device.address}: ${e.message}")
-            connectionScope.launch {
-                delay(CLEANUP_DELAY)
-                subscribedDevices.remove(device)
-                addressPeerMap.remove(device.address)
-            }
-            false
-        }
-    }
-
-    // Function to send data to a single device (client side)
-    private fun writeToDeviceConn(deviceConn: DeviceConnection, data: ByteArray): Boolean {
-        return try {
-            deviceConn.characteristic?.let { char ->
-                char.value = data
-                val result = deviceConn.gatt?.writeCharacteristic(char) ?: false
-                result
-            } ?: false
-        } catch (e: Exception) {
-            Log.w(TAG, "Error sending to client connection ${deviceConn.device.address}: ${e.message}")
-            connectionScope.launch {
-                delay(CLEANUP_DELAY)
-                cleanupDeviceConnection(deviceConn.device.address)
-            }
-            false
-        }
-    }
 
     /**
      * Broadcast packet to connected devices with connection limit enforcement
      */
     fun broadcastPacket(routed: RoutedPacket) {
-        val packet = routed.packet
-
         if (!isActive) return
         
-        val data = packet.toBinaryData() ?: return
-        
-        if (packet.recipientID != SpecialRecipients.BROADCAST) {
-            val recipientID = packet.recipientID?.let {
-                String(it).replace("\u0000", "").trim()
-            } ?: ""
-
-            // Try to find the recipient in server connections (subscribedDevices)
-            val targetDevice = subscribedDevices.firstOrNull { addressPeerMap[it.address] == recipientID }
-            // If found, send directly
-            if (targetDevice != null) {
-                Log.d(TAG, "Send packet type ${packet.type} directly to target device for recipient $recipientID: ${targetDevice.address}")
-                if (notifyDevice(targetDevice, data))
-                    return  // Sent, no need to continue
-            }
-
-            // Try to find the recipient in client connections (connectedDevices)
-            val targetDeviceConn = connectedDevices.values.firstOrNull { addressPeerMap[it.device.address] == recipientID }
-            // If found, send directly
-            if (targetDeviceConn != null) {
-                Log.d(TAG, "Send packet type ${packet.type} directly to target client connection for recipient $recipientID: ${targetDeviceConn.device.address}")
-                if (writeToDeviceConn(targetDeviceConn, data))
-                    return  // Sent, no need to continue
-            }
-        }
-
-        // Else, continue with broadcasting to all devices
-        Log.d(TAG, "Broadcasting packet type ${packet.type} to ${subscribedDevices.size} server + ${connectedDevices.size} client connections")
-
-        val senderID = String(packet.senderID).replace("\u0000", "")        
-        // Send to server connections (devices connected to our GATT server)
-        subscribedDevices.forEach { device ->
-            if (device.address == routed.relayAddress) {
-                Log.d(TAG, "Skipping broadcast back to relayer: ${device.address}")
-                return@forEach
-            }
-            if (addressPeerMap[device.address] == senderID) {
-                Log.d(TAG, "Skipping broadcast back to sender: ${device.address}")
-                return@forEach
-            }
-            notifyDevice(device, data)
-        }
-        
-        // Send to client connections
-        connectedDevices.values.forEach { deviceConn ->
-            if (deviceConn.isClient && deviceConn.gatt != null && deviceConn.characteristic != null) {
-                if (deviceConn.device.address == routed.relayAddress) {
-                    Log.d(TAG, "Skipping broadcast back to relayer: ${deviceConn.device.address}")
-                    return@forEach
-                }
-                if (addressPeerMap[deviceConn.device.address] == senderID) {
-                    Log.d(TAG, "Skipping broadcast back to sender: ${deviceConn.device.address}")
-                    return@forEach
-                }
-                writeToDeviceConn(deviceConn, data)
-            }
-        }
+        packetBroadcaster.broadcastPacket(
+            routed,
+            serverManager.getGattServer(),
+            serverManager.getCharacteristic()
+        )
     }
     
     /**
      * Get connected device count
      */
-    fun getConnectedDeviceCount(): Int = connectedDevices.size
+    fun getConnectedDeviceCount(): Int = connectionTracker.getConnectedDeviceCount()
     
     /**
      * Get debug information including power management
@@ -320,25 +181,12 @@ class BluetoothConnectionManager(
             appendLine("Bluetooth MAC Address: ${bluetoothAdapter?.address}")
             appendLine("Active: $isActive")
             appendLine("Bluetooth Enabled: ${bluetoothAdapter?.isEnabled}")
-            appendLine("Has Permissions: ${hasBluetoothPermissions()}")
-            appendLine("GATT Server Active: ${gattServer != null}")
+            appendLine("Has Permissions: ${permissionManager.hasBluetoothPermissions()}")
+            appendLine("GATT Server Active: ${serverManager.getGattServer() != null}")
             appendLine()
             appendLine(powerManager.getPowerInfo())
             appendLine()
-            appendLine("Connected Devices: ${connectedDevices.size} / ${powerManager.getMaxConnections()}")
-            connectedDevices.forEach { (address, deviceConn) ->
-                val age = (System.currentTimeMillis() - deviceConn.connectedAt) / 1000
-                appendLine("  - $address (${if (deviceConn.isClient) "client" else "server"}, ${age}s, RSSI: ${deviceConn.rssi})")
-            }
-            appendLine()
-            appendLine("Subscribed Devices (server mode): ${subscribedDevices.size}")
-            appendLine()
-            appendLine("Pending Connections: ${pendingConnections.size}")
-            val now = System.currentTimeMillis()
-            pendingConnections.forEach { (address, attempt) ->
-                val elapsed = (now - attempt.lastAttempt) / 1000
-                appendLine("  - $address: ${attempt.attempts} attempts, last ${elapsed}s ago")
-            }
+            appendLine(connectionTracker.getDebugInfo())
         }
     }
     
@@ -352,655 +200,27 @@ class BluetoothConnectionManager(
             val wasUsingDutyCycle = powerManager.shouldUseDutyCycle()
             
             // Update advertising with new power settings
-            stopAdvertising()
-            delay(100)
-            startAdvertising()
+            serverManager.restartAdvertising()
             
             // Only restart scanning if the duty cycle behavior changed
             val nowUsingDutyCycle = powerManager.shouldUseDutyCycle()
             if (wasUsingDutyCycle != nowUsingDutyCycle) {
                 Log.d(TAG, "Duty cycle behavior changed (${wasUsingDutyCycle} -> ${nowUsingDutyCycle}), restarting scan")
-                stopScanning()
-                delay(1000) // Extra delay to avoid rate limiting
-                
-                if (nowUsingDutyCycle) {
-                    Log.i(TAG, "Switching to duty cycle scanning mode")
-                    // Duty cycle will handle scanning
-                } else {
-                    Log.i(TAG, "Switching to continuous scanning mode")
-                    startScanning()
-                }
+                clientManager.restartScanning()
             } else {
                 Log.d(TAG, "Duty cycle behavior unchanged, keeping existing scan state")
             }
             
             // Enforce connection limits
-            enforceConnectionLimits()
+            connectionTracker.enforceConnectionLimits()
         }
     }
     
     override fun onScanStateChanged(shouldScan: Boolean) {
-        if (shouldScan) {
-            startScanning()
-        } else {
-            stopScanning()
-        }
+        clientManager.onScanStateChanged(shouldScan)
     }
     
-    // MARK: - Private Implementation
-    
-    private fun hasBluetoothPermissions(): Boolean {
-        val permissions = mutableListOf<String>()
-        
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-            permissions.addAll(listOf(
-                Manifest.permission.BLUETOOTH_ADVERTISE,
-                Manifest.permission.BLUETOOTH_CONNECT,
-                Manifest.permission.BLUETOOTH_SCAN
-            ))
-        } else {
-            permissions.addAll(listOf(
-                Manifest.permission.BLUETOOTH,
-                Manifest.permission.BLUETOOTH_ADMIN
-            ))
-        }
-        
-        permissions.addAll(listOf(
-            Manifest.permission.ACCESS_COARSE_LOCATION,
-            Manifest.permission.ACCESS_FINE_LOCATION
-        ))
-        
-        return permissions.all { 
-            ActivityCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED 
-        }
-    }
-    
-    @Suppress("DEPRECATION")
-    private fun setupGattServer() {
-        if (!hasBluetoothPermissions()) return
-        
-        val serverCallback = object : BluetoothGattServerCallback() {
-            override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
-                // Guard against callbacks after service shutdown
-                if (!isActive) {
-                    Log.d(TAG, "Server: Ignoring connection state change after shutdown")
-                    return
-                }
-                
-                when (newState) {
-                    BluetoothProfile.STATE_CONNECTED -> {
-                        Log.d(TAG, "Server: Device connected ${device.address}")
-                        val deviceConn = DeviceConnection(
-                            device = device,
-                            isClient = false
-                        )
-                        connectedDevices[device.address] = deviceConn
-                    }
-                    BluetoothProfile.STATE_DISCONNECTED -> {
-                        Log.d(TAG, "Server: Device disconnected ${device.address}")
-                        cleanupDeviceConnection(device.address)
-                    }
-                }
-            }
-            
-            override fun onServiceAdded(status: Int, service: BluetoothGattService) {
-                // Guard against callbacks after service shutdown
-                if (!isActive) {
-                    Log.d(TAG, "Server: Ignoring service added callback after shutdown")
-                    return
-                }
-                
-                if (status == BluetoothGatt.GATT_SUCCESS) {
-                    Log.d(TAG, "Server: Service added successfully: ${service.uuid}")
-                } else {
-                    Log.e(TAG, "Server: Failed to add service: ${service.uuid}, status: $status")
-                }
-            }
-            
-            override fun onCharacteristicWriteRequest(
-                device: BluetoothDevice,
-                requestId: Int,
-                characteristic: BluetoothGattCharacteristic,
-                preparedWrite: Boolean,
-                responseNeeded: Boolean,
-                offset: Int,
-                value: ByteArray
-            ) {
-                // Guard against callbacks after service shutdown
-                if (!isActive) {
-                    Log.d(TAG, "Server: Ignoring characteristic write after shutdown")
-                    return
-                }
-                
-                if (characteristic.uuid == CHARACTERISTIC_UUID) {
-                    Log.d(TAG, "Server: Received packet from ${device.address}, size: ${value.size} bytes")
-                    val packet = BitchatPacket.fromBinaryData(value)
-                    if (packet != null) {
-                        val peerID = String(packet.senderID).replace("\u0000", "")
-                        Log.d(TAG, "Server: Parsed packet type ${packet.type} from $peerID")
-                        delegate?.onPacketReceived(packet, peerID, device)
-                    } else {
-                        Log.w(TAG, "Server: Failed to parse packet from ${device.address}, size: ${value.size} bytes")
-                        Log.w(TAG, "Server: Packet data: ${value.joinToString(" ") { "%02x".format(it) }}")
-                    }
-                    
-                    if (responseNeeded) {
-                        gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
-                    }
-                }
-            }
-            
-            override fun onDescriptorWriteRequest(
-                device: BluetoothDevice,
-                requestId: Int,
-                descriptor: BluetoothGattDescriptor,
-                preparedWrite: Boolean,
-                responseNeeded: Boolean,
-                offset: Int,
-                value: ByteArray
-            ) {
-                // Guard against callbacks after service shutdown
-                if (!isActive) {
-                    Log.d(TAG, "Server: Ignoring descriptor write after shutdown")
-                    return
-                }
-                
-                if (BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE.contentEquals(value)) {
-                    Log.d(TAG, "Device ${device.address} subscribed to notifications")
-                    subscribedDevices.add(device)
-                    
-                    connectionScope.launch {
-                        delay(100)
-                        if (isActive) { // Check if still active
-                            delegate?.onDeviceConnected(device)
-                        }
-                    }
-                }
-                
-                if (responseNeeded) {
-                    gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
-                }
-            }
-        }
-        
-        // Proper cleanup sequencing to prevent race conditions
-        gattServer?.let { server ->
-            Log.d(TAG, "Cleaning up existing GATT server")
-            try {
-                server.close()
-            } catch (e: Exception) {
-                Log.w(TAG, "Error closing existing GATT server: ${e.message}")
-            }
-        }
-        
-        // Small delay to ensure cleanup is complete
-        Thread.sleep(100)
-        
-        if (!isActive) {
-            Log.d(TAG, "Service inactive, skipping GATT server creation")
-            return
-        }
-        
-        // Create new server
-        gattServer = bluetoothManager.openGattServer(context, serverCallback)
-        
-        // Create characteristic with notification support
-        characteristic = BluetoothGattCharacteristic(
-            CHARACTERISTIC_UUID,
-            BluetoothGattCharacteristic.PROPERTY_READ or 
-            BluetoothGattCharacteristic.PROPERTY_WRITE or 
-            BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE or
-            BluetoothGattCharacteristic.PROPERTY_NOTIFY,
-            BluetoothGattCharacteristic.PERMISSION_READ or 
-            BluetoothGattCharacteristic.PERMISSION_WRITE
-        )
-        
-        val descriptor = BluetoothGattDescriptor(
-            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"),
-            BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE
-        )
-        characteristic?.addDescriptor(descriptor)
-        
-        val service = BluetoothGattService(SERVICE_UUID, BluetoothGattService.SERVICE_TYPE_PRIMARY)
-        service.addCharacteristic(characteristic)
-        
-        gattServer?.addService(service)
-        
-        Log.i(TAG, "GATT server setup complete")
-    }
-    
-    @Suppress("DEPRECATION")
-    private fun startAdvertising() {
-        if (!hasBluetoothPermissions() || bleAdvertiser == null || !isActive) return
-
-        val settings = powerManager.getAdvertiseSettings()
-        
-        val data = AdvertiseData.Builder()
-            .addServiceUuid(ParcelUuid(SERVICE_UUID))
-            .setIncludeTxPowerLevel(false)
-            .setIncludeDeviceName(false)
-            .build()
-        
-        advertiseCallback = object : AdvertiseCallback() {
-            override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
-                Log.i(TAG, "Advertising started (power mode: ${powerManager.getPowerInfo().split("Current Mode: ")[1].split("\n")[0]})")
-            }
-            
-            override fun onStartFailure(errorCode: Int) {
-                Log.e(TAG, "Advertising failed: $errorCode")
-            }
-        }
-        
-        try {
-            bleAdvertiser.startAdvertising(settings, data, advertiseCallback)
-        } catch (e: Exception) {
-            Log.e(TAG, "Exception starting advertising: ${e.message}")
-        }
-    }
-    
-    @Suppress("DEPRECATION")
-    private fun stopAdvertising() {
-        if (!hasBluetoothPermissions() || bleAdvertiser == null) return
-        try {
-            advertiseCallback?.let { bleAdvertiser.stopAdvertising(it) }
-        } catch (e: Exception) {
-            Log.w(TAG, "Error stopping advertising: ${e.message}")
-        }
-    }
-    
-    @Suppress("DEPRECATION")
-    private fun startScanning() {
-        if (!hasBluetoothPermissions() || bleScanner == null || !isActive) return
-        
-        // CRITICAL FIX: Rate limit scan starts to prevent "scanning too frequently" errors
-        val currentTime = System.currentTimeMillis()
-        if (isCurrentlyScanning) {
-            Log.d(TAG, "Scan already in progress, skipping start request")
-            return
-        }
-        
-        val timeSinceLastStart = currentTime - lastScanStartTime
-        if (timeSinceLastStart < scanRateLimit) {
-            val remainingWait = scanRateLimit - timeSinceLastStart
-            Log.w(TAG, "Scan rate limited: need to wait ${remainingWait}ms before starting scan")
-            
-            // Schedule delayed scan start
-            connectionScope.launch {
-                delay(remainingWait)
-                if (isActive && !isCurrentlyScanning) {
-                    startScanning()
-                }
-            }
-            return
-        }
-        
-        // DIAGNOSTIC: Add both filtered and unfiltered scanning for debugging
-        val scanFilter = ScanFilter.Builder()
-            .setServiceUuid(ParcelUuid(SERVICE_UUID))
-            .build()
-        
-
-        val scanFilters = listOf(scanFilter) 
-        
-        Log.d(TAG, "Starting BLE scan with target service UUID: $SERVICE_UUID")
-        
-        scanCallback = object : ScanCallback() {
-            override fun onScanResult(callbackType: Int, result: ScanResult) {
-                // DEBUG: Log ALL scan results first
-                val device = result.device
-                val rssi = result.rssi
-                // Log.d(TAG, "Scan result: device: ${device.address}, Name: '${device.name}', RSSI: $rssi")
-                handleScanResult(result)
-            }
-            
-            override fun onBatchScanResults(results: MutableList<ScanResult>) {
-                Log.d(TAG, "Batch scan results received: ${results.size} devices")
-                results.forEach { result ->
-                    handleScanResult(result)
-                }
-            }
-            
-            override fun onScanFailed(errorCode: Int) {
-                Log.e(TAG, "Scan failed: $errorCode")
-                isCurrentlyScanning = false
-                lastScanStopTime = System.currentTimeMillis()
-                
-                when (errorCode) {
-                    1 -> Log.e(TAG, "SCAN_FAILED_ALREADY_STARTED")
-                    2 -> Log.e(TAG, "SCAN_FAILED_APPLICATION_REGISTRATION_FAILED") 
-                    3 -> Log.e(TAG, "SCAN_FAILED_INTERNAL_ERROR")
-                    4 -> Log.e(TAG, "SCAN_FAILED_FEATURE_UNSUPPORTED")
-                    5 -> Log.e(TAG, "SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES")
-                    6 -> {
-                        Log.e(TAG, "SCAN_FAILED_SCANNING_TOO_FREQUENTLY")
-                        Log.w(TAG, "Scan failed due to rate limiting - will retry after delay")
-                        connectionScope.launch {
-                            delay(10000) // Wait 10 seconds before retrying
-                            if (isActive) {
-                                startScanning()
-                            }
-                        }
-                    }
-                    else -> Log.e(TAG, "Unknown scan failure code: $errorCode")
-                }
-            }
-        }
-        
-        try {
-            lastScanStartTime = currentTime
-            isCurrentlyScanning = true
-            
-            bleScanner.startScan(scanFilters, powerManager.getScanSettings(), scanCallback)
-            Log.d(TAG, "BLE scan started successfully")
-        } catch (e: Exception) {
-            Log.e(TAG, "Exception starting scan: ${e.message}")
-            isCurrentlyScanning = false
-        }
-    }
-    
-    @Suppress("DEPRECATION")
-    private fun stopScanning() {
-        if (!hasBluetoothPermissions() || bleScanner == null) return
-        
-        if (isCurrentlyScanning) {
-            try {
-                scanCallback?.let { 
-                    bleScanner.stopScan(it)
-                    Log.d(TAG, "BLE scan stopped successfully")
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Error stopping scan: ${e.message}")
-            }
-            
-            isCurrentlyScanning = false
-            lastScanStopTime = System.currentTimeMillis()
-        }
-    }
-    
-    private fun handleScanResult(result: ScanResult) {
-        val device = result.device
-        val rssi = result.rssi
-        val deviceAddress = device.address
-        val scanRecord = result.scanRecord
-        
-        // CRITICAL: Only process devices that have our service UUID
-        val hasOurService = scanRecord?.serviceUuids?.any { it.uuid == SERVICE_UUID } == true
-        if (!hasOurService) {
-            return
-        }
-        
-        // FIXED: Extract peer ID from device name for iOS compatibility
-        val deviceName = device.name
-        val extractedPeerID = if (deviceName != null && deviceName.length == 8) {
-            deviceName
-        } else {
-            null
-        }
-                
-        // Power-aware RSSI filtering
-        if (rssi < powerManager.getRSSIThreshold()) {
-            Log.d(TAG, "Skipping device $deviceAddress due to weak signal: $rssi < ${powerManager.getRSSIThreshold()}")
-            return
-        }
-        
-        // CRITICAL FIX: Prevent multiple simultaneous connections to same device
-        // Check if already connected OR already attempting to connect
-        if (connectedDevices.containsKey(deviceAddress)) {
-            // Log.d(TAG, "Device $deviceAddress already connected, skipping")
-            return
-        }
-        
-        // CRITICAL FIX: Check if connection attempt is already in progress
-        val existingAttempt = pendingConnections[deviceAddress]
-        if (existingAttempt != null && !existingAttempt.isExpired()) {
-            if (!existingAttempt.shouldRetry()) {
-                Log.d(TAG, "Connection to $deviceAddress already in progress or too many recent attempts (${existingAttempt.attempts})")
-                return
-            }
-        }
-        
-        if (connectedDevices.size >= powerManager.getMaxConnections()) {
-            Log.d(TAG, "Connection limit reached (${powerManager.getMaxConnections()})")
-            return
-        }
-        
-        // CRITICAL FIX: Use synchronized block to prevent race conditions
-        synchronized(pendingConnections) {
-            // Double-check inside synchronized block
-            val currentAttempt = pendingConnections[deviceAddress]
-            if (currentAttempt != null && !currentAttempt.isExpired() && !currentAttempt.shouldRetry()) {
-                Log.d(TAG, "Connection to $deviceAddress blocked by concurrent attempt check")
-                return
-            }
-            
-            // Update connection attempt atomically
-            val attempts = (currentAttempt?.attempts ?: 0) + 1
-            pendingConnections[deviceAddress] = ConnectionAttempt(attempts)
-            
-            // Start connection immediately while holding lock
-            connectToDevice(device, rssi)
-        }
-    }
-    
-    @Suppress("DEPRECATION")
-    private fun connectToDevice(device: BluetoothDevice, rssi: Int) {
-        if (!hasBluetoothPermissions()) return
-        
-        val deviceAddress = device.address
-        Log.d(TAG, "Connecting to bitchat device: $deviceAddress")
-        
-                val gattCallback = object : BluetoothGattCallback() {
-            override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
-                Log.d(TAG, "Client: Connection state change - Device: $deviceAddress, Status: $status, NewState: $newState")
-
-                if (newState == BluetoothProfile.STATE_CONNECTED && status == BluetoothGatt.GATT_SUCCESS) {
-                    Log.i(TAG, "Client: Successfully connected to $deviceAddress. Requesting MTU...")
-                    // FIX: Request a larger MTU. Must be done before any data transfer.
-                    // 517 is the maximum supported MTU size on Android.
-                    connectionScope.launch {
-                        delay(200) // A small delay can improve reliability of MTU request.
-                        gatt.requestMtu(517)
-                    }
-                } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
-                    if (status != BluetoothGatt.GATT_SUCCESS) {
-                        Log.w(TAG, "Client: Disconnected from $deviceAddress with error status $status")
-                        if (status == 147) {
-                            Log.e(TAG, "Client: Connection establishment failed (status 147) for $deviceAddress")
-                        }
-                    } else {
-                        Log.d(TAG, "Client: Cleanly disconnected from $deviceAddress")
-                    }
-                    
-                    cleanupDeviceConnection(deviceAddress)
-                    
-                    connectionScope.launch {
-                        delay(CLEANUP_DELAY)
-                        try {
-                            gatt.close()
-                        } catch (e: Exception) {
-                            Log.w(TAG, "Error closing GATT: ${e.message}")
-                        }
-                    }
-                }
-            }
-            
-            override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
-                val deviceAddress = gatt.device.address
-                Log.i(TAG, "Client: MTU changed for $deviceAddress to $mtu with status $status")
-
-                if (status == BluetoothGatt.GATT_SUCCESS) {
-                    Log.i(TAG, "MTU successfully negotiated for $deviceAddress. Discovering services.")
-                    
-                    // Now that MTU is set, connection is fully ready.
-                    val deviceConn = DeviceConnection(
-                        device = gatt.device,
-                        gatt = gatt,
-                        rssi = rssi,
-                        isClient = true
-                    )
-                    connectedDevices[deviceAddress] = deviceConn
-                    pendingConnections.remove(deviceAddress)
-                    
-                    // Start service discovery only AFTER MTU is set.
-                    gatt.discoverServices()
-                } else {
-                    Log.w(TAG, "MTU negotiation failed for $deviceAddress with status: $status. Disconnecting.")
-                    pendingConnections.remove(deviceAddress)
-                    gatt.disconnect()
-                }
-            }
-
-            override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {                
-                if (status == BluetoothGatt.GATT_SUCCESS) {
-                    val service = gatt.getService(SERVICE_UUID)
-                    if (service != null) {
-                        val characteristic = service.getCharacteristic(CHARACTERISTIC_UUID)
-                        if (characteristic != null) {
-                            connectedDevices[deviceAddress]?.let { deviceConn ->
-                                val updatedConn = deviceConn.copy(characteristic = characteristic)
-                                connectedDevices[deviceAddress] = updatedConn
-                                Log.d(TAG, "Client: Updated device connection with characteristic for $deviceAddress")
-                            }
-                            
-                            gatt.setCharacteristicNotification(characteristic, true)
-                            val descriptor = characteristic.getDescriptor(UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"))
-                            if (descriptor != null) {
-                                descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-                                gatt.writeDescriptor(descriptor)
-                                
-                                connectionScope.launch {
-                                    delay(200)
-                                    Log.i(TAG, "Client: Connection setup complete for $deviceAddress")
-                                    delegate?.onDeviceConnected(device)
-                                }
-                            } else {
-                                Log.e(TAG, "Client: CCCD descriptor not found for $deviceAddress")
-                                gatt.disconnect()
-                            }
-                        } else {
-                            Log.e(TAG, "Client: Required characteristic not found for $deviceAddress")
-                            gatt.disconnect()
-                        }
-                    } else {
-                        Log.e(TAG, "Client: Required service not found for $deviceAddress")
-                        gatt.disconnect()
-                    }
-                } else {
-                    Log.e(TAG, "Client: Service discovery failed with status $status for $deviceAddress")
-                    gatt.disconnect()
-                }
-            }
-            
-            override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
-                val value = characteristic.value
-                Log.d(TAG, "Client: Received packet from ${gatt.device.address}, size: ${value.size} bytes")
-                val packet = BitchatPacket.fromBinaryData(value)
-                if (packet != null) {
-                    val peerID = String(packet.senderID).replace("\u0000", "")
-                    Log.d(TAG, "Client: Parsed packet type ${packet.type} from $peerID")
-                    delegate?.onPacketReceived(packet, peerID, gatt.device)
-                } else {
-                    Log.w(TAG, "Client: Failed to parse packet from ${gatt.device.address}, size: ${value.size} bytes")
-                    Log.w(TAG, "Client: Packet data: ${value.joinToString(" ") { "%02x".format(it) }}")
-                }
-            }
-        }
-        
-        try {
-            Log.d(TAG, "Client: Attempting GATT connection to $deviceAddress with autoConnect=false")
-            val gatt = device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
-            if (gatt == null) {
-                Log.e(TAG, "connectGatt returned null for $deviceAddress")
-                pendingConnections.remove(deviceAddress)
-            } else {
-                Log.d(TAG, "Client: GATT connection initiated successfully for $deviceAddress")
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Client: Exception connecting to $deviceAddress: ${e.message}")
-            pendingConnections.remove(deviceAddress)
-        }
-    }
-    
-    private fun startPeriodicCleanup() {
-        connectionScope.launch {
-            while (isActive) {
-                delay(CLEANUP_INTERVAL)
-                
-                if (!isActive) break
-                
-                try {
-                    // Clean up expired pending connections
-                    val expiredConnections = pendingConnections.filter { it.value.isExpired() }
-                    expiredConnections.keys.forEach { pendingConnections.remove(it) }
-                    
-                    // Log cleanup if any
-                    if (expiredConnections.isNotEmpty()) {
-                        Log.d(TAG, "Cleaned up ${expiredConnections.size} expired connection attempts")
-                    }
-                    
-                    // Log current state
-                    Log.d(TAG, "Periodic cleanup: ${connectedDevices.size} connections, ${pendingConnections.size} pending")
-                    
-                } catch (e: Exception) {
-                    Log.w(TAG, "Error in periodic cleanup: ${e.message}")
-                }
-            }
-        }
-    }
-    
-    private fun enforceConnectionLimits() {
-        val maxConnections = powerManager.getMaxConnections()
-        if (connectedDevices.size > maxConnections) {
-            Log.i(TAG, "Enforcing connection limit: ${connectedDevices.size} > $maxConnections")
-            
-            // Disconnect oldest client connections first
-            val sortedConnections = connectedDevices.values
-                .filter { it.isClient }
-                .sortedBy { it.connectedAt }
-            
-            val toDisconnect = sortedConnections.take(connectedDevices.size - maxConnections)
-            toDisconnect.forEach { deviceConn ->
-                Log.d(TAG, "Disconnecting ${deviceConn.device.address} due to connection limit")
-                deviceConn.gatt?.disconnect()
-            }
-        }
-    }
-    
-    private fun cleanupDeviceConnection(deviceAddress: String) {
-        connectedDevices.remove(deviceAddress)?.let { deviceConn ->
-            subscribedDevices.removeAll { it.address == deviceAddress }
-            addressPeerMap.remove(deviceAddress)
-        }
-        // CRITICAL FIX: Always remove from pending connections when cleaning up
-        // This prevents failed connections from blocking future attempts
-        pendingConnections.remove(deviceAddress)
-        Log.d(TAG, "Cleaned up device connection for $deviceAddress")
-    }
-    
-    private fun cleanupAllConnections() {
-        connectedDevices.values.forEach { deviceConn ->
-            deviceConn.gatt?.disconnect()
-        }
-        
-        connectionScope.launch {
-            delay(CLEANUP_DELAY)
-            
-            connectedDevices.values.forEach { deviceConn ->
-                try {
-                    deviceConn.gatt?.close()
-                } catch (e: Exception) {
-                    Log.w(TAG, "Error closing GATT during cleanup: ${e.message}")
-                }
-            }
-        }
-    }
-    
-    private fun clearAllConnections() {
-        connectedDevices.clear()
-        subscribedDevices.clear()
-        addressPeerMap.clear()
-        pendingConnections.clear()
-    }
+    // MARK: - Private Implementation - All moved to component managers
 }
 
 /**

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
@@ -9,6 +9,8 @@ import android.os.ParcelUuid
 import android.util.Log
 import androidx.core.app.ActivityCompat
 import com.bitchat.android.protocol.BitchatPacket
+import com.bitchat.android.protocol.SpecialRecipients
+import com.bitchat.android.model.RoutedPacket
 import kotlinx.coroutines.*
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -53,6 +55,7 @@ class BluetoothConnectionManager(
     // Simplified connection tracking - reduced memory footprint
     private val connectedDevices = ConcurrentHashMap<String, DeviceConnection>()
     private val subscribedDevices = CopyOnWriteArrayList<BluetoothDevice>()
+    public val addressPeerMap = ConcurrentHashMap<String, String>()
     
     // Connection attempt tracking with automatic cleanup
     private val pendingConnections = ConcurrentHashMap<String, ConnectionAttempt>()
@@ -199,47 +202,106 @@ class BluetoothConnectionManager(
         powerManager.setAppBackgroundState(inBackground)
     }
     
+    // Function to send data to a single device (server side)
+    private fun notifyDevice(device: BluetoothDevice, data: ByteArray): Boolean {
+        return try {
+            characteristic?.let { char ->
+                char.value = data
+                val result = gattServer?.notifyCharacteristicChanged(device, char, false) ?: false
+                result
+            } ?: false
+        } catch (e: Exception) {
+            Log.w(TAG, "Error sending to server connection ${device.address}: ${e.message}")
+            connectionScope.launch {
+                delay(CLEANUP_DELAY)
+                subscribedDevices.remove(device)
+                addressPeerMap.remove(device.address)
+            }
+            false
+        }
+    }
+
+    // Function to send data to a single device (client side)
+    private fun writeToDeviceConn(deviceConn: DeviceConnection, data: ByteArray): Boolean {
+        return try {
+            deviceConn.characteristic?.let { char ->
+                char.value = data
+                val result = deviceConn.gatt?.writeCharacteristic(char) ?: false
+                result
+            } ?: false
+        } catch (e: Exception) {
+            Log.w(TAG, "Error sending to client connection ${deviceConn.device.address}: ${e.message}")
+            connectionScope.launch {
+                delay(CLEANUP_DELAY)
+                cleanupDeviceConnection(deviceConn.device.address)
+            }
+            false
+        }
+    }
+
     /**
      * Broadcast packet to connected devices with connection limit enforcement
      */
-    fun broadcastPacket(packet: BitchatPacket) {
+    fun broadcastPacket(routed: RoutedPacket) {
+        val packet = routed.packet
+
         if (!isActive) return
         
         val data = packet.toBinaryData() ?: return
         
+        if (packet.recipientID != SpecialRecipients.BROADCAST) {
+            val recipientID = packet.recipientID?.let {
+                String(it).replace("\u0000", "").trim()
+            } ?: ""
+
+            // Try to find the recipient in server connections (subscribedDevices)
+            val targetDevice = subscribedDevices.firstOrNull { addressPeerMap[it.address] == recipientID }
+            // If found, send directly
+            if (targetDevice != null) {
+                Log.d(TAG, "Send packet type ${packet.type} directly to target device for recipient $recipientID: ${targetDevice.address}")
+                if (notifyDevice(targetDevice, data))
+                    return  // Sent, no need to continue
+            }
+
+            // Try to find the recipient in client connections (connectedDevices)
+            val targetDeviceConn = connectedDevices.values.firstOrNull { addressPeerMap[it.device.address] == recipientID }
+            // If found, send directly
+            if (targetDeviceConn != null) {
+                Log.d(TAG, "Send packet type ${packet.type} directly to target client connection for recipient $recipientID: ${targetDeviceConn.device.address}")
+                if (writeToDeviceConn(targetDeviceConn, data))
+                    return  // Sent, no need to continue
+            }
+        }
+
+        // Else, continue with broadcasting to all devices
         Log.d(TAG, "Broadcasting packet type ${packet.type} to ${subscribedDevices.size} server + ${connectedDevices.size} client connections")
-        
+
+        val senderID = String(packet.senderID).replace("\u0000", "")        
         // Send to server connections (devices connected to our GATT server)
         subscribedDevices.forEach { device ->
-            try {
-                characteristic?.let { char ->
-                    char.value = data
-                    gattServer?.notifyCharacteristicChanged(device, char, false)
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Error sending to server connection ${device.address}: ${e.message}")
-                // Clean up failed connection
-                connectionScope.launch {
-                    delay(CLEANUP_DELAY)
-                    subscribedDevices.remove(device)
-                }
+            if (device.address == routed.relayAddress) {
+                Log.d(TAG, "Skipping broadcast back to relayer: ${device.address}")
+                return@forEach
             }
+            if (addressPeerMap[device.address] == senderID) {
+                Log.d(TAG, "Skipping broadcast back to sender: ${device.address}")
+                return@forEach
+            }
+            notifyDevice(device, data)
         }
         
         // Send to client connections
         connectedDevices.values.forEach { deviceConn ->
             if (deviceConn.isClient && deviceConn.gatt != null && deviceConn.characteristic != null) {
-                try {
-                    deviceConn.characteristic.value = data
-                    deviceConn.gatt.writeCharacteristic(deviceConn.characteristic)
-                } catch (e: Exception) {
-                    Log.w(TAG, "Error sending to client connection ${deviceConn.device.address}: ${e.message}")
-                    // Clean up failed connection
-                    connectionScope.launch {
-                        delay(CLEANUP_DELAY)
-                        cleanupDeviceConnection(deviceConn.device.address)
-                    }
+                if (deviceConn.device.address == routed.relayAddress) {
+                    Log.d(TAG, "Skipping broadcast back to relayer: ${deviceConn.device.address}")
+                    return@forEach
                 }
+                if (addressPeerMap[deviceConn.device.address] == senderID) {
+                    Log.d(TAG, "Skipping broadcast back to sender: ${deviceConn.device.address}")
+                    return@forEach
+                }
+                writeToDeviceConn(deviceConn, data)
             }
         }
     }
@@ -916,6 +978,7 @@ class BluetoothConnectionManager(
     private fun cleanupDeviceConnection(deviceAddress: String) {
         connectedDevices.remove(deviceAddress)?.let { deviceConn ->
             subscribedDevices.removeAll { it.address == deviceAddress }
+            addressPeerMap.remove(deviceAddress)
         }
         // CRITICAL FIX: Always remove from pending connections when cleaning up
         // This prevents failed connections from blocking future attempts
@@ -944,6 +1007,7 @@ class BluetoothConnectionManager(
     private fun clearAllConnections() {
         connectedDevices.clear()
         subscribedDevices.clear()
+        addressPeerMap.clear()
         pendingConnections.clear()
     }
 }

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionTracker.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionTracker.kt
@@ -1,0 +1,305 @@
+package com.bitchat.android.mesh
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Tracks all Bluetooth connections and handles cleanup
+ */
+class BluetoothConnectionTracker(
+    private val connectionScope: CoroutineScope,
+    private val powerManager: PowerManager
+) {
+    
+    companion object {
+        private const val TAG = "BluetoothConnectionTracker"
+        private const val CONNECTION_RETRY_DELAY = 5000L
+        private const val MAX_CONNECTION_ATTEMPTS = 3
+        private const val CLEANUP_DELAY = 500L
+        private const val CLEANUP_INTERVAL = 30000L // 30 seconds
+    }
+    
+    // Connection tracking - reduced memory footprint
+    private val connectedDevices = ConcurrentHashMap<String, DeviceConnection>()
+    private val subscribedDevices = CopyOnWriteArrayList<BluetoothDevice>()
+    val addressPeerMap = ConcurrentHashMap<String, String>()
+    
+    // Connection attempt tracking with automatic cleanup
+    private val pendingConnections = ConcurrentHashMap<String, ConnectionAttempt>()
+    
+    // State management
+    private var isActive = false
+    
+    /**
+     * Consolidated device connection information
+     */
+    data class DeviceConnection(
+        val device: BluetoothDevice,
+        val gatt: BluetoothGatt? = null,
+        val characteristic: BluetoothGattCharacteristic? = null,
+        val rssi: Int = Int.MIN_VALUE,
+        val isClient: Boolean = false,
+        val connectedAt: Long = System.currentTimeMillis()
+    )
+    
+    /**
+     * Connection attempt tracking with automatic expiry
+     */
+    data class ConnectionAttempt(
+        val attempts: Int,
+        val lastAttempt: Long = System.currentTimeMillis()
+    ) {
+        fun isExpired(): Boolean = 
+            System.currentTimeMillis() - lastAttempt > CONNECTION_RETRY_DELAY * 2
+        
+        fun shouldRetry(): Boolean = 
+            attempts < MAX_CONNECTION_ATTEMPTS && 
+            System.currentTimeMillis() - lastAttempt > CONNECTION_RETRY_DELAY
+    }
+    
+    /**
+     * Start the connection tracker
+     */
+    fun start() {
+        isActive = true
+        startPeriodicCleanup()
+    }
+    
+    /**
+     * Stop the connection tracker
+     */
+    fun stop() {
+        isActive = false
+        cleanupAllConnections()
+        clearAllConnections()
+    }
+    
+    /**
+     * Add a device connection
+     */
+    fun addDeviceConnection(deviceAddress: String, deviceConn: DeviceConnection) {
+        connectedDevices[deviceAddress] = deviceConn
+        pendingConnections.remove(deviceAddress)
+    }
+    
+    /**
+     * Update a device connection
+     */
+    fun updateDeviceConnection(deviceAddress: String, deviceConn: DeviceConnection) {
+        connectedDevices[deviceAddress] = deviceConn
+    }
+    
+    /**
+     * Get a device connection
+     */
+    fun getDeviceConnection(deviceAddress: String): DeviceConnection? {
+        return connectedDevices[deviceAddress]
+    }
+    
+    /**
+     * Get all connected devices
+     */
+    fun getConnectedDevices(): Map<String, DeviceConnection> {
+        return connectedDevices.toMap()
+    }
+    
+    /**
+     * Get subscribed devices (for server connections)
+     */
+    fun getSubscribedDevices(): List<BluetoothDevice> {
+        return subscribedDevices.toList()
+    }
+    
+    /**
+     * Add a subscribed device
+     */
+    fun addSubscribedDevice(device: BluetoothDevice) {
+        subscribedDevices.add(device)
+    }
+    
+    /**
+     * Remove a subscribed device
+     */
+    fun removeSubscribedDevice(device: BluetoothDevice) {
+        subscribedDevices.remove(device)
+    }
+    
+    /**
+     * Check if device is already connected
+     */
+    fun isDeviceConnected(deviceAddress: String): Boolean {
+        return connectedDevices.containsKey(deviceAddress)
+    }
+    
+    /**
+     * Check if connection attempt is allowed
+     */
+    fun isConnectionAttemptAllowed(deviceAddress: String): Boolean {
+        val existingAttempt = pendingConnections[deviceAddress]
+        return existingAttempt?.let { 
+            it.isExpired() || it.shouldRetry() 
+        } ?: true
+    }
+    
+    /**
+     * Add a pending connection attempt
+     */
+    fun addPendingConnection(deviceAddress: String): Boolean {
+        synchronized(pendingConnections) {
+            // Double-check inside synchronized block
+            val currentAttempt = pendingConnections[deviceAddress]
+            if (currentAttempt != null && !currentAttempt.isExpired() && !currentAttempt.shouldRetry()) {
+                return false
+            }
+            
+            // Update connection attempt atomically
+            val attempts = (currentAttempt?.attempts ?: 0) + 1
+            pendingConnections[deviceAddress] = ConnectionAttempt(attempts)
+            return true
+        }
+    }
+    
+    /**
+     * Remove a pending connection
+     */
+    fun removePendingConnection(deviceAddress: String) {
+        pendingConnections.remove(deviceAddress)
+    }
+    
+    /**
+     * Get connected device count
+     */
+    fun getConnectedDeviceCount(): Int = connectedDevices.size
+    
+    /**
+     * Check if connection limit is reached
+     */
+    fun isConnectionLimitReached(): Boolean {
+        return connectedDevices.size >= powerManager.getMaxConnections()
+    }
+    
+    /**
+     * Enforce connection limits by disconnecting oldest connections
+     */
+    fun enforceConnectionLimits() {
+        val maxConnections = powerManager.getMaxConnections()
+        if (connectedDevices.size > maxConnections) {
+            Log.i(TAG, "Enforcing connection limit: ${connectedDevices.size} > $maxConnections")
+            
+            // Disconnect oldest client connections first
+            val sortedConnections = connectedDevices.values
+                .filter { it.isClient }
+                .sortedBy { it.connectedAt }
+            
+            val toDisconnect = sortedConnections.take(connectedDevices.size - maxConnections)
+            toDisconnect.forEach { deviceConn ->
+                Log.d(TAG, "Disconnecting ${deviceConn.device.address} due to connection limit")
+                deviceConn.gatt?.disconnect()
+            }
+        }
+    }
+    
+    /**
+     * Clean up a specific device connection
+     */
+    fun cleanupDeviceConnection(deviceAddress: String) {
+        connectedDevices.remove(deviceAddress)?.let { deviceConn ->
+            subscribedDevices.removeAll { it.address == deviceAddress }
+            addressPeerMap.remove(deviceAddress)
+        }
+        // CRITICAL FIX: Always remove from pending connections when cleaning up
+        // This prevents failed connections from blocking future attempts
+        pendingConnections.remove(deviceAddress)
+        Log.d(TAG, "Cleaned up device connection for $deviceAddress")
+    }
+    
+    /**
+     * Clean up all connections
+     */
+    private fun cleanupAllConnections() {
+        connectedDevices.values.forEach { deviceConn ->
+            deviceConn.gatt?.disconnect()
+        }
+        
+        connectionScope.launch {
+            delay(CLEANUP_DELAY)
+            
+            connectedDevices.values.forEach { deviceConn ->
+                try {
+                    deviceConn.gatt?.close()
+                } catch (e: Exception) {
+                    Log.w(TAG, "Error closing GATT during cleanup: ${e.message}")
+                }
+            }
+        }
+    }
+    
+    /**
+     * Clear all connection tracking
+     */
+    private fun clearAllConnections() {
+        connectedDevices.clear()
+        subscribedDevices.clear()
+        addressPeerMap.clear()
+        pendingConnections.clear()
+    }
+    
+    /**
+     * Start periodic cleanup of expired connections
+     */
+    private fun startPeriodicCleanup() {
+        connectionScope.launch {
+            while (isActive) {
+                delay(CLEANUP_INTERVAL)
+                
+                if (!isActive) break
+                
+                try {
+                    // Clean up expired pending connections
+                    val expiredConnections = pendingConnections.filter { it.value.isExpired() }
+                    expiredConnections.keys.forEach { pendingConnections.remove(it) }
+                    
+                    // Log cleanup if any
+                    if (expiredConnections.isNotEmpty()) {
+                        Log.d(TAG, "Cleaned up ${expiredConnections.size} expired connection attempts")
+                    }
+                    
+                    // Log current state
+                    Log.d(TAG, "Periodic cleanup: ${connectedDevices.size} connections, ${pendingConnections.size} pending")
+                    
+                } catch (e: Exception) {
+                    Log.w(TAG, "Error in periodic cleanup: ${e.message}")
+                }
+            }
+        }
+    }
+    
+    /**
+     * Get debug information
+     */
+    fun getDebugInfo(): String {
+        return buildString {
+            appendLine("Connected Devices: ${connectedDevices.size} / ${powerManager.getMaxConnections()}")
+            connectedDevices.forEach { (address, deviceConn) ->
+                val age = (System.currentTimeMillis() - deviceConn.connectedAt) / 1000
+                appendLine("  - $address (${if (deviceConn.isClient) "client" else "server"}, ${age}s, RSSI: ${deviceConn.rssi})")
+            }
+            appendLine()
+            appendLine("Subscribed Devices (server mode): ${subscribedDevices.size}")
+            appendLine()
+            appendLine("Pending Connections: ${pendingConnections.size}")
+            val now = System.currentTimeMillis()
+            pendingConnections.forEach { (address, attempt) ->
+                val elapsed = (now - attempt.lastAttempt) / 1000
+                appendLine("  - $address: ${attempt.attempts} attempts, last ${elapsed}s ago")
+            }
+        }
+    }
+} 

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothGattClientManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothGattClientManager.kt
@@ -32,6 +32,7 @@ class BluetoothGattClientManager(
         // Use exact same UUIDs as iOS version
         private val SERVICE_UUID = UUID.fromString("F47B5E2D-4A9E-4C5A-9B3F-8E1D2C3A4B5C")
         private val CHARACTERISTIC_UUID = UUID.fromString("A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D")
+        private val DESCRIPTOR_UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
         
         // RSSI monitoring constants
         private const val RSSI_UPDATE_INTERVAL = 5000L // 5 seconds
@@ -389,7 +390,7 @@ class BluetoothGattClientManager(
                             }
                             
                             gatt.setCharacteristicNotification(characteristic, true)
-                            val descriptor = characteristic.getDescriptor(UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"))
+                            val descriptor = characteristic.getDescriptor(DESCRIPTOR_UUID)
                             if (descriptor != null) {
                                 descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
                                 gatt.writeDescriptor(descriptor)

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothGattClientManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothGattClientManager.kt
@@ -1,0 +1,420 @@
+package com.bitchat.android.mesh
+
+import android.bluetooth.*
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.content.Context
+import android.os.ParcelUuid
+import android.util.Log
+import com.bitchat.android.protocol.BitchatPacket
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.*
+
+/**
+ * Manages GATT client operations, scanning, and client-side connections
+ */
+class BluetoothGattClientManager(
+    private val context: Context,
+    private val connectionScope: CoroutineScope,
+    private val connectionTracker: BluetoothConnectionTracker,
+    private val permissionManager: BluetoothPermissionManager,
+    private val powerManager: PowerManager,
+    private val delegate: BluetoothConnectionManagerDelegate?
+) {
+    
+    companion object {
+        private const val TAG = "BluetoothGattClientManager"
+        // Use exact same UUIDs as iOS version
+        private val SERVICE_UUID = UUID.fromString("F47B5E2D-4A9E-4C5A-9B3F-8E1D2C3A4B5C")
+        private val CHARACTERISTIC_UUID = UUID.fromString("A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D")
+    }
+    
+    // Core Bluetooth components
+    private val bluetoothManager: BluetoothManager = 
+        context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+    private val bluetoothAdapter: BluetoothAdapter? = bluetoothManager.adapter
+    private val bleScanner: BluetoothLeScanner? = bluetoothAdapter?.bluetoothLeScanner
+    
+    // Scan management
+    private var scanCallback: ScanCallback? = null
+    
+    // CRITICAL FIX: Scan rate limiting to prevent "scanning too frequently" errors
+    private var lastScanStartTime = 0L
+    private var lastScanStopTime = 0L
+    private var isCurrentlyScanning = false
+    private val scanRateLimit = 5000L // Minimum 5 seconds between scan start attempts
+    
+    // State management
+    private var isActive = false
+    
+    /**
+     * Start client manager
+     */
+    fun start(): Boolean {
+        if (!permissionManager.hasBluetoothPermissions()) {
+            Log.e(TAG, "Missing Bluetooth permissions")
+            return false
+        }
+        
+        if (bluetoothAdapter?.isEnabled != true) {
+            Log.e(TAG, "Bluetooth is not enabled")
+            return false
+        }
+        
+        if (bleScanner == null) {
+            Log.e(TAG, "BLE scanner not available")
+            return false
+        }
+        
+        isActive = true
+        
+        connectionScope.launch {
+            if (powerManager.shouldUseDutyCycle()) {
+                Log.i(TAG, "Using power-aware duty cycling")
+            } else {
+                startScanning()
+            }
+        }
+        
+        return true
+    }
+    
+    /**
+     * Stop client manager
+     */
+    fun stop() {
+        isActive = false
+        
+        connectionScope.launch {
+            stopScanning()
+            Log.i(TAG, "GATT client manager stopped")
+        }
+    }
+    
+    /**
+     * Handle scan state changes from power manager
+     */
+    fun onScanStateChanged(shouldScan: Boolean) {
+        if (shouldScan) {
+            startScanning()
+        } else {
+            stopScanning()
+        }
+    }
+    
+    /**
+     * Start scanning with rate limiting
+     */
+    @Suppress("DEPRECATION")
+    private fun startScanning() {
+        if (!permissionManager.hasBluetoothPermissions() || bleScanner == null || !isActive) return
+        
+        // CRITICAL FIX: Rate limit scan starts to prevent "scanning too frequently" errors
+        val currentTime = System.currentTimeMillis()
+        if (isCurrentlyScanning) {
+            Log.d(TAG, "Scan already in progress, skipping start request")
+            return
+        }
+        
+        val timeSinceLastStart = currentTime - lastScanStartTime
+        if (timeSinceLastStart < scanRateLimit) {
+            val remainingWait = scanRateLimit - timeSinceLastStart
+            Log.w(TAG, "Scan rate limited: need to wait ${remainingWait}ms before starting scan")
+            
+            // Schedule delayed scan start
+            connectionScope.launch {
+                delay(remainingWait)
+                if (isActive && !isCurrentlyScanning) {
+                    startScanning()
+                }
+            }
+            return
+        }
+        
+        val scanFilter = ScanFilter.Builder()
+            .setServiceUuid(ParcelUuid(SERVICE_UUID))
+            .build()
+        
+        val scanFilters = listOf(scanFilter) 
+        
+        Log.d(TAG, "Starting BLE scan with target service UUID: $SERVICE_UUID")
+        
+        scanCallback = object : ScanCallback() {
+            override fun onScanResult(callbackType: Int, result: ScanResult) {
+                handleScanResult(result)
+            }
+            
+            override fun onBatchScanResults(results: MutableList<ScanResult>) {
+                Log.d(TAG, "Batch scan results received: ${results.size} devices")
+                results.forEach { result ->
+                    handleScanResult(result)
+                }
+            }
+            
+            override fun onScanFailed(errorCode: Int) {
+                Log.e(TAG, "Scan failed: $errorCode")
+                isCurrentlyScanning = false
+                lastScanStopTime = System.currentTimeMillis()
+                
+                when (errorCode) {
+                    1 -> Log.e(TAG, "SCAN_FAILED_ALREADY_STARTED")
+                    2 -> Log.e(TAG, "SCAN_FAILED_APPLICATION_REGISTRATION_FAILED") 
+                    3 -> Log.e(TAG, "SCAN_FAILED_INTERNAL_ERROR")
+                    4 -> Log.e(TAG, "SCAN_FAILED_FEATURE_UNSUPPORTED")
+                    5 -> Log.e(TAG, "SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES")
+                    6 -> {
+                        Log.e(TAG, "SCAN_FAILED_SCANNING_TOO_FREQUENTLY")
+                        Log.w(TAG, "Scan failed due to rate limiting - will retry after delay")
+                        connectionScope.launch {
+                            delay(10000) // Wait 10 seconds before retrying
+                            if (isActive) {
+                                startScanning()
+                            }
+                        }
+                    }
+                    else -> Log.e(TAG, "Unknown scan failure code: $errorCode")
+                }
+            }
+        }
+        
+        try {
+            lastScanStartTime = currentTime
+            isCurrentlyScanning = true
+            
+            bleScanner.startScan(scanFilters, powerManager.getScanSettings(), scanCallback)
+            Log.d(TAG, "BLE scan started successfully")
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception starting scan: ${e.message}")
+            isCurrentlyScanning = false
+        }
+    }
+    
+    /**
+     * Stop scanning
+     */
+    @Suppress("DEPRECATION")
+    private fun stopScanning() {
+        if (!permissionManager.hasBluetoothPermissions() || bleScanner == null) return
+        
+        if (isCurrentlyScanning) {
+            try {
+                scanCallback?.let { 
+                    bleScanner.stopScan(it)
+                    Log.d(TAG, "BLE scan stopped successfully")
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Error stopping scan: ${e.message}")
+            }
+            
+            isCurrentlyScanning = false
+            lastScanStopTime = System.currentTimeMillis()
+        }
+    }
+    
+    /**
+     * Handle scan result and initiate connection if appropriate
+     */
+    private fun handleScanResult(result: ScanResult) {
+        val device = result.device
+        val rssi = result.rssi
+        val deviceAddress = device.address
+        val scanRecord = result.scanRecord
+        
+        // CRITICAL: Only process devices that have our service UUID
+        val hasOurService = scanRecord?.serviceUuids?.any { it.uuid == SERVICE_UUID } == true
+        if (!hasOurService) {
+            return
+        }
+        
+        // Power-aware RSSI filtering
+        if (rssi < powerManager.getRSSIThreshold()) {
+            Log.d(TAG, "Skipping device $deviceAddress due to weak signal: $rssi < ${powerManager.getRSSIThreshold()}")
+            return
+        }
+        
+        // Check if already connected OR already attempting to connect
+        if (connectionTracker.isDeviceConnected(deviceAddress)) {
+            return
+        }
+        
+        // Check if connection attempt is allowed
+        if (!connectionTracker.isConnectionAttemptAllowed(deviceAddress)) {
+            Log.d(TAG, "Connection to $deviceAddress not allowed due to recent attempts")
+            return
+        }
+        
+        if (connectionTracker.isConnectionLimitReached()) {
+            Log.d(TAG, "Connection limit reached (${powerManager.getMaxConnections()})")
+            return
+        }
+        
+        // Add pending connection and start connection
+        if (connectionTracker.addPendingConnection(deviceAddress)) {
+            connectToDevice(device, rssi)
+        }
+    }
+    
+    /**
+     * Connect to a device as GATT client
+     */
+    @Suppress("DEPRECATION")
+    private fun connectToDevice(device: BluetoothDevice, rssi: Int) {
+        if (!permissionManager.hasBluetoothPermissions()) return
+        
+        val deviceAddress = device.address
+        Log.i(TAG, "Connecting to bitchat device: $deviceAddress")
+        
+        val gattCallback = object : BluetoothGattCallback() {
+            override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+                Log.d(TAG, "Client: Connection state change - Device: $deviceAddress, Status: $status, NewState: $newState")
+
+                if (newState == BluetoothProfile.STATE_CONNECTED && status == BluetoothGatt.GATT_SUCCESS) {
+                    Log.i(TAG, "Client: Successfully connected to $deviceAddress. Requesting MTU...")
+                    // Request a larger MTU. Must be done before any data transfer.
+                    connectionScope.launch {
+                        delay(200) // A small delay can improve reliability of MTU request.
+                        gatt.requestMtu(517)
+                    }
+                } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                    if (status != BluetoothGatt.GATT_SUCCESS) {
+                        Log.w(TAG, "Client: Disconnected from $deviceAddress with error status $status")
+                        if (status == 147) {
+                            Log.e(TAG, "Client: Connection establishment failed (status 147) for $deviceAddress")
+                        }
+                    } else {
+                        Log.d(TAG, "Client: Cleanly disconnected from $deviceAddress")
+                    }
+                    
+                    connectionTracker.cleanupDeviceConnection(deviceAddress)
+                    
+                    connectionScope.launch {
+                        delay(500) // CLEANUP_DELAY
+                        try {
+                            gatt.close()
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Error closing GATT: ${e.message}")
+                        }
+                    }
+                }
+            }
+            
+            override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
+                val deviceAddress = gatt.device.address
+                Log.i(TAG, "Client: MTU changed for $deviceAddress to $mtu with status $status")
+
+                if (status == BluetoothGatt.GATT_SUCCESS) {
+                    Log.i(TAG, "MTU successfully negotiated for $deviceAddress. Discovering services.")
+                    
+                    // Now that MTU is set, connection is fully ready.
+                    val deviceConn = BluetoothConnectionTracker.DeviceConnection(
+                        device = gatt.device,
+                        gatt = gatt,
+                        rssi = rssi,
+                        isClient = true
+                    )
+                    connectionTracker.addDeviceConnection(deviceAddress, deviceConn)
+                    
+                    // Start service discovery only AFTER MTU is set.
+                    gatt.discoverServices()
+                } else {
+                    Log.w(TAG, "MTU negotiation failed for $deviceAddress with status: $status. Disconnecting.")
+                    connectionTracker.removePendingConnection(deviceAddress)
+                    gatt.disconnect()
+                }
+            }
+
+            override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {                
+                if (status == BluetoothGatt.GATT_SUCCESS) {
+                    val service = gatt.getService(SERVICE_UUID)
+                    if (service != null) {
+                        val characteristic = service.getCharacteristic(CHARACTERISTIC_UUID)
+                        if (characteristic != null) {
+                            connectionTracker.getDeviceConnection(deviceAddress)?.let { deviceConn ->
+                                val updatedConn = deviceConn.copy(characteristic = characteristic)
+                                connectionTracker.updateDeviceConnection(deviceAddress, updatedConn)
+                                Log.d(TAG, "Client: Updated device connection with characteristic for $deviceAddress")
+                            }
+                            
+                            gatt.setCharacteristicNotification(characteristic, true)
+                            val descriptor = characteristic.getDescriptor(UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"))
+                            if (descriptor != null) {
+                                descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                                gatt.writeDescriptor(descriptor)
+                                
+                                connectionScope.launch {
+                                    delay(200)
+                                    Log.i(TAG, "Client: Connection setup complete for $deviceAddress")
+                                    delegate?.onDeviceConnected(device)
+                                }
+                            } else {
+                                Log.e(TAG, "Client: CCCD descriptor not found for $deviceAddress")
+                                gatt.disconnect()
+                            }
+                        } else {
+                            Log.e(TAG, "Client: Required characteristic not found for $deviceAddress")
+                            gatt.disconnect()
+                        }
+                    } else {
+                        Log.e(TAG, "Client: Required service not found for $deviceAddress")
+                        gatt.disconnect()
+                    }
+                } else {
+                    Log.e(TAG, "Client: Service discovery failed with status $status for $deviceAddress")
+                    gatt.disconnect()
+                }
+            }
+            
+            override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
+                val value = characteristic.value
+                Log.d(TAG, "Client: Received packet from ${gatt.device.address}, size: ${value.size} bytes")
+                val packet = BitchatPacket.fromBinaryData(value)
+                if (packet != null) {
+                    val peerID = String(packet.senderID).replace("\u0000", "")
+                    Log.d(TAG, "Client: Parsed packet type ${packet.type} from $peerID")
+                    delegate?.onPacketReceived(packet, peerID, gatt.device)
+                } else {
+                    Log.w(TAG, "Client: Failed to parse packet from ${gatt.device.address}, size: ${value.size} bytes")
+                    Log.w(TAG, "Client: Packet data: ${value.joinToString(" ") { "%02x".format(it) }}")
+                }
+            }
+        }
+        
+        try {
+            Log.d(TAG, "Client: Attempting GATT connection to $deviceAddress with autoConnect=false")
+            val gatt = device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+            if (gatt == null) {
+                Log.e(TAG, "connectGatt returned null for $deviceAddress")
+                connectionTracker.removePendingConnection(deviceAddress)
+            } else {
+                Log.d(TAG, "Client: GATT connection initiated successfully for $deviceAddress")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Client: Exception connecting to $deviceAddress: ${e.message}")
+            connectionTracker.removePendingConnection(deviceAddress)
+        }
+    }
+    
+    /**
+     * Restart scanning for power mode changes
+     */
+    fun restartScanning() {
+        if (!isActive) return
+        
+        connectionScope.launch {
+            stopScanning()
+            delay(1000) // Extra delay to avoid rate limiting
+            
+            if (powerManager.shouldUseDutyCycle()) {
+                Log.i(TAG, "Switching to duty cycle scanning mode")
+                // Duty cycle will handle scanning
+            } else {
+                Log.i(TAG, "Switching to continuous scanning mode")
+                startScanning()
+            }
+        }
+    }
+} 

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothGattServerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothGattServerManager.kt
@@ -69,7 +69,7 @@ class BluetoothGattServerManager(
         isActive = true
         
         connectionScope.launch {
-            // setupGattServer()
+            setupGattServer()
             delay(300) // Brief delay to ensure GATT server is ready
             startAdvertising()
         }

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothGattServerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothGattServerManager.kt
@@ -31,6 +31,7 @@ class BluetoothGattServerManager(
         // Use exact same UUIDs as iOS version
         private val SERVICE_UUID = UUID.fromString("F47B5E2D-4A9E-4C5A-9B3F-8E1D2C3A4B5C")
         private val CHARACTERISTIC_UUID = UUID.fromString("A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D")
+        private val DESCRIPTOR_UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
     }
     
     // Core Bluetooth components
@@ -253,7 +254,7 @@ class BluetoothGattServerManager(
         )
         
         val descriptor = BluetoothGattDescriptor(
-            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"),
+            DESCRIPTOR_UUID,
             BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE
         )
         characteristic?.addDescriptor(descriptor)

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothGattServerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothGattServerManager.kt
@@ -1,0 +1,321 @@
+package com.bitchat.android.mesh
+
+import android.bluetooth.*
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.content.Context
+import android.os.ParcelUuid
+import android.util.Log
+import com.bitchat.android.protocol.BitchatPacket
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.*
+
+/**
+ * Manages GATT server operations, advertising, and server-side connections
+ */
+class BluetoothGattServerManager(
+    private val context: Context,
+    private val connectionScope: CoroutineScope,
+    private val connectionTracker: BluetoothConnectionTracker,
+    private val permissionManager: BluetoothPermissionManager,
+    private val powerManager: PowerManager,
+    private val delegate: BluetoothConnectionManagerDelegate?
+) {
+    
+    companion object {
+        private const val TAG = "BluetoothGattServerManager"
+        // Use exact same UUIDs as iOS version
+        private val SERVICE_UUID = UUID.fromString("F47B5E2D-4A9E-4C5A-9B3F-8E1D2C3A4B5C")
+        private val CHARACTERISTIC_UUID = UUID.fromString("A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D")
+    }
+    
+    // Core Bluetooth components
+    private val bluetoothManager: BluetoothManager = 
+        context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+    private val bluetoothAdapter: BluetoothAdapter? = bluetoothManager.adapter
+    private val bleAdvertiser: BluetoothLeAdvertiser? = bluetoothAdapter?.bluetoothLeAdvertiser
+    
+    // GATT server for peripheral mode
+    private var gattServer: BluetoothGattServer? = null
+    private var characteristic: BluetoothGattCharacteristic? = null
+    private var advertiseCallback: AdvertiseCallback? = null
+    
+    // State management
+    private var isActive = false
+    
+    /**
+     * Start GATT server
+     */
+    fun start(): Boolean {
+        if (!permissionManager.hasBluetoothPermissions()) {
+            Log.e(TAG, "Missing Bluetooth permissions")
+            return false
+        }
+        
+        if (bluetoothAdapter?.isEnabled != true) {
+            Log.e(TAG, "Bluetooth is not enabled")
+            return false
+        }
+        
+        if (bleAdvertiser == null) {
+            Log.e(TAG, "BLE advertiser not available")
+            return false
+        }
+        
+        isActive = true
+        
+        connectionScope.launch {
+            setupGattServer()
+            delay(300) // Brief delay to ensure GATT server is ready
+            startAdvertising()
+        }
+        
+        return true
+    }
+    
+    /**
+     * Stop GATT server
+     */
+    fun stop() {
+        isActive = false
+        
+        connectionScope.launch {
+            stopAdvertising()
+            
+            // Close GATT server
+            gattServer?.close()
+            gattServer = null
+            
+            Log.i(TAG, "GATT server stopped")
+        }
+    }
+    
+    /**
+     * Get GATT server instance
+     */
+    fun getGattServer(): BluetoothGattServer? = gattServer
+    
+    /**
+     * Get characteristic instance
+     */
+    fun getCharacteristic(): BluetoothGattCharacteristic? = characteristic
+    
+    /**
+     * Setup GATT server with proper sequencing
+     */
+    @Suppress("DEPRECATION")
+    private fun setupGattServer() {
+        if (!permissionManager.hasBluetoothPermissions()) return
+        
+        val serverCallback = object : BluetoothGattServerCallback() {
+            override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
+                // Guard against callbacks after service shutdown
+                if (!isActive) {
+                    Log.d(TAG, "Server: Ignoring connection state change after shutdown")
+                    return
+                }
+                
+                when (newState) {
+                    BluetoothProfile.STATE_CONNECTED -> {
+                        Log.i(TAG, "Server: Device connected ${device.address}")
+                        val deviceConn = BluetoothConnectionTracker.DeviceConnection(
+                            device = device,
+                            isClient = false
+                        )
+                        connectionTracker.addDeviceConnection(device.address, deviceConn)
+                    }
+                    BluetoothProfile.STATE_DISCONNECTED -> {
+                        Log.i(TAG, "Server: Device disconnected ${device.address}")
+                        connectionTracker.cleanupDeviceConnection(device.address)
+                    }
+                }
+            }
+            
+            override fun onServiceAdded(status: Int, service: BluetoothGattService) {
+                // Guard against callbacks after service shutdown
+                if (!isActive) {
+                    Log.d(TAG, "Server: Ignoring service added callback after shutdown")
+                    return
+                }
+                
+                if (status == BluetoothGatt.GATT_SUCCESS) {
+                    Log.d(TAG, "Server: Service added successfully: ${service.uuid}")
+                } else {
+                    Log.e(TAG, "Server: Failed to add service: ${service.uuid}, status: $status")
+                }
+            }
+            
+            override fun onCharacteristicWriteRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                characteristic: BluetoothGattCharacteristic,
+                preparedWrite: Boolean,
+                responseNeeded: Boolean,
+                offset: Int,
+                value: ByteArray
+            ) {
+                // Guard against callbacks after service shutdown
+                if (!isActive) {
+                    Log.d(TAG, "Server: Ignoring characteristic write after shutdown")
+                    return
+                }
+                
+                if (characteristic.uuid == CHARACTERISTIC_UUID) {
+                    Log.i(TAG, "Server: Received packet from ${device.address}, size: ${value.size} bytes")
+                    val packet = BitchatPacket.fromBinaryData(value)
+                    if (packet != null) {
+                        val peerID = String(packet.senderID).replace("\u0000", "")
+                        Log.d(TAG, "Server: Parsed packet type ${packet.type} from $peerID")
+                        delegate?.onPacketReceived(packet, peerID, device)
+                    } else {
+                        Log.w(TAG, "Server: Failed to parse packet from ${device.address}, size: ${value.size} bytes")
+                        Log.w(TAG, "Server: Packet data: ${value.joinToString(" ") { "%02x".format(it) }}")
+                    }
+                    
+                    if (responseNeeded) {
+                        gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
+                    }
+                }
+            }
+            
+            override fun onDescriptorWriteRequest(
+                device: BluetoothDevice,
+                requestId: Int,
+                descriptor: BluetoothGattDescriptor,
+                preparedWrite: Boolean,
+                responseNeeded: Boolean,
+                offset: Int,
+                value: ByteArray
+            ) {
+                // Guard against callbacks after service shutdown
+                if (!isActive) {
+                    Log.d(TAG, "Server: Ignoring descriptor write after shutdown")
+                    return
+                }
+                
+                if (BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE.contentEquals(value)) {
+                    Log.d(TAG, "Device ${device.address} subscribed to notifications")
+                    connectionTracker.addSubscribedDevice(device)
+                    
+                    connectionScope.launch {
+                        delay(100)
+                        if (isActive) { // Check if still active
+                            delegate?.onDeviceConnected(device)
+                        }
+                    }
+                }
+                
+                if (responseNeeded) {
+                    gattServer?.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, 0, null)
+                }
+            }
+        }
+        
+        // Proper cleanup sequencing to prevent race conditions
+        gattServer?.let { server ->
+            Log.d(TAG, "Cleaning up existing GATT server")
+            try {
+                server.close()
+            } catch (e: Exception) {
+                Log.w(TAG, "Error closing existing GATT server: ${e.message}")
+            }
+        }
+        
+        // Small delay to ensure cleanup is complete
+        Thread.sleep(100)
+        
+        if (!isActive) {
+            Log.d(TAG, "Service inactive, skipping GATT server creation")
+            return
+        }
+        
+        // Create new server
+        gattServer = bluetoothManager.openGattServer(context, serverCallback)
+        
+        // Create characteristic with notification support
+        characteristic = BluetoothGattCharacteristic(
+            CHARACTERISTIC_UUID,
+            BluetoothGattCharacteristic.PROPERTY_READ or 
+            BluetoothGattCharacteristic.PROPERTY_WRITE or 
+            BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE or
+            BluetoothGattCharacteristic.PROPERTY_NOTIFY,
+            BluetoothGattCharacteristic.PERMISSION_READ or 
+            BluetoothGattCharacteristic.PERMISSION_WRITE
+        )
+        
+        val descriptor = BluetoothGattDescriptor(
+            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"),
+            BluetoothGattDescriptor.PERMISSION_READ or BluetoothGattDescriptor.PERMISSION_WRITE
+        )
+        characteristic?.addDescriptor(descriptor)
+        
+        val service = BluetoothGattService(SERVICE_UUID, BluetoothGattService.SERVICE_TYPE_PRIMARY)
+        service.addCharacteristic(characteristic)
+        
+        gattServer?.addService(service)
+        
+        Log.i(TAG, "GATT server setup complete")
+    }
+    
+    /**
+     * Start advertising
+     */
+    @Suppress("DEPRECATION")
+    private fun startAdvertising() {
+        if (!permissionManager.hasBluetoothPermissions() || bleAdvertiser == null || !isActive) return
+
+        val settings = powerManager.getAdvertiseSettings()
+        
+        val data = AdvertiseData.Builder()
+            .addServiceUuid(ParcelUuid(SERVICE_UUID))
+            .setIncludeTxPowerLevel(false)
+            .setIncludeDeviceName(false)
+            .build()
+        
+        advertiseCallback = object : AdvertiseCallback() {
+            override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
+                Log.i(TAG, "Advertising started (power mode: ${powerManager.getPowerInfo().split("Current Mode: ")[1].split("\n")[0]})")
+            }
+            
+            override fun onStartFailure(errorCode: Int) {
+                Log.e(TAG, "Advertising failed: $errorCode")
+            }
+        }
+        
+        try {
+            bleAdvertiser.startAdvertising(settings, data, advertiseCallback)
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception starting advertising: ${e.message}")
+        }
+    }
+    
+    /**
+     * Stop advertising
+     */
+    @Suppress("DEPRECATION")
+    private fun stopAdvertising() {
+        if (!permissionManager.hasBluetoothPermissions() || bleAdvertiser == null) return
+        try {
+            advertiseCallback?.let { bleAdvertiser.stopAdvertising(it) }
+        } catch (e: Exception) {
+            Log.w(TAG, "Error stopping advertising: ${e.message}")
+        }
+    }
+    
+    /**
+     * Restart advertising (for power mode changes)
+     */
+    fun restartAdvertising() {
+        if (!isActive) return
+        
+        connectionScope.launch {
+            stopAdvertising()
+            delay(100)
+            startAdvertising()
+        }
+    }
+} 

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothGattServerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothGattServerManager.kt
@@ -69,7 +69,7 @@ class BluetoothGattServerManager(
         isActive = true
         
         connectionScope.launch {
-            setupGattServer()
+            // setupGattServer()
             delay(300) // Brief delay to ensure GATT server is ready
             startAdvertising()
         }
@@ -122,8 +122,13 @@ class BluetoothGattServerManager(
                 when (newState) {
                     BluetoothProfile.STATE_CONNECTED -> {
                         Log.i(TAG, "Server: Device connected ${device.address}")
+                        
+                        // Get best available RSSI (scan RSSI for server connections)
+                        val rssi = connectionTracker.getBestRSSI(device.address) ?: Int.MIN_VALUE
+                        
                         val deviceConn = BluetoothConnectionTracker.DeviceConnection(
                             device = device,
+                            rssi = rssi,
                             isClient = false
                         )
                         connectionTracker.addDeviceConnection(device.address, deviceConn)

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -45,7 +45,7 @@ class BluetoothMeshService(private val context: Context) {
     private val securityManager = SecurityManager(encryptionService, myPeerID)
     private val storeForwardManager = StoreForwardManager()
     private val messageHandler = MessageHandler(myPeerID)
-    internal val connectionManager = BluetoothConnectionManager(context, myPeerID) // Made internal for access
+    internal val connectionManager = BluetoothConnectionManager(context, myPeerID, fragmentManager) // Made internal for access
     private val packetProcessor = PacketProcessor(myPeerID)
     
     // Service state management

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -280,6 +280,13 @@ class BluetoothMeshService(private val context: Context) {
                     sendKeyExchangeToDevice()
                 }
             }
+            
+            override fun onRSSIUpdated(deviceAddress: String, rssi: Int) {
+                // Find the peer ID for this device address and update RSSI in PeerManager
+                connectionManager.addressPeerMap[deviceAddress]?.let { peerID ->
+                    peerManager.updatePeerRSSI(peerID, rssi)
+                }
+            }
         }
     }
     

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.bitchat.android.crypto.EncryptionService
 import com.bitchat.android.crypto.MessagePadding
 import com.bitchat.android.model.BitchatMessage
+import com.bitchat.android.model.RoutedPacket
 import com.bitchat.android.model.DeliveryAck
 import com.bitchat.android.model.ReadReceipt
 import com.bitchat.android.protocol.BitchatPacket
@@ -101,10 +102,14 @@ class BluetoothMeshService(private val context: Context) {
         
         // SecurityManager delegate for key exchange notifications
         securityManager.delegate = object : SecurityManagerDelegate {
-            override fun onKeyExchangeCompleted(peerID: String, peerPublicKeyData: ByteArray) {
+            override fun onKeyExchangeCompleted(peerID: String, peerPublicKeyData: ByteArray, receivedAddress: String?) {
                 // Notify delegate about key exchange completion so it can register peer fingerprint
                 delegate?.registerPeerPublicKey(peerID, peerPublicKeyData)
                 
+                receivedAddress?.let { address ->
+                    connectionManager.addressPeerMap[address] = peerID
+                }
+
                 // Send announcement and cached messages after key exchange
                 serviceScope.launch {
                     delay(100)
@@ -127,7 +132,7 @@ class BluetoothMeshService(private val context: Context) {
             }
             
             override fun sendPacket(packet: BitchatPacket) {
-                connectionManager.broadcastPacket(packet)
+                connectionManager.broadcastPacket(RoutedPacket(packet))
             }
         }
         
@@ -160,11 +165,11 @@ class BluetoothMeshService(private val context: Context) {
             
             // Packet operations
             override fun sendPacket(packet: BitchatPacket) {
-                connectionManager.broadcastPacket(packet)
+                connectionManager.broadcastPacket(RoutedPacket(packet))
             }
             
-            override fun relayPacket(packet: BitchatPacket) {
-                connectionManager.broadcastPacket(packet)
+            override fun relayPacket(routed: RoutedPacket) {
+                connectionManager.broadcastPacket(routed)
             }
             
             override fun getBroadcastRecipient(): ByteArray {
@@ -221,32 +226,32 @@ class BluetoothMeshService(private val context: Context) {
                 peerManager.updatePeerLastSeen(peerID)
             }
             
-            override fun handleKeyExchange(packet: BitchatPacket, peerID: String): Boolean {
-                return runBlocking { securityManager.handleKeyExchange(packet, peerID) }
+            override fun handleKeyExchange(routed: RoutedPacket): Boolean {
+                return runBlocking { securityManager.handleKeyExchange(routed) }
             }
             
-            override fun handleAnnounce(packet: BitchatPacket, peerID: String) {
-                serviceScope.launch { messageHandler.handleAnnounce(packet, peerID) }
+            override fun handleAnnounce(routed: RoutedPacket) {
+                serviceScope.launch { messageHandler.handleAnnounce(routed) }
             }
             
-            override fun handleMessage(packet: BitchatPacket, peerID: String) {
-                serviceScope.launch { messageHandler.handleMessage(packet, peerID) }
+            override fun handleMessage(routed: RoutedPacket) {
+                serviceScope.launch { messageHandler.handleMessage(routed) }
             }
             
-            override fun handleLeave(packet: BitchatPacket, peerID: String) {
-                serviceScope.launch { messageHandler.handleLeave(packet, peerID) }
+            override fun handleLeave(routed: RoutedPacket) {
+                serviceScope.launch { messageHandler.handleLeave(routed) }
             }
             
             override fun handleFragment(packet: BitchatPacket): BitchatPacket? {
                 return fragmentManager.handleFragment(packet)
             }
             
-            override fun handleDeliveryAck(packet: BitchatPacket, peerID: String) {
-                serviceScope.launch { messageHandler.handleDeliveryAck(packet, peerID) }
+            override fun handleDeliveryAck(routed: RoutedPacket) {
+                serviceScope.launch { messageHandler.handleDeliveryAck(routed) }
             }
             
-            override fun handleReadReceipt(packet: BitchatPacket, peerID: String) {
-                serviceScope.launch { messageHandler.handleReadReceipt(packet, peerID) }
+            override fun handleReadReceipt(routed: RoutedPacket) {
+                serviceScope.launch { messageHandler.handleReadReceipt(routed) }
             }
             
             override fun sendAnnouncementToPeer(peerID: String) {
@@ -257,15 +262,15 @@ class BluetoothMeshService(private val context: Context) {
                 storeForwardManager.sendCachedMessages(peerID)
             }
             
-            override fun relayPacket(packet: BitchatPacket) {
-                connectionManager.broadcastPacket(packet)
+            override fun relayPacket(routed: RoutedPacket) {
+                connectionManager.broadcastPacket(routed)
             }
         }
         
         // BluetoothConnectionManager delegates
         connectionManager.delegate = object : BluetoothConnectionManagerDelegate {
             override fun onPacketReceived(packet: BitchatPacket, peerID: String, device: android.bluetooth.BluetoothDevice?) {
-                packetProcessor.processPacket(packet, peerID)
+                packetProcessor.processPacket(RoutedPacket(packet, peerID, device?.address))
             }
             
             override fun onDeviceConnected(device: android.bluetooth.BluetoothDevice) {
@@ -370,7 +375,7 @@ class BluetoothMeshService(private val context: Context) {
                 
                 // Send with random delay and retry for reliability
                 // delay(Random.nextLong(50, 500))
-                connectionManager.broadcastPacket(packet)
+                connectionManager.broadcastPacket(RoutedPacket(packet))
             }
         }
     }
@@ -423,7 +428,7 @@ class BluetoothMeshService(private val context: Context) {
                         
                         // Send with delay
                         delay(Random.nextLong(50, 500))
-                        connectionManager.broadcastPacket(packet)
+                        connectionManager.broadcastPacket(RoutedPacket(packet))
                     }
                     
                 } catch (e: Exception) {
@@ -449,13 +454,13 @@ class BluetoothMeshService(private val context: Context) {
             
             // Send multiple times for reliability
             delay(Random.nextLong(0, 500))
-            connectionManager.broadcastPacket(announcePacket)
+            connectionManager.broadcastPacket(RoutedPacket(announcePacket))
             
             delay(500 + Random.nextLong(0, 500))
-            connectionManager.broadcastPacket(announcePacket)
+            connectionManager.broadcastPacket(RoutedPacket(announcePacket))
             
             delay(1000 + Random.nextLong(0, 500))
-            connectionManager.broadcastPacket(announcePacket)
+            connectionManager.broadcastPacket(RoutedPacket(announcePacket))
         }
     }
     
@@ -473,7 +478,7 @@ class BluetoothMeshService(private val context: Context) {
             payload = nickname.toByteArray()
         )
         
-        connectionManager.broadcastPacket(packet)
+        connectionManager.broadcastPacket(RoutedPacket(packet))
         peerManager.markPeerAsAnnouncedTo(peerID)
     }
     
@@ -489,7 +494,7 @@ class BluetoothMeshService(private val context: Context) {
             payload = publicKeyData
         )
         
-        connectionManager.broadcastPacket(packet)
+        connectionManager.broadcastPacket(RoutedPacket(packet))
         Log.d(TAG, "Sent key exchange")
     }
     
@@ -505,7 +510,7 @@ class BluetoothMeshService(private val context: Context) {
             payload = nickname.toByteArray()
         )
         
-        connectionManager.broadcastPacket(packet)
+        connectionManager.broadcastPacket(RoutedPacket(packet))
     }
     
     /**

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -296,9 +296,7 @@ class BluetoothMeshService(private val context: Context) {
         Log.i(TAG, "Starting Bluetooth mesh service with peer ID: $myPeerID")
         
         if (connectionManager.startServices()) {
-            isActive = true
-            Log.i(TAG, "Bluetooth services started successfully")
-            
+            isActive = true            
             // Send initial announcements after services are ready
             serviceScope.launch {
                 delay(1000)

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -522,6 +522,27 @@ class BluetoothMeshService(private val context: Context) {
     fun getPeerRSSI(): Map<String, Int> = peerManager.getAllPeerRSSI()
     
     /**
+     * Get device address for a specific peer ID
+     */
+    fun getDeviceAddressForPeer(peerID: String): String? {
+        return connectionManager.addressPeerMap.entries.find { it.value == peerID }?.key
+    }
+    
+    /**
+     * Get all device addresses mapped to their peer IDs
+     */
+    fun getDeviceAddressToPeerMapping(): Map<String, String> {
+        return connectionManager.addressPeerMap.toMap()
+    }
+    
+    /**
+     * Print device addresses for all connected peers
+     */
+    fun printDeviceAddressesForPeers(): String {
+        return peerManager.getDebugInfoWithDeviceAddresses(connectionManager.addressPeerMap)
+    }
+
+    /**
      * Get debug status information
      */
     fun getDebugStatus(): String {
@@ -531,7 +552,7 @@ class BluetoothMeshService(private val context: Context) {
             appendLine()
             appendLine(connectionManager.getDebugInfo())
             appendLine()
-            appendLine(peerManager.getDebugInfo())
+            appendLine(peerManager.getDebugInfo(connectionManager.addressPeerMap))
             appendLine()
             appendLine(fragmentManager.getDebugInfo())
             appendLine()

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothPacketBroadcaster.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothPacketBroadcaster.kt
@@ -1,0 +1,151 @@
+package com.bitchat.android.mesh
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattServer
+import android.util.Log
+import com.bitchat.android.protocol.SpecialRecipients
+import com.bitchat.android.model.RoutedPacket
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Handles packet broadcasting to connected devices
+ */
+class BluetoothPacketBroadcaster(
+    private val connectionScope: CoroutineScope,
+    private val connectionTracker: BluetoothConnectionTracker
+) {
+    
+    companion object {
+        private const val TAG = "BluetoothPacketBroadcaster"
+        private const val CLEANUP_DELAY = 500L
+    }
+    
+    /**
+     * Broadcast packet to connected devices with connection limit enforcement
+     */
+    fun broadcastPacket(
+        routed: RoutedPacket,
+        gattServer: BluetoothGattServer?,
+        characteristic: BluetoothGattCharacteristic?
+    ) {
+        val packet = routed.packet
+        val data = packet.toBinaryData() ?: return
+        
+        if (packet.recipientID != SpecialRecipients.BROADCAST) {
+            val recipientID = packet.recipientID?.let {
+                String(it).replace("\u0000", "").trim()
+            } ?: ""
+
+            // Try to find the recipient in server connections (subscribedDevices)
+            val targetDevice = connectionTracker.getSubscribedDevices()
+                .firstOrNull { connectionTracker.addressPeerMap[it.address] == recipientID }
+            
+            // If found, send directly
+            if (targetDevice != null) {
+                Log.d(TAG, "Send packet type ${packet.type} directly to target device for recipient $recipientID: ${targetDevice.address}")
+                if (notifyDevice(targetDevice, data, gattServer, characteristic))
+                    return  // Sent, no need to continue
+            }
+
+            // Try to find the recipient in client connections (connectedDevices)
+            val targetDeviceConn = connectionTracker.getConnectedDevices().values
+                .firstOrNull { connectionTracker.addressPeerMap[it.device.address] == recipientID }
+            
+            // If found, send directly
+            if (targetDeviceConn != null) {
+                Log.d(TAG, "Send packet type ${packet.type} directly to target client connection for recipient $recipientID: ${targetDeviceConn.device.address}")
+                if (writeToDeviceConn(targetDeviceConn, data))
+                    return  // Sent, no need to continue
+            }
+        }
+
+        // Else, continue with broadcasting to all devices
+        val subscribedDevices = connectionTracker.getSubscribedDevices()
+        val connectedDevices = connectionTracker.getConnectedDevices()
+        
+        Log.d(TAG, "Broadcasting packet type ${packet.type} to ${subscribedDevices.size} server + ${connectedDevices.size} client connections")
+
+        val senderID = String(packet.senderID).replace("\u0000", "")        
+        
+        // Send to server connections (devices connected to our GATT server)
+        subscribedDevices.forEach { device ->
+            if (device.address == routed.relayAddress) {
+                Log.d(TAG, "Skipping broadcast back to relayer: ${device.address}")
+                return@forEach
+            }
+            if (connectionTracker.addressPeerMap[device.address] == senderID) {
+                Log.d(TAG, "Skipping broadcast back to sender: ${device.address}")
+                return@forEach
+            }
+            notifyDevice(device, data, gattServer, characteristic)
+        }
+        
+        // Send to client connections
+        connectedDevices.values.forEach { deviceConn ->
+            if (deviceConn.isClient && deviceConn.gatt != null && deviceConn.characteristic != null) {
+                if (deviceConn.device.address == routed.relayAddress) {
+                    Log.d(TAG, "Skipping broadcast back to relayer: ${deviceConn.device.address}")
+                    return@forEach
+                }
+                if (connectionTracker.addressPeerMap[deviceConn.device.address] == senderID) {
+                    Log.d(TAG, "Skipping broadcast back to sender: ${deviceConn.device.address}")
+                    return@forEach
+                }
+                writeToDeviceConn(deviceConn, data)
+            }
+        }
+    }
+    
+    /**
+     * Send data to a single device (server side)
+     */
+    private fun notifyDevice(
+        device: BluetoothDevice, 
+        data: ByteArray,
+        gattServer: BluetoothGattServer?,
+        characteristic: BluetoothGattCharacteristic?
+    ): Boolean {
+        return try {
+            characteristic?.let { char ->
+                char.value = data
+                val result = gattServer?.notifyCharacteristicChanged(device, char, false) ?: false
+                result
+            } ?: false
+        } catch (e: Exception) {
+            Log.w(TAG, "Error sending to server connection ${device.address}: ${e.message}")
+            connectionScope.launch {
+                delay(CLEANUP_DELAY)
+                connectionTracker.removeSubscribedDevice(device)
+                connectionTracker.addressPeerMap.remove(device.address)
+            }
+            false
+        }
+    }
+
+    /**
+     * Send data to a single device (client side)
+     */
+    private fun writeToDeviceConn(
+        deviceConn: BluetoothConnectionTracker.DeviceConnection, 
+        data: ByteArray
+    ): Boolean {
+        return try {
+            deviceConn.characteristic?.let { char ->
+                char.value = data
+                val result = deviceConn.gatt?.writeCharacteristic(char) ?: false
+                result
+            } ?: false
+        } catch (e: Exception) {
+            Log.w(TAG, "Error sending to client connection ${deviceConn.device.address}: ${e.message}")
+            connectionScope.launch {
+                delay(CLEANUP_DELAY)
+                connectionTracker.cleanupDeviceConnection(deviceConn.device.address)
+            }
+            false
+        }
+    }
+} 

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothPermissionManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothPermissionManager.kt
@@ -1,0 +1,41 @@
+package com.bitchat.android.mesh
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+
+/**
+ * Handles all Bluetooth permission checking logic
+ */
+class BluetoothPermissionManager(private val context: Context) {
+    
+    /**
+     * Check if all required Bluetooth permissions are granted
+     */
+    fun hasBluetoothPermissions(): Boolean {
+        val permissions = mutableListOf<String>()
+        
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            permissions.addAll(listOf(
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Manifest.permission.BLUETOOTH_SCAN
+            ))
+        } else {
+            permissions.addAll(listOf(
+                Manifest.permission.BLUETOOTH,
+                Manifest.permission.BLUETOOTH_ADMIN
+            ))
+        }
+        
+        permissions.addAll(listOf(
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ))
+        
+        return permissions.all { 
+            ActivityCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED 
+        }
+    }
+} 

--- a/app/src/main/java/com/bitchat/android/mesh/PacketProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/PacketProcessor.kt
@@ -3,6 +3,7 @@ package com.bitchat.android.mesh
 import android.util.Log
 import com.bitchat.android.protocol.BitchatPacket
 import com.bitchat.android.protocol.MessageType
+import com.bitchat.android.model.RoutedPacket
 import kotlinx.coroutines.*
 
 /**
@@ -24,16 +25,19 @@ class PacketProcessor(private val myPeerID: String) {
     /**
      * Process received packet - main entry point for all incoming packets
      */
-    fun processPacket(packet: BitchatPacket, peerID: String) {
+    fun processPacket(routed: RoutedPacket) {
         processorScope.launch {
-            handleReceivedPacket(packet, peerID)
+            handleReceivedPacket(routed)
         }
     }
     
     /**
      * Handle received packet - core protocol logic (exact same as iOS)
      */
-    private suspend fun handleReceivedPacket(packet: BitchatPacket, peerID: String) {
+    private suspend fun handleReceivedPacket(routed: RoutedPacket) {
+        val packet = routed.packet
+        val peerID = routed.peerID ?: "unknown"
+
         // Basic validation and security checks
         if (!delegate?.validatePacketSecurity(packet, peerID)!!) {
             Log.d(TAG, "Packet failed security validation from $peerID")
@@ -47,15 +51,15 @@ class PacketProcessor(private val myPeerID: String) {
         
         // Process based on message type (exact same logic as iOS)
         when (MessageType.fromValue(packet.type)) {
-            MessageType.KEY_EXCHANGE -> handleKeyExchange(packet, peerID)
-            MessageType.ANNOUNCE -> handleAnnounce(packet, peerID)
-            MessageType.MESSAGE -> handleMessage(packet, peerID)
-            MessageType.LEAVE -> handleLeave(packet, peerID)
+            MessageType.KEY_EXCHANGE -> handleKeyExchange(routed)
+            MessageType.ANNOUNCE -> handleAnnounce(routed)
+            MessageType.MESSAGE -> handleMessage(routed)
+            MessageType.LEAVE -> handleLeave(routed)
             MessageType.FRAGMENT_START,
             MessageType.FRAGMENT_CONTINUE,
-            MessageType.FRAGMENT_END -> handleFragment(packet, peerID)
-            MessageType.DELIVERY_ACK -> handleDeliveryAck(packet, peerID)
-            MessageType.READ_RECEIPT -> handleReadReceipt(packet, peerID)
+            MessageType.FRAGMENT_END -> handleFragment(routed)
+            MessageType.DELIVERY_ACK -> handleDeliveryAck(routed)
+            MessageType.READ_RECEIPT -> handleReadReceipt(routed)
             else -> {
                 Log.w(TAG, "Unknown message type: ${packet.type}")
             }
@@ -65,10 +69,11 @@ class PacketProcessor(private val myPeerID: String) {
     /**
      * Handle key exchange message
      */
-    private suspend fun handleKeyExchange(packet: BitchatPacket, peerID: String) {
+    private suspend fun handleKeyExchange(routed: RoutedPacket) {
+        val peerID = routed.peerID ?: "unknown"
         Log.d(TAG, "Processing key exchange from $peerID")
         
-        val success = delegate?.handleKeyExchange(packet, peerID) ?: false
+        val success = delegate?.handleKeyExchange(routed) ?: false
         
         if (success) {
             // Key exchange successful, send announce and cached messages
@@ -83,60 +88,60 @@ class PacketProcessor(private val myPeerID: String) {
     /**
      * Handle announce message
      */
-    private suspend fun handleAnnounce(packet: BitchatPacket, peerID: String) {
-        Log.d(TAG, "Processing announce from $peerID")
-        delegate?.handleAnnounce(packet, peerID)
+    private suspend fun handleAnnounce(routed: RoutedPacket) {
+        Log.d(TAG, "Processing announce from ${routed.peerID}")
+        delegate?.handleAnnounce(routed)
     }
     
     /**
      * Handle regular message
      */
-    private suspend fun handleMessage(packet: BitchatPacket, peerID: String) {
-        Log.d(TAG, "Processing message from $peerID")
-        delegate?.handleMessage(packet, peerID)
+    private suspend fun handleMessage(routed: RoutedPacket) {
+        Log.d(TAG, "Processing message from ${routed.peerID}")
+        delegate?.handleMessage(routed)
     }
     
     /**
      * Handle leave message
      */
-    private suspend fun handleLeave(packet: BitchatPacket, peerID: String) {
-        Log.d(TAG, "Processing leave from $peerID")
-        delegate?.handleLeave(packet, peerID)
+    private suspend fun handleLeave(routed: RoutedPacket) {
+        Log.d(TAG, "Processing leave from ${routed.peerID}")
+        delegate?.handleLeave(routed)
     }
     
     /**
      * Handle message fragments
      */
-    private suspend fun handleFragment(packet: BitchatPacket, peerID: String) {
-        Log.d(TAG, "Processing fragment from $peerID")
+    private suspend fun handleFragment(routed: RoutedPacket) {
+        Log.d(TAG, "Processing fragment from ${routed.peerID}")
         
-        val reassembledPacket = delegate?.handleFragment(packet)
+        val reassembledPacket = delegate?.handleFragment(routed.packet)
         if (reassembledPacket != null) {
             Log.d(TAG, "Fragment reassembled, processing complete message")
-            handleReceivedPacket(reassembledPacket, peerID)
+            handleReceivedPacket(RoutedPacket(reassembledPacket, routed.peerID, routed.relayAddress))
         }
         
         // Relay fragment regardless of reassembly
-        if (packet.ttl > 0u) {
-            val relayPacket = packet.copy(ttl = (packet.ttl - 1u).toUByte())
-            delegate?.relayPacket(relayPacket)
+        if (routed.packet.ttl > 0u) {
+            val relayPacket = routed.packet.copy(ttl = (routed.packet.ttl - 1u).toUByte())
+            delegate?.relayPacket(RoutedPacket(relayPacket, routed.peerID, routed.relayAddress))
         }
     }
     
     /**
      * Handle delivery acknowledgment
      */
-    private suspend fun handleDeliveryAck(packet: BitchatPacket, peerID: String) {
-        Log.d(TAG, "Processing delivery ACK from $peerID")
-        delegate?.handleDeliveryAck(packet, peerID)
+    private suspend fun handleDeliveryAck(routed: RoutedPacket) {
+        Log.d(TAG, "Processing delivery ACK from ${routed.peerID}")
+        delegate?.handleDeliveryAck(routed)
     }
     
     /**
      * Handle read receipt
      */
-    private suspend fun handleReadReceipt(packet: BitchatPacket, peerID: String) {
-        Log.d(TAG, "Processing read receipt from $peerID")
-        delegate?.handleReadReceipt(packet, peerID)
+    private suspend fun handleReadReceipt(routed: RoutedPacket) {
+        Log.d(TAG, "Processing read receipt from ${routed.peerID}")
+        delegate?.handleReadReceipt(routed)
     }
     
     /**
@@ -169,16 +174,16 @@ interface PacketProcessorDelegate {
     fun updatePeerLastSeen(peerID: String)
     
     // Message type handlers
-    fun handleKeyExchange(packet: BitchatPacket, peerID: String): Boolean
-    fun handleAnnounce(packet: BitchatPacket, peerID: String)
-    fun handleMessage(packet: BitchatPacket, peerID: String)
-    fun handleLeave(packet: BitchatPacket, peerID: String)
+    fun handleKeyExchange(routed: RoutedPacket): Boolean
+    fun handleAnnounce(routed: RoutedPacket)
+    fun handleMessage(routed: RoutedPacket)
+    fun handleLeave(routed: RoutedPacket)
     fun handleFragment(packet: BitchatPacket): BitchatPacket?
-    fun handleDeliveryAck(packet: BitchatPacket, peerID: String)
-    fun handleReadReceipt(packet: BitchatPacket, peerID: String)
+    fun handleDeliveryAck(routed: RoutedPacket)
+    fun handleReadReceipt(routed: RoutedPacket)
     
     // Communication
     fun sendAnnouncementToPeer(peerID: String)
     fun sendCachedMessages(peerID: String)
-    fun relayPacket(packet: BitchatPacket)
+    fun relayPacket(routed: RoutedPacket)
 }

--- a/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
@@ -183,7 +183,7 @@ class PeerManager {
     /**
      * Get debug information
      */
-    fun getDebugInfo(): String {
+    fun getDebugInfo(addressPeerMap: Map<String, String>? = null): String {
         return buildString {
             appendLine("=== Peer Manager Debug Info ===")
             appendLine("Active Peers: ${activePeers.size}")
@@ -191,10 +191,36 @@ class PeerManager {
                 val nickname = peerNicknames[peerID] ?: "Unknown"
                 val timeSince = (System.currentTimeMillis() - lastSeen) / 1000
                 val rssi = peerRSSI[peerID]?.let { "${it} dBm" } ?: "No RSSI"
-                appendLine("  - $peerID ($nickname) - last seen ${timeSince}s ago, RSSI: $rssi")
+                
+                // Find device address for this peer ID
+                val deviceAddress = addressPeerMap?.entries?.find { it.value == peerID }?.key
+                val addressInfo = deviceAddress?.let { " [Device: $it]" } ?: " [Device: Unknown]"
+                
+                appendLine("  - $peerID ($nickname)$addressInfo - last seen ${timeSince}s ago, RSSI: $rssi")
             }
             appendLine("Announced Peers: ${announcedPeers.size}")
             appendLine("Announced To Peers: ${announcedToPeers.size}")
+        }
+    }
+    
+    /**
+     * Get debug information with device addresses
+     */
+    fun getDebugInfoWithDeviceAddresses(addressPeerMap: Map<String, String>): String {
+        return buildString {
+            appendLine("=== Device Address to Peer Mapping ===")
+            if (addressPeerMap.isEmpty()) {
+                appendLine("No device address mappings available")
+            } else {
+                addressPeerMap.forEach { (deviceAddress, peerID) ->
+                    val nickname = peerNicknames[peerID] ?: "Unknown"
+                    val isActive = activePeers.containsKey(peerID)
+                    val status = if (isActive) "ACTIVE" else "INACTIVE"
+                    appendLine("  Device: $deviceAddress -> Peer: $peerID ($nickname) [$status]")
+                }
+            }
+            appendLine()
+            appendLine(getDebugInfo(addressPeerMap))
         }
     }
     

--- a/app/src/main/java/com/bitchat/android/mesh/PowerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/PowerManager.kt
@@ -26,12 +26,12 @@ class PowerManager(private val context: Context) {
         private const val MEDIUM_BATTERY = 50
         
         // Scan duty cycle periods (ms)
-        private const val SCAN_ON_DURATION_NORMAL = 2000L    // 2 seconds on
-        private const val SCAN_OFF_DURATION_NORMAL = 8000L   // 8 seconds off
-        private const val SCAN_ON_DURATION_POWER_SAVE = 1000L    // 1 second on
-        private const val SCAN_OFF_DURATION_POWER_SAVE = 15000L  // 15 seconds off
-        private const val SCAN_ON_DURATION_ULTRA_LOW = 500L      // 0.5 seconds on
-        private const val SCAN_OFF_DURATION_ULTRA_LOW = 30000L   // 30 seconds off
+        private const val SCAN_ON_DURATION_NORMAL = 8000L    // 8 seconds on
+        private const val SCAN_OFF_DURATION_NORMAL = 2000L   // 2 seconds off
+        private const val SCAN_ON_DURATION_POWER_SAVE = 2000L    // 2 seconds on
+        private const val SCAN_OFF_DURATION_POWER_SAVE = 8000L  // 8 seconds off
+        private const val SCAN_ON_DURATION_ULTRA_LOW = 1000L      // 1 second on
+        private const val SCAN_OFF_DURATION_ULTRA_LOW = 10000L   // 10 seconds off
         
         // Connection limits
         private const val MAX_CONNECTIONS_NORMAL = 8
@@ -112,38 +112,38 @@ class PowerManager(private val context: Context) {
     /**
      * Get scan settings optimized for current power mode
      */
-        fun getScanSettings(): ScanSettings {
-            // CRITICAL FIX: Set reportDelay to 0 for all modes.
-            // When using a custom duty cycle, we want scan results delivered immediately,
-            // not batched. A non-zero report delay can conflict with the scan window,
-            // causing missed results if the scan stops before the delay is met.
-            val builder = ScanSettings.Builder()
-                .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
+    fun getScanSettings(): ScanSettings {
+        // CRITICAL FIX: Set reportDelay to 0 for all modes.
+        // When using a custom duty cycle, we want scan results delivered immediately,
+        // not batched. A non-zero report delay can conflict with the scan window,
+        // causing missed results if the scan stops before the delay is met.
+        val builder = ScanSettings.Builder()
+            .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
 
-            when (currentMode) {
-                PowerMode.PERFORMANCE -> builder
-                    .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
-                    .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
-                    .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)
+        when (currentMode) {
+            PowerMode.PERFORMANCE -> builder
+                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)
 
-                PowerMode.BALANCED -> builder
-                    .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
-                    .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
-                    .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
+            PowerMode.BALANCED -> builder
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+                .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
 
-                PowerMode.POWER_SAVER -> builder
-                    .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
-                    .setMatchMode(ScanSettings.MATCH_MODE_STICKY)
-                    .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
+            PowerMode.POWER_SAVER -> builder
+                .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+                .setMatchMode(ScanSettings.MATCH_MODE_STICKY)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
 
-                PowerMode.ULTRA_LOW_POWER -> builder
-                    .setScanMode(ScanSettings.SCAN_MODE_OPPORTUNISTIC)
-                    .setMatchMode(ScanSettings.MATCH_MODE_STICKY)
-                    .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
-            }
-
-            return builder.setReportDelay(0).build()
+            PowerMode.ULTRA_LOW_POWER -> builder
+                .setScanMode(ScanSettings.SCAN_MODE_OPPORTUNISTIC)
+                .setMatchMode(ScanSettings.MATCH_MODE_STICKY)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT)
         }
+
+        return builder.setReportDelay(0).build()
+    }
     
     /**
      * Get advertising settings optimized for current power mode

--- a/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.bitchat.android.crypto.EncryptionService
 import com.bitchat.android.protocol.BitchatPacket
 import com.bitchat.android.protocol.MessageType
+import com.bitchat.android.model.RoutedPacket
 import kotlinx.coroutines.*
 import java.util.*
 import kotlin.collections.mutableSetOf
@@ -88,7 +89,10 @@ class SecurityManager(private val encryptionService: EncryptionService, private 
     /**
      * Handle key exchange packet
      */
-    suspend fun handleKeyExchange(packet: BitchatPacket, peerID: String): Boolean {
+    suspend fun handleKeyExchange(routed: RoutedPacket): Boolean {
+        val packet = routed.packet
+        val peerID = routed.peerID ?: "unknown"
+
         if (peerID == myPeerID) return false
         
         if (packet.payload.isEmpty()) {
@@ -113,7 +117,7 @@ class SecurityManager(private val encryptionService: EncryptionService, private 
             Log.d(TAG, "Successfully processed key exchange from $peerID")
             
             // Notify delegate
-            delegate?.onKeyExchangeCompleted(peerID, packet.payload)
+            delegate?.onKeyExchangeCompleted(peerID, packet.payload, routed.relayAddress)
             
             return true
             
@@ -315,5 +319,5 @@ class SecurityManager(private val encryptionService: EncryptionService, private 
  * Delegate interface for security manager callbacks
  */
 interface SecurityManagerDelegate {
-    fun onKeyExchangeCompleted(peerID: String, peerPublicKeyData: ByteArray)
+    fun onKeyExchangeCompleted(peerID: String, peerPublicKeyData: ByteArray, receivedAddress: String?)
 }

--- a/app/src/main/java/com/bitchat/android/model/RoutedPacket.kt
+++ b/app/src/main/java/com/bitchat/android/model/RoutedPacket.kt
@@ -1,0 +1,13 @@
+package com.bitchat.android.model
+
+import com.bitchat.android.protocol.BitchatPacket
+
+/**
+ * Represents a routed packet with additional metadata
+ * Used for processing and routing packets in the mesh network
+ */
+data class RoutedPacket(
+    val packet: BitchatPacket,
+    val peerID: String? = null,           // Who sent it (parsed from packet.senderID)
+    val relayAddress: String? = null      // Address it came from (for avoiding loopback)
+)

--- a/app/src/main/java/com/bitchat/android/onboarding/BluetoothStatusManager.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/BluetoothStatusManager.kt
@@ -91,7 +91,7 @@ class BluetoothStatusManager(
      * This should be called on every app startup
      */
     fun checkBluetoothStatus(): BluetoothStatus {
-        Log.d(TAG, "Checking Bluetooth status")
+        // Log.d(TAG, "Checking Bluetooth status")
         
         return when {
             bluetoothAdapter == null -> {
@@ -103,7 +103,7 @@ class BluetoothStatusManager(
                 BluetoothStatus.DISABLED
             }
             else -> {
-                Log.d(TAG, "Bluetooth is enabled and ready")
+                // Log.d(TAG, "Bluetooth is enabled and ready")
                 BluetoothStatus.ENABLED
             }
         }

--- a/app/src/main/java/com/bitchat/android/onboarding/LocationCheckScreen.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/LocationCheckScreen.kt
@@ -1,0 +1,297 @@
+package com.bitchat.android.onboarding
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * Screen shown when checking location services status or requesting location services enable
+ */
+@Composable
+fun LocationCheckScreen(
+    status: LocationStatus,
+    onEnableLocation: () -> Unit,
+    onRetry: () -> Unit,
+    isLoading: Boolean = false
+) {
+    val colorScheme = MaterialTheme.colorScheme
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        when (status) {
+            LocationStatus.DISABLED -> {
+                LocationDisabledContent(
+                    onEnableLocation = onEnableLocation,
+                    onRetry = onRetry,
+                    colorScheme = colorScheme,
+                    isLoading = isLoading
+                )
+            }
+            LocationStatus.NOT_AVAILABLE -> {
+                LocationNotAvailableContent(
+                    colorScheme = colorScheme
+                )
+            }
+            LocationStatus.ENABLED -> {
+                LocationCheckingContent(
+                    colorScheme = colorScheme
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocationDisabledContent(
+    onEnableLocation: () -> Unit,
+    onRetry: () -> Unit,
+    colorScheme: ColorScheme,
+    isLoading: Boolean
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Location icon - using LocationOn outlined icon in app's green color
+        Icon(
+            imageVector = Icons.Outlined.LocationOn,
+            contentDescription = "Location Services",
+            modifier = Modifier.size(64.dp),
+            tint = Color(0xFF00C851) // App's main green color
+        )
+
+        Text(
+            text = "Location Services Required",
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontFamily = FontFamily.Monospace,
+                fontWeight = FontWeight.Bold,
+                color = colorScheme.primary
+            ),
+            textAlign = TextAlign.Center
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = colorScheme.surfaceVariant.copy(alpha = 0.3f)
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                // Privacy assurance section
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Security,
+                        contentDescription = "Privacy",
+                        tint = Color(0xFF4CAF50),
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Privacy First",
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            color = colorScheme.onSurface
+                        )
+                    )
+                }
+                
+                Text(
+                    text = "bitchat does NOT track your location or use GPS.\n\nLocation services are required by Android for Bluetooth scanning to work properly. This is an Android system requirement.",
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        fontFamily = FontFamily.Monospace,
+                        color = colorScheme.onSurface.copy(alpha = 0.8f)
+                    )
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    text = "bitchat needs location services for:",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.Medium,
+                        color = colorScheme.onSurface
+                    ),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                
+                Text(
+                    text = "• Bluetooth device scanning (Android requirement)\n" +
+                            "• Discovering nearby users on mesh network\n" +
+                            "• Creating connections without internet\n" +
+                            "• No GPS tracking or location collection",
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        fontFamily = FontFamily.Monospace,
+                        color = colorScheme.onSurface.copy(alpha = 0.8f)
+                    )
+                )
+            }
+        }
+
+        if (isLoading) {
+            LocationLoadingIndicator()
+        } else {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Button(
+                    onClick = onEnableLocation,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFF00C851) // App's main green color
+                    )
+                ) {
+                    Text(
+                        text = "Open Location Settings",
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            fontFamily = FontFamily.Monospace,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+
+                OutlinedButton(
+                    onClick = onRetry,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "Check Again",
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            fontFamily = FontFamily.Monospace
+                        ),
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocationNotAvailableContent(
+    colorScheme: ColorScheme
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Error icon
+        Icon(
+            imageVector = Icons.Filled.ErrorOutline,
+            contentDescription = "Error",
+            modifier = Modifier.size(64.dp),
+            tint = colorScheme.error
+        )
+
+        Text(
+            text = "Location Services Unavailable",
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontFamily = FontFamily.Monospace,
+                fontWeight = FontWeight.Bold,
+                color = colorScheme.error
+            ),
+            textAlign = TextAlign.Center
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = colorScheme.errorContainer.copy(alpha = 0.1f)
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Text(
+                text = "Location services are not available on this device. This is unusual as location services are standard on Android devices.\n\nbitchat needs location services for Bluetooth scanning to work properly (Android requirement). Without this, the app cannot discover nearby users.",
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    fontFamily = FontFamily.Monospace,
+                    color = colorScheme.onSurface
+                ),
+                modifier = Modifier.padding(16.dp),
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun LocationCheckingContent(
+    colorScheme: ColorScheme
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "bitchat*",
+            style = MaterialTheme.typography.headlineLarge.copy(
+                fontFamily = FontFamily.Monospace,
+                fontWeight = FontWeight.Bold,
+                color = colorScheme.primary
+            ),
+            textAlign = TextAlign.Center
+        )
+
+        LocationLoadingIndicator()
+
+        Text(
+            text = "Checking location services...",
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontFamily = FontFamily.Monospace,
+                color = colorScheme.onSurface.copy(alpha = 0.7f)
+            )
+        )
+    }
+}
+
+@Composable
+private fun LocationLoadingIndicator() {
+    // Animated rotation for the loading indicator
+    val infiniteTransition = rememberInfiniteTransition(label = "location_loading")
+    val rotationAngle by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "rotation"
+    )
+
+    Box(
+        modifier = Modifier.size(60.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .fillMaxSize()
+                .rotate(rotationAngle),
+            color = Color(0xFF4CAF50), // Location green
+            strokeWidth = 3.dp
+        )
+    }
+}

--- a/app/src/main/java/com/bitchat/android/onboarding/LocationStatusManager.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/LocationStatusManager.kt
@@ -1,0 +1,247 @@
+package com.bitchat.android.onboarding
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.location.LocationManager
+import android.os.Build
+import android.provider.Settings
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+
+/**
+ * Manages Location Services enable/disable state and user prompts
+ * Checks location services status on every app startup
+ * Note: This is for system location services, not location permissions
+ */
+class LocationStatusManager(
+    private val activity: ComponentActivity,
+    private val context: Context,
+    private val onLocationEnabled: () -> Unit,
+    private val onLocationDisabled: (String) -> Unit
+) {
+
+    companion object {
+        private const val TAG = "LocationStatusManager"
+    }
+
+    private var locationSettingsLauncher: ActivityResultLauncher<Intent>? = null
+    private var locationManager: LocationManager? = null
+    private var locationStateReceiver: BroadcastReceiver? = null
+
+    init {
+        setupLocationManager()
+        setupLocationSettingsLauncher()
+        setupLocationStateReceiver()
+    }
+
+    /**
+     * Setup LocationManager reference
+     */
+    private fun setupLocationManager() {
+        try {
+            locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+            Log.d(TAG, "LocationManager initialized: ${locationManager != null}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to initialize LocationManager", e)
+            locationManager = null
+        }
+    }
+
+    /**
+     * Setup launcher for location settings request
+     */
+    private fun setupLocationSettingsLauncher() {
+        locationSettingsLauncher = activity.registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) { result ->
+            val isEnabled = isLocationEnabled()
+            Log.d(TAG, "Location settings request result: $isEnabled (result code: ${result.resultCode})")
+            if (isEnabled) {
+                onLocationEnabled()
+            } else {
+                onLocationDisabled("Location services are required for Bluetooth scanning on Android. Please enable location services to continue.")
+            }
+        }
+    }
+
+    /**
+     * Setup broadcast receiver to listen for location settings changes
+     */
+    private fun setupLocationStateReceiver() {
+        locationStateReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                if (intent.action == LocationManager.MODE_CHANGED_ACTION || 
+                    intent.action == LocationManager.PROVIDERS_CHANGED_ACTION) {
+                    Log.d(TAG, "Location settings changed, checking status")
+                    val isEnabled = isLocationEnabled()
+                    if (isEnabled) {
+                        onLocationEnabled()
+                    } else {
+                        onLocationDisabled("Location services have been disabled.")
+                    }
+                }
+            }
+        }
+        
+        // Register receiver for location changes
+        val filter = IntentFilter().apply {
+            addAction(LocationManager.MODE_CHANGED_ACTION)
+            addAction(LocationManager.PROVIDERS_CHANGED_ACTION)
+        }
+        context.registerReceiver(locationStateReceiver, filter)
+    }
+
+    /**
+     * Check if location services are enabled (system-wide setting)
+     * Uses proper API depending on Android version
+     */
+    fun isLocationEnabled(): Boolean {
+        return try {
+            locationManager?.let { lm ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    // API 28+ (Android 9) - Modern approach
+                    lm.isLocationEnabled
+                } else {
+                    // Older devices - Check individual providers
+                    lm.isProviderEnabled(LocationManager.GPS_PROVIDER) ||
+                    lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+                }
+            } ?: false
+        } catch (e: Exception) {
+            Log.w(TAG, "Error checking location enabled state: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * Check location services status
+     * This should be called on every app startup
+     */
+    fun checkLocationStatus(): LocationStatus {
+        Log.d(TAG, "Checking location services status")
+        
+        return when {
+            locationManager == null -> {
+                Log.e(TAG, "LocationManager not available on this device")
+                LocationStatus.NOT_AVAILABLE
+            }
+            !isLocationEnabled() -> {
+                Log.w(TAG, "Location services are disabled")
+                LocationStatus.DISABLED
+            }
+            else -> {
+                Log.d(TAG, "Location services are enabled and ready")
+                LocationStatus.ENABLED
+            }
+        }
+    }
+
+    /**
+     * Request user to enable location services
+     * Opens system location settings screen
+     */
+    fun requestEnableLocation() {
+        Log.d(TAG, "Requesting user to enable location services")
+        
+        try {
+            val enableLocationIntent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+            locationSettingsLauncher?.launch(enableLocationIntent)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to request location enable", e)
+            onLocationDisabled("Failed to open location settings: ${e.message}")
+        }
+    }
+
+    /**
+     * Handle location status check result
+     */
+    fun handleLocationStatus(status: LocationStatus) {
+        when (status) {
+            LocationStatus.ENABLED -> {
+                Log.d(TAG, "Location services enabled, proceeding")
+                onLocationEnabled()
+            }
+            LocationStatus.DISABLED -> {
+                Log.d(TAG, "Location services disabled, requesting enable")
+                requestEnableLocation()
+            }
+            LocationStatus.NOT_AVAILABLE -> {
+                Log.e(TAG, "Location services not available")
+                onLocationDisabled("Location services are not available on this device.")
+            }
+        }
+    }
+
+    /**
+     * Get user-friendly status message
+     */
+    fun getStatusMessage(status: LocationStatus): String {
+        return when (status) {
+            LocationStatus.ENABLED -> "Location services are enabled and ready"
+            LocationStatus.DISABLED -> "Location services are disabled. Please enable location services for Bluetooth scanning."
+            LocationStatus.NOT_AVAILABLE -> "Location services are not available on this device."
+        }
+    }
+
+    /**
+     * Get detailed diagnostics
+     */
+    fun getDiagnostics(): String {
+        return buildString {
+            appendLine("Location Services Status Diagnostics:")
+            appendLine("LocationManager available: ${locationManager != null}")
+            appendLine("Location services enabled: ${isLocationEnabled()}")
+            appendLine("Current status: ${checkLocationStatus()}")
+            appendLine("Android version: ${Build.VERSION.SDK_INT}")
+            
+            locationManager?.let { lm ->
+                try {
+                    appendLine("GPS provider enabled: ${lm.isProviderEnabled(LocationManager.GPS_PROVIDER)}")
+                    appendLine("Network provider enabled: ${lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER)}")
+                } catch (e: Exception) {
+                    appendLine("Provider details: [Error: ${e.message}]")
+                }
+                
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    appendLine("Using modern isLocationEnabled() API")
+                } else {
+                    appendLine("Using legacy provider check API")
+                }
+            }
+        }
+    }
+
+    /**
+     * Log current location status for debugging
+     */
+    fun logLocationStatus() {
+        Log.d(TAG, getDiagnostics())
+    }
+
+    /**
+     * Cleanup resources - call this when activity is destroyed
+     */
+    fun cleanup() {
+        locationStateReceiver?.let { receiver ->
+            try {
+                context.unregisterReceiver(receiver)
+                Log.d(TAG, "Location state receiver unregistered")
+            } catch (e: Exception) {
+                Log.w(TAG, "Error unregistering location state receiver: ${e.message}")
+            }
+        }
+    }
+}
+
+/**
+ * Location services status enum
+ */
+enum class LocationStatus {
+    ENABLED,
+    DISABLED, 
+    NOT_AVAILABLE
+}

--- a/app/src/main/java/com/bitchat/android/onboarding/NicknamePromptScreen.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/NicknamePromptScreen.kt
@@ -1,0 +1,54 @@
+package com.bitchat.android.onboarding
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun NicknamePromptScreen(
+    onSubmit: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var nickname by remember { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Choose your nickname", style = MaterialTheme.typography.titleLarge)
+        Spacer(Modifier.height(16.dp))
+        TextField(
+            value = nickname,
+            onValueChange = { nickname = it },
+            placeholder = { Text("e.g. BlueFox") }
+        )
+        Spacer(Modifier.height(24.dp))
+        Button(
+            onClick = {
+                if (nickname.trim().isNotEmpty()) {
+                    onSubmit(nickname.trim())
+                }
+            }
+        ) {
+            Text("Continue")
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -81,7 +81,9 @@ class ChatViewModel(
     private fun loadAndInitialize() {
         // Load nickname
         val nickname = dataManager.loadNickname()
-        state.setNickname(nickname)
+        if (!nickname.isNullOrBlank()) {
+            state.setNickname(nickname)
+        }
         
         // Load data
         val (joinedChannels, protectedChannels) = channelManager.loadChannelData()

--- a/app/src/main/java/com/bitchat/android/ui/DataManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/DataManager.kt
@@ -30,16 +30,9 @@ class DataManager(private val context: Context) {
     val channelMembers: Map<String, MutableSet<String>> get() = _channelMembers
     
     // MARK: - Nickname Management
-    
-    fun loadNickname(): String {
-        val savedNickname = prefs.getString("nickname", null)
-        return if (savedNickname != null) {
-            savedNickname
-        } else {
-            val randomNickname = "anon${Random.nextInt(1000, 9999)}"
-            saveNickname(randomNickname)
-            randomNickname
-        }
+
+    fun loadNickname(): String? {
+        return prefs.getString("nickname", null)
     }
     
     fun saveNickname(nickname: String) {

--- a/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
@@ -49,15 +49,13 @@ class MeshDelegateHandler(
                 
                 // Show notification with enhanced information - now includes senderPeerID 
                 message.senderPeerID?.let { senderPeerID ->
-                    if (state.getSelectedPrivateChatPeerValue() != senderPeerID) {
-                        // Use nickname if available, fall back to sender or senderPeerID
-                        val senderNickname = message.sender.takeIf { it != senderPeerID } ?: senderPeerID
-                        notificationManager.showPrivateMessageNotification(
-                            senderPeerID = senderPeerID, 
-                            senderNickname = senderNickname, 
-                            messageContent = message.content
-                        )
-                    }
+                    // Use nickname if available, fall back to sender or senderPeerID
+                    val senderNickname = message.sender.takeIf { it != senderPeerID } ?: senderPeerID
+                    notificationManager.showPrivateMessageNotification(
+                        senderPeerID = senderPeerID, 
+                        senderNickname = senderNickname, 
+                        messageContent = message.content
+                    )
                 }
             } else if (message.channel != null) {
                 // Channel message

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -41,17 +42,19 @@ fun MessagesList(
         }
     }
     
-    LazyColumn(
-        state = listState,
-        modifier = modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(2.dp)
-    ) {
-        items(messages) { message ->
-            MessageItem(
-                message = message,
-                currentUserNickname = currentUserNickname,
-                meshService = meshService
-            )
+    SelectionContainer {
+        LazyColumn(
+            state = listState,
+            modifier = modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            items(messages) { message ->
+                MessageItem(
+                    message = message,
+                    currentUserNickname = currentUserNickname,
+                    meshService = meshService
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/bitchat/android/ui/NotificationManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/NotificationManager.kt
@@ -96,7 +96,7 @@ class NotificationManager(private val context: Context) {
      */
     fun showPrivateMessageNotification(senderPeerID: String, senderNickname: String, messageContent: String) {
         // Only show notifications if app is in background OR user is not viewing this specific chat
-        val shouldNotify = isAppInBackground || currentPrivateChatPeer != senderPeerID
+        val shouldNotify = isAppInBackground || (!isAppInBackground && currentPrivateChatPeer != senderPeerID)
         
         if (!shouldNotify) {
             Log.d(TAG, "Skipping notification - app in foreground and viewing chat with $senderNickname")

--- a/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
@@ -39,6 +39,7 @@ fun SidebarOverlay(
     val currentChannel by viewModel.currentChannel.observeAsState()
     val selectedPrivatePeer by viewModel.selectedPrivateChatPeer.observeAsState()
     val nickname by viewModel.nickname.observeAsState("")
+    val unreadChannelMessages by viewModel.unreadChannelMessages.observeAsState(emptyMap())
     
     // Get peer data from mesh service
     val peerNicknames = viewModel.meshService.getPeerNicknames()
@@ -94,7 +95,8 @@ fun SidebarOverlay(
                                 },
                                 onLeaveChannel = { channel ->
                                     viewModel.leaveChannel(channel)
-                                }
+                                },
+                                unreadChannelMessages = unreadChannelMessages
                             )
                         }
                         
@@ -155,7 +157,8 @@ fun ChannelsSection(
     currentChannel: String?,
     colorScheme: ColorScheme,
     onChannelClick: (String) -> Unit,
-    onLeaveChannel: (String) -> Unit
+    onLeaveChannel: (String) -> Unit,
+    unreadChannelMessages: Map<String, Int> = emptyMap()
 ) {
     Column {
         Row(
@@ -181,6 +184,7 @@ fun ChannelsSection(
         
         channels.forEach { channel ->
             val isSelected = channel == currentChannel
+            val unreadCount = unreadChannelMessages[channel] ?: 0
             
             Row(
                 modifier = Modifier
@@ -193,6 +197,13 @@ fun ChannelsSection(
                     .padding(horizontal = 24.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                // Unread badge for channels
+                UnreadBadge(
+                    count = unreadCount,
+                    colorScheme = colorScheme,
+                    modifier = Modifier.padding(end = 8.dp)
+                )
+                
                 Text(
                     text = channel, // Channel already contains the # prefix
                     style = MaterialTheme.typography.bodyMedium,
@@ -288,7 +299,7 @@ fun PeopleSection(
                 PeerItem(
                     peerID = peerID,
                     displayName = if (peerID == nickname) "You" else (peerNicknames[peerID] ?: peerID),
-                    signalStrength = peerRSSI[peerID] ?: 0,
+                    signalStrength = convertRSSIToSignalStrength(peerRSSI[peerID]),
                     isSelected = peerID == selectedPrivatePeer,
                     isFavorite = isFavorite,
                     hasUnreadDM = hasUnreadPrivateMessages.contains(peerID),
@@ -297,7 +308,11 @@ fun PeopleSection(
                     onToggleFavorite = { 
                         Log.d("SidebarComponents", "Sidebar toggle favorite: peerID=$peerID, currentFavorite=$isFavorite")
                         viewModel.toggleFavorite(peerID) 
-                    }
+                    },
+                    unreadCount = privateChats[peerID]?.count { msg -> 
+                        // Count unread messages from this peer (messages not from the current user)
+                        msg.sender != nickname && hasUnreadPrivateMessages.contains(peerID)
+                    } ?: if (hasUnreadPrivateMessages.contains(peerID)) 1 else 0
                 )
             }
         }
@@ -314,7 +329,8 @@ private fun PeerItem(
     hasUnreadDM: Boolean,
     colorScheme: ColorScheme,
     onItemClick: () -> Unit,
-    onToggleFavorite: () -> Unit
+    onToggleFavorite: () -> Unit,
+    unreadCount: Int = 0
 ) {
     Row(
         modifier = Modifier
@@ -327,13 +343,11 @@ private fun PeerItem(
             .padding(horizontal = 24.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Show filled mail icon instead of signal strength when user has unread DMs
+        // Show unread badge or signal strength
         if (hasUnreadDM) {
-            Icon(
-                imageVector = Icons.Filled.Email,
-                contentDescription = "Unread messages",
-                modifier = Modifier.size(16.dp),
-                tint = Color(0xFFFF9500) // Orange to match private message theme
+            UnreadBadge(
+                count = unreadCount,
+                colorScheme = colorScheme
             )
         } else {
             // Signal strength indicators
@@ -389,5 +403,59 @@ private fun SignalStrengthIndicator(
             )
             if (index < 2) Spacer(modifier = Modifier.width(2.dp))
         }
+    }
+}
+
+/**
+ * Reusable unread badge component for both channels and private messages
+ */
+@Composable
+private fun UnreadBadge(
+    count: Int,
+    colorScheme: ColorScheme,
+    modifier: Modifier = Modifier
+) {
+    if (count > 0) {
+        Box(
+            modifier = modifier
+                .background(
+                    color = Color(0xFFFFD700), // Yellow color
+                    shape = RoundedCornerShape(10.dp)
+                )
+                .padding(horizontal = 2.dp, vertical = 0.dp)
+                .defaultMinSize(minWidth = 14.dp, minHeight = 14.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = if (count > 99) "99+" else count.toString(),
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = Color.Black // Black text on yellow background
+            )
+        }
+    }
+}
+
+/**
+ * Convert RSSI value (dBm) to signal strength percentage (0-100)
+ * RSSI typically ranges from -30 (excellent) to -100 (very poor)
+ * Maps to 0-100 scale where:
+ * - 0-32: No signal (0 bars)
+ * - 33-65: Weak (1 bar) 
+ * - 66-98: Good (2 bars)
+ * - 99-100: Excellent (3 bars)
+ */
+private fun convertRSSIToSignalStrength(rssi: Int?): Int {
+    if (rssi == null) return 0
+    
+    return when {
+        rssi >= -40 -> 100  // Excellent signal
+        rssi >= -55 -> 85   // Very good signal  
+        rssi >= -70 -> 70   // Good signal
+        rssi >= -85 -> 50   // Fair signal
+        rssi >= -100 -> 25  // Poor signal
+        else -> 0           // Very poor or no signal
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.compose) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,36 +1,35 @@
 [versions]
 # Android and Kotlin
-agp = "8.2.0"
-kotlin = "1.9.20"
-compileSdk = "34"
+agp = "8.10.1"
+kotlin = "2.2.0"
+compileSdk = "35"
 minSdk = "26" # API 26 for proper BLE support
 targetSdk = "34"
 
 # AndroidX Core
-core-ktx = "1.12.0"
-lifecycle-runtime = "2.7.0"
-activity-compose = "1.8.2"
-appcompat = "1.6.1"
+core-ktx = "1.16.0"
+lifecycle-runtime = "2.9.1"
+activity-compose = "1.10.1"
+appcompat = "1.7.1"
 
 # Compose
-compose-bom = "2023.10.01"
-compose-compiler = "1.5.5"
+compose-bom = "2025.06.01"
 
 # Navigation
-navigation-compose = "2.7.6"
+navigation-compose = "2.9.1"
 
 # Accompanist
-accompanist-permissions = "0.32.0"
+accompanist-permissions = "0.37.3"
 
 # Cryptography
 bouncycastle = "1.70"
 tink-android = "1.10.0"
 
 # JSON
-gson = "2.10.1"
+gson = "2.13.1"
 
 # Coroutines
-kotlinx-coroutines = "1.7.3"
+kotlinx-coroutines = "1.10.2"
 
 # Bluetooth
 nordic-ble = "2.6.1"
@@ -39,12 +38,12 @@ nordic-ble = "2.6.1"
 lz4-java = "1.8.0"
 
 # Security
-security-crypto = "1.1.0-alpha06"
+security-crypto = "1.1.0-beta01"
 
 # Testing
 junit = "4.13.2"
-androidx-test-ext = "1.1.5"
-espresso = "3.5.1"
+androidx-test-ext = "1.2.1"
+espresso = "3.6.1"
 
 [libraries]
 # AndroidX Core
@@ -104,6 +103,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "kotlin-parcelize" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
 [bundles]
 compose = [


### PR DESCRIPTION
This commit introduces a nickname prompt screen after the onboarding process is complete.

- A new `NICKNAME_PROMPT` state is added to the `OnboardingState` enum.
- After successful app initialization, the onboarding state transitions to `NICKNAME_PROMPT` instead of `COMPLETE`.
- The `NicknamePromptScreen` is displayed, allowing the user to set a nickname.
- The submitted nickname is stored in the `ChatViewModel`.
- After submitting the nickname, the onboarding state transitions to `COMPLETE`, and the `ChatScreen` is displayed.

# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/callebtc/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x] If it is a core feature, I have added automated tests
