### PR TITLE
Fixes #69 Send messages based on channel state

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -71,7 +71,7 @@ class CommandProcessor(
                 timestamp = Date(),
                 isRelay = false
             )
-            messageManager.addMessage(systemMessage)
+            messageManager.addMessage(systemMessage, state.currentChannel.value)
         }
     }
     
@@ -123,7 +123,7 @@ class CommandProcessor(
                 timestamp = Date(),
                 isRelay = false
             )
-            messageManager.addMessage(systemMessage)
+            messageManager.addMessage(systemMessage, state.currentChannel.value)
         }
     }
     
@@ -144,7 +144,7 @@ class CommandProcessor(
             timestamp = Date(),
             isRelay = false
         )
-        messageManager.addMessage(systemMessage)
+        messageManager.addMessage(systemMessage, state.currentChannel.value)
     }
     
     private fun handleClearCommand() {
@@ -179,7 +179,7 @@ class CommandProcessor(
                 timestamp = Date(),
                 isRelay = false
             )
-            messageManager.addMessage(systemMessage)
+            messageManager.addMessage(systemMessage, state.currentChannel.value)
         }
     }
     
@@ -194,7 +194,7 @@ class CommandProcessor(
                 timestamp = Date(),
                 isRelay = false
             )
-            messageManager.addMessage(systemMessage)
+            messageManager.addMessage(systemMessage, state.currentChannel.value)
         }
     }
     
@@ -247,7 +247,7 @@ class CommandProcessor(
                 timestamp = Date(),
                 isRelay = false
             )
-            messageManager.addMessage(systemMessage)
+            messageManager.addMessage(systemMessage, state.currentChannel.value)
         }
     }
     
@@ -265,7 +265,7 @@ class CommandProcessor(
             timestamp = Date(),
             isRelay = false
         )
-        messageManager.addMessage(systemMessage)
+        messageManager.addMessage(systemMessage, state.currentChannel.value)
     }
     
     private fun handleUnknownCommand(cmd: String) {
@@ -275,7 +275,7 @@ class CommandProcessor(
             timestamp = Date(),
             isRelay = false
         )
-        messageManager.addMessage(systemMessage)
+        messageManager.addMessage(systemMessage, state.currentChannel.value)
     }
     
     // MARK: - Command Autocomplete

--- a/app/src/main/java/com/bitchat/android/ui/MessageManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageManager.kt
@@ -18,11 +18,15 @@ class MessageManager(private val state: ChatState) {
     
     // MARK: - Public Message Management
     
-    fun addMessage(message: BitchatMessage) {
-        val currentMessages = state.getMessagesValue().toMutableList()
-        currentMessages.add(message)
-        currentMessages.sortBy { it.timestamp }
-        state.setMessages(currentMessages)
+    fun addMessage(message: BitchatMessage, channel: String? = null) {
+        if (channel == null) {
+            val currentMessages = state.getMessagesValue().toMutableList()
+            currentMessages.add(message)
+            currentMessages.sortBy { it.timestamp }
+            state.setMessages(currentMessages)
+        }else {
+            addChannelMessage(channel, message)
+        }
     }
     
     fun clearMessages() {


### PR DESCRIPTION
This commit fixes and shows channel commands in the channel instead of outside of it.

# Description
Send messages based on channel state to see commands in the desired channel and not in the main chat screen

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/callebtc/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
