### PR TITLE
Enhancement: Added Support for multi-line text in Chat Input

### DIFF
--- a/app/src/main/java/com/bitchat/android/core/ui/utils/TextFieldValueExt.kt
+++ b/app/src/main/java/com/bitchat/android/core/ui/utils/TextFieldValueExt.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 fun TextFieldValue.lineBreak(
     onValueChange: (TextFieldValue) -> Unit
 ) {
-    val selection = this.selection
     val newTextValue = TextFieldValue(
         text = this.text.substring(
             0,

--- a/app/src/main/java/com/bitchat/android/core/ui/utils/TextFieldValueExt.kt
+++ b/app/src/main/java/com/bitchat/android/core/ui/utils/TextFieldValueExt.kt
@@ -1,0 +1,32 @@
+package com.bitchat.android.core.ui.utils
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+
+/**
+ * Inserts a line break (`\n`) into the [TextFieldValue] at the current cursor position or replaces the selected text with a line break.
+ *
+ * This function modifies the text by:
+ * 1. Taking the substring before the current selection start.
+ * 2. Appending a newline character (`\n`).
+ * 3. Appending the substring after the current selection end.
+ *
+ * The cursor is then moved to the position immediately after the inserted newline character.
+ *
+ * @param onValueChange A lambda function that will be invoked with the new [TextFieldValue]
+ *                      after the line break has been inserted. This is typically used to update
+ *                      the state of a `TextField`.
+ */
+fun TextFieldValue.lineBreak(
+    onValueChange: (TextFieldValue) -> Unit
+) {
+    val selection = this.selection
+    val newTextValue = TextFieldValue(
+        text = this.text.substring(
+            0,
+            selection.start
+        ) + '\n' + this.text.substring(selection.end),
+        selection = TextRange(selection.start + 1)
+    )
+    onValueChange(newTextValue)
+}

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -1,42 +1,47 @@
 package com.bitchat.android.ui
 
-import androidx.compose.animation.*
-import androidx.compose.animation.core.*
-import androidx.compose.foundation.*
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.EaseInCubic
+import androidx.compose.animation.core.EaseOutCubic
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import com.bitchat.android.model.BitchatMessage
-import com.bitchat.android.model.DeliveryStatus
-import com.bitchat.android.mesh.BluetoothMeshService
-import java.text.SimpleDateFormat
-import java.util.*
 
 /**
  * Main ChatScreen - REFACTORED to use component-based architecture
@@ -235,6 +240,7 @@ private fun ChatInputSection(
                 currentChannel = currentChannel,
                 nickname = nickname,
                 modifier = Modifier.fillMaxWidth()
+                    .heightIn(max = 80.dp)
             )
         }
     }

--- a/app/src/main/java/com/bitchat/android/ui/InputComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/InputComponents.kt
@@ -1,6 +1,5 @@
 package com.bitchat.android.ui
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -39,7 +38,6 @@ import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -52,6 +50,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.bitchat.android.core.ui.utils.lineBreak
 
 /**
  * Input components for ChatScreen
@@ -154,7 +153,6 @@ fun MessageInput(
                 .weight(1f)
                 .onFocusChanged { focusState -> isFocused.value = focusState.isFocused }
                 .onPreInterceptKeyBeforeSoftKeyboard { keyEvent ->
-                    Log.d("MessageInput", "onKey event: ${keyEvent.key}")
                     if (keyEvent.isShiftPressed) {
                         if (keyEvent.key == Key.Enter && keyEvent.type == KeyEventType.KeyDown) {
                             value.lineBreak(onValueChange)
@@ -293,19 +291,4 @@ fun CommandSuggestionItem(
             overflow = TextOverflow.Ellipsis
         )
     }
-}
-
-
-fun TextFieldValue.lineBreak(
-    onValueChange: (TextFieldValue) -> Unit
-) {
-    val selection = this.selection
-    val newTextValue = TextFieldValue(
-        text = this.text.substring(
-            0,
-            selection.start
-        ) + '\n' + this.text.substring(selection.end),
-        selection = TextRange(selection.start + 1)
-    )
-    onValueChange(newTextValue)
 }

--- a/app/src/main/java/com/bitchat/android/ui/InputComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/InputComponents.kt
@@ -125,7 +125,7 @@ fun MessageInput(
                 fontFamily = FontFamily.Monospace
             ),
             cursorBrush = SolidColor(colorScheme.primary),
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Default),
             keyboardActions = KeyboardActions(onSend = { onSend() }),
             visualTransformation = SlashCommandVisualTransformation(),
             modifier = Modifier


### PR DESCRIPTION
Closes #157 
Added Support for multi line text
The IME action for the text input field has been changed from `ImeAction.Send` to `ImeAction.Default`. This ensures the keyboard displays the appropriate action based on the context, rather than always showing a "Send" button. -In this context, default will be to go to a new line instead of send, (there is no other way to go to a new line)

# Description

- Added line break utility function for TextFieldValue
- Added support for multi line text
- Added special case support for external keyboard (Enter: Send message / Shift + Enter: Go to new line)


## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [ ] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
