### PR TITLE
Fix content padding in messages list

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -46,7 +46,6 @@ import java.util.*
  * - DialogComponents: Password prompts and modals
  * - ChatUIUtils: Utility functions for formatting and colors
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatScreen(viewModel: ChatViewModel) {
     val colorScheme = MaterialTheme.colorScheme
@@ -190,7 +189,6 @@ fun ChatScreen(viewModel: ChatViewModel) {
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ChatInputSection(
     messageText: String,

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -100,14 +100,12 @@ fun ChatScreen(viewModel: ChatViewModel) {
             Spacer(modifier = Modifier.height(headerHeight))
             
             // Messages area - takes up available space, will compress when keyboard appears
-            Box(modifier = Modifier.weight(1f)) {
-                MessagesList(
-                    messages = displayMessages,
-                    currentUserNickname = nickname,
-                    meshService = viewModel.meshService,
-                    modifier = Modifier.fillMaxSize()
-                )
-            }
+            MessagesList(
+                messages = displayMessages,
+                currentUserNickname = nickname,
+                meshService = viewModel.meshService,
+                modifier = Modifier.weight(1f)
+            )
             
             // Input area - stays at bottom
             ChatInputSection(

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -210,7 +210,7 @@ private fun ChatInputSection(
         shadowElevation = 8.dp
     ) {
         Column {
-            Divider(color = colorScheme.outline.copy(alpha = 0.3f))
+            HorizontalDivider(color = colorScheme.outline.copy(alpha = 0.3f))
             
             // Command suggestions box
             if (showCommandSuggestions && commandSuggestions.isNotEmpty()) {
@@ -219,8 +219,8 @@ private fun ChatInputSection(
                     onSuggestionClick = onSuggestionClick,
                     modifier = Modifier.fillMaxWidth()
                 )
-                
-                Divider(color = colorScheme.outline.copy(alpha = 0.2f))
+
+                HorizontalDivider(color = colorScheme.outline.copy(alpha = 0.2f))
             }
             
             MessageInput(
@@ -283,12 +283,12 @@ private fun ChatFloatingHeader(
     }
     
     // Divider under header
-    Divider(
-        color = colorScheme.outline.copy(alpha = 0.3f),
+    HorizontalDivider(
         modifier = Modifier
             .fillMaxWidth()
             .offset(y = headerHeight)
-            .zIndex(1f)
+            .zIndex(1f),
+        color = colorScheme.outline.copy(alpha = 0.3f)
     )
 }
 

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -86,7 +86,7 @@ fun ChatScreen(viewModel: ChatViewModel) {
     }
     
     // Use WindowInsets to handle keyboard properly
-    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize()) {
         val headerHeight = 36.dp
         
         // Main content area that responds to keyboard/window insets

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -42,10 +42,10 @@ fun MessagesList(
         }
     }
     
-    SelectionContainer {
+    SelectionContainer(modifier = modifier) {
         LazyColumn(
             state = listState,
-            modifier = modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             items(messages) { message ->

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -45,7 +45,7 @@ fun MessagesList(
     SelectionContainer(modifier = modifier) {
         LazyColumn(
             state = listState,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             items(messages) { message ->

--- a/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
@@ -73,8 +73,8 @@ fun SidebarOverlay(
                     .windowInsetsPadding(WindowInsets.statusBars) // Add status bar padding
             ) {
                 SidebarHeader()
-                
-                Divider()
+
+                HorizontalDivider()
                 
                 // Scrollable content
                 LazyColumn(
@@ -101,7 +101,7 @@ fun SidebarOverlay(
                         }
                         
                         item {
-                            Divider(modifier = Modifier.padding(vertical = 4.dp))
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                         }
                     }
                     


### PR DESCRIPTION
# Description

| Before | After |
|--------|--------|
| <img width="1080" height="2400" alt="before" src="https://github.com/user-attachments/assets/69da068f-fbd3-4f80-aaa8-fdf5c4734a78" /> | <img width="1080" height="2400" alt="after" src="https://github.com/user-attachments/assets/3840285b-81aa-4019-94b0-0087704867d6" /> | 

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
