### PR TITLE
refactor: remove context attribute at ChatViewModel.kt

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -24,14 +24,12 @@ class ChatViewModel(
     application: Application,
     val meshService: BluetoothMeshService
 ) : AndroidViewModel(application), BluetoothMeshDelegate {
-    
-    private val context: Context = application.applicationContext
-    
+
     // State management
     private val state = ChatState()
     
     // Specialized managers
-    private val dataManager = DataManager(context)
+    private val dataManager = DataManager(application.applicationContext)
     private val messageManager = MessageManager(state)
     private val channelManager = ChannelManager(state, messageManager, dataManager, viewModelScope)
     val privateChatManager = PrivateChatManager(state, messageManager, dataManager)
@@ -46,7 +44,7 @@ class ChatViewModel(
         privateChatManager = privateChatManager,
         notificationManager = notificationManager,
         coroutineScope = viewModelScope,
-        onHapticFeedback = { ChatViewModelUtils.triggerHapticFeedback(context) },
+        onHapticFeedback = { ChatViewModelUtils.triggerHapticFeedback(application.applicationContext) },
         getMyPeerID = { meshService.myPeerID }
     )
     


### PR DESCRIPTION
# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [+] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [+] I have performed a self-review of my code
<!-- - [+] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [+] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [+] If it is a core feature, I have added automated tests

Store context as a static field inside of classes can cause memory leaks. 
`
  private val context: Context = application.applicationContext
`

