### PR TITLE
Feat: Implement message selection mode

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatState.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatState.kt
@@ -26,7 +26,10 @@ class ChatState {
     // Core messages and peer state
     private val _messages = MutableLiveData<List<BitchatMessage>>(emptyList())
     val messages: LiveData<List<BitchatMessage>> = _messages
-    
+
+    private val _selectedMessages = MutableLiveData<Set<BitchatMessage>>( emptySet())
+    val selectedMessages : LiveData<Set<BitchatMessage>> = _selectedMessages
+
     private val _connectedPeers = MutableLiveData<List<String>>(emptyList())
     val connectedPeers: LiveData<List<String>> = _connectedPeers
     
@@ -92,6 +95,9 @@ class ChatState {
     // Unread state computed properties
     val hasUnreadChannels: MediatorLiveData<Boolean> = MediatorLiveData<Boolean>()
     val hasUnreadPrivateMessages: MediatorLiveData<Boolean> = MediatorLiveData<Boolean>()
+
+    private val _isSelectionMode  = MutableLiveData(false)
+    val selectionMode: LiveData<Boolean> = _isSelectionMode
     
     init {
         // Initialize unread state mediators
@@ -127,6 +133,14 @@ class ChatState {
     // Setters for state updates
     fun setMessages(messages: List<BitchatMessage>) {
         _messages.value = messages
+    }
+
+    fun setSelectedMessages(selectedMessages: Set<BitchatMessage>) {
+        _selectedMessages.value = selectedMessages
+    }
+
+    fun setSelectionMode(enabled: Boolean) {
+        _isSelectionMode.value = enabled
     }
     
     fun setConnectedPeers(peers: List<String>) {


### PR DESCRIPTION
This commit introduces a message selection mode in the chat interface.

Key changes:

-   **State Management:** Added `selectedMessages` and `selectionMode` LiveData to `ChatState` to track selected messages and the current mode.
-   **UI:**
    -   `MessageItem` now supports selection visuals (background highlight, selection icon) and handles long-press/tap gestures to toggle selection.
    -   A new `SelectionModeHeader` is displayed when `isSelectionMode` is true, replacing the standard `ChatFloatingHeader`. This header shows the selected count and provides actions like "Clear Selection", "Select All", "Copy", and "Share".
    -   The divider below the header is now conditional, only showing when not in selection mode.
-   **ViewModel Logic:**
    -   `onMessageTap` and `onMessageLongClick` methods in `ChatViewModel` handle entering selection mode and updating selected messages or starting private chats when pressing other user.
    -   New methods for selection actions:
        -   `clearSelection()`: Clears selected messages and optionally exits selection mode.
        -   `selectAllMessages()`: Selects all messages in the current view (channel or private chat). Toggles to clear selection if all are already selected.
        -   `copySelectedMessages()`: Copies selected messages to the clipboard in a formatted way.
        -   `shareSelectedMessages()`: Shares selected messages using the system share intent.
-   **Integration:**
    -   `ChatScreen` observes `selectedMessages` and `isSelectionMode` to update the UI accordingly.
    -   `MessageList` passes selection-related callbacks and state to `MessageItem`.

# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [ ] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
