### PR TITLE
feat(bluetooth): implement Bluetooth state monitoring

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,5 +50,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver android:name=".BluetoothStateReceiver"
+            android:exported="true"
+            tools:ignore="Instantiatable">
+            <intent-filter>
+                <action android:name="android.bluetooth.adapter.action.STATE_CHANGED" />
+            </intent-filter>
+        </receiver>
+
     </application>
 </manifest>

--- a/app/src/main/java/com/bitchat/android/BluetoothStateReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/BluetoothStateReceiver.kt
@@ -1,0 +1,29 @@
+package com.bitchat.android
+
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.bitchat.android.onboarding.BluetoothStatus
+
+class BluetoothStateReceiver(private val onConnectionChange: (BluetoothStatus) -> Unit) : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent != null && context != null) {
+            val action = intent.action
+            if (BluetoothAdapter.ACTION_STATE_CHANGED == action) {
+                val state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR)
+                when (state) {
+                    BluetoothAdapter.STATE_ON -> {
+                        onConnectionChange.invoke(BluetoothStatus.ENABLED)
+                    }
+                    BluetoothAdapter.STATE_OFF -> {
+                        onConnectionChange.invoke(BluetoothStatus.DISABLED)
+                    }
+                    else -> {
+                        onConnectionChange.invoke(BluetoothStatus.NOT_SUPPORTED)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -681,5 +681,6 @@ class MainActivity : ComponentActivity() {
                 Log.w("MainActivity", "Error stopping mesh services in onDestroy: ${e.message}")
             }
         }
+        bluetoothStatusManager.unregisterBluetoothStateReceiver()
     }
 }


### PR DESCRIPTION
Closes #173

This commit introduces a `BluetoothStateReceiver` to monitor changes in Bluetooth state (enabled/disabled).

Key changes:
- Added `BluetoothStateReceiver.kt` to handle Bluetooth state change broadcasts.
- Integrated `BluetoothStateReceiver` into `BluetoothStatusManager.kt` to update UI and logic based on Bluetooth status.
- Registered the receiver in `BluetoothStatusManager` and added methods for registration and unregistration.
- Unregistered the receiver in `MainActivity.onDestroy` to prevent memory leaks.
- Declared the `BluetoothStateReceiver` in `AndroidManifest.xml`.

# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests

Fix:

https://github.com/user-attachments/assets/95395da1-888c-4fd3-b248-d927b5370118

