### PR TITLE
Auto-generate versionCode from versionName

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,18 +55,17 @@ android {
 }
 
 
-private fun getVersionName(): String = app.versions.major.get() +
-    ".${app.versions.minor.get()}" +
-    ".${app.versions.patch.get()}"
+private fun getVersionName(): String = listOf(
+    app.versions.major,
+    app.versions.minor,
+    app.versions.patch
+).joinToString(".") { it.get() }
 
 private fun getVersionCode(): Int = listOf(
-        app.versions.major.get().padStart(3, '0'),
-        app.versions.minor.get().padStart(3, '0'),
-        app.versions.patch.get().padStart(3, '0')
-    )
-    .joinToString("")
-    .toInt()
-
+    app.versions.major,
+    app.versions.minor,
+    app.versions.patch
+).joinToString("") { it.get().padStart(3, '0') }.toInt()
 
 dependencies {
     // Core Android dependencies

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,11 +10,10 @@ android {
     compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
-        applicationId = "com.bitchat.android"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 5
-        versionName = "0.7.2"
+        versionName = getVersionName()
+        versionCode = getVersionCode()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -40,6 +39,7 @@ android {
         jvmTarget = "1.8"
     }
     buildFeatures {
+        buildConfig = true
         compose = true
     }
     packaging {
@@ -53,6 +53,20 @@ android {
         checkReleaseBuilds = false
     }
 }
+
+
+private fun getVersionName(): String = app.versions.major.get() +
+    ".${app.versions.minor.get()}" +
+    ".${app.versions.patch.get()}"
+
+private fun getVersionCode(): Int = listOf(
+        app.versions.major.get().padStart(3, '0'),
+        app.versions.minor.get().padStart(3, '0'),
+        app.versions.patch.get().padStart(3, '0')
+    )
+    .joinToString("")
+    .toInt()
+
 
 dependencies {
     // Core Android dependencies

--- a/gradle/app.version.toml
+++ b/gradle/app.version.toml
@@ -1,0 +1,4 @@
+[versions]
+major = "0"
+minor = "7"
+patch = "2"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
     }
+    versionCatalogs {
+        create("app") { from(files("gradle/app.version.toml")) }
+    }
 }
 
 rootProject.name = "bitchat-android"


### PR DESCRIPTION
# Description

Improves app version management by using a single .toml source for `versionName` and auto-calculating `versionCode` from it.

| versionName  | versionCode  |
|---|---|
| 0.7.2 | 7002  |
| 0.7.3 | 7003  |
| 1.0.80 | 1000080 |
| 1.8.2 | 1008002 |
| 1.12.0 | 1012000 |

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
