### PR TITLE
Bugfix: Handled single or triple clicked at once instead of executing them as separate events

### DIFF
--- a/app/src/main/java/com/bitchat/android/core/ui/utils/ModifierExt.kt
+++ b/app/src/main/java/com/bitchat/android/core/ui/utils/ModifierExt.kt
@@ -1,0 +1,57 @@
+package com.bitchat.android.core.ui.utils
+
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+fun Modifier.singleOrTripleClickable(
+    onSingleClick: () -> Unit,
+    onTripleClick: () -> Unit,
+    clickTimeThreshold: Long = 300L
+): Modifier = composed {
+    var tapCount by remember { mutableIntStateOf(0) }
+    var lastTapTime by remember { mutableLongStateOf(0L) }
+    var singleClickJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+
+    this.clickable {
+        val currentTime = System.currentTimeMillis()
+
+        if (currentTime - lastTapTime < clickTimeThreshold) {
+            tapCount++
+        } else {
+            tapCount = 1
+        }
+
+        lastTapTime = currentTime
+
+        // Cancel any pending single click action
+        singleClickJob?.cancel()
+        singleClickJob = null
+
+        when (tapCount) {
+            1 -> {
+                // Wait to see if more taps come
+                singleClickJob = coroutineScope.launch {
+                    delay(clickTimeThreshold)
+                    if (tapCount == 1) {
+                        onSingleClick()
+                    }
+                }
+            }
+            3 -> {
+                // Triple click detected - execute immediately
+                onTripleClick()
+                tapCount = 0
+            }
+        }
+
+        // Reset after threshold if no triple click
+        if (tapCount > 3) {
+            tapCount = 0
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.bitchat.android.core.ui.utils.singleOrTripleClickable
 
 /**
  * Header components for ChatScreen
@@ -181,15 +182,8 @@ fun ChatHeaderContent(
             MainHeader(
                 nickname = nickname,
                 onNicknameChange = viewModel::setNickname,
-                onTitleClick = {
-                    tripleClickCount++
-                    if (tripleClickCount >= 3) {
-                        tripleClickCount = 0
-                        onTripleClick()
-                    } else {
-                        onShowAppInfo()
-                    }
-                },
+                onTitleClick = onShowAppInfo,
+                onTripleTitleClick = onTripleClick,
                 onSidebarClick = onSidebarClick,
                 viewModel = viewModel
             )
@@ -345,6 +339,7 @@ private fun MainHeader(
     nickname: String,
     onNicknameChange: (String) -> Unit,
     onTitleClick: () -> Unit,
+    onTripleTitleClick: () -> Unit,
     onSidebarClick: () -> Unit,
     viewModel: ChatViewModel
 ) {
@@ -365,7 +360,10 @@ private fun MainHeader(
                 text = "bitchat*",
                 style = MaterialTheme.typography.headlineSmall,
                 color = colorScheme.primary,
-                modifier = Modifier.clickable { onTitleClick() }
+                modifier = Modifier.singleOrTripleClickable(
+                    onSingleClick = onTitleClick,
+                    onTripleClick = onTripleTitleClick
+                )
             )
             
             Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
@@ -149,8 +149,7 @@ fun ChatHeaderContent(
     onShowAppInfo: () -> Unit
 ) {
     val colorScheme = MaterialTheme.colorScheme
-    var tripleClickCount by remember { mutableStateOf(0) }
-    
+
     when {
         selectedPrivatePeer != null -> {
             // Private chat header - ensure state synchronization


### PR DESCRIPTION
Closes #105 
This commit introduces a new `singleOrTripleClickable` Modifier extension function.

This function allows distinguishing between single and triple clicks on a Composable element.

The `ChatHeader` was updated to utilize this new Modifier for handling clicks on the "bitchat*" title, where a single click shows app info and a triple click triggers a separate action.

# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x] If it is a core feature, I have added automated tests
