### PR TITLE
Update README.md - Mention Bitchat-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,8 +283,10 @@ This Android port enables seamless communication with the original iOS bitchat a
 
 **iOS Version**: For iPhone/iPad users, get the original bitchat at [github.com/jackjackbits/bitchat](https://github.com/jackjackbits/bitchat)
 
-- **Terminal Windows/Linux/MacOS ↔ iOS/Android**: Use bitchat‑tui in your shell with full interopoperability
-- **bitchat‑tui**: Terminal client available at [github.com/vaibhav‑mattoo/bitchat‑tui](https://github.com/vaibhav-mattoo/bitchat-tui)
+Regarding other implementations, there is also **bitchat‑tui** for Windows, Linux, and macOS. It works seamlessly with both bitchat and bitchat‑android:
+
+- **Terminal (Windows/Linux/macOS) ↔ iOS/Android**: Use bitchat‑tui in your shell with full interoperability  
+- **bitchat‑tui**: Terminal client available at [github.com/vaibhav-mattoo/bitchat-tui](https://github.com/vaibhav-mattoo/bitchat-tui)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -282,8 +282,9 @@ This Android port enables seamless communication with the original iOS bitchat a
 - **Protocol Sync**: Identical message format and routing behavior
 
 **iOS Version**: For iPhone/iPad users, get the original bitchat at [github.com/jackjackbits/bitchat](https://github.com/jackjackbits/bitchat)
-**bitchat‑tui**: Terminal client available at [github.com/vaibhav‑mattoo/bitchat‑tui](https://github.com/vaibhav-mattoo/bitchat-tui)
+
 - **Terminal Windows/Linux/MacOS ↔ iOS/Android**: Use bitchat‑tui in your shell with full interopoperability
+- **bitchat‑tui**: Terminal client available at [github.com/vaibhav‑mattoo/bitchat‑tui](https://github.com/vaibhav-mattoo/bitchat-tui)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ This Android port enables seamless communication with the original iOS bitchat a
 - **Protocol Sync**: Identical message format and routing behavior
 
 **iOS Version**: For iPhone/iPad users, get the original bitchat at [github.com/jackjackbits/bitchat](https://github.com/jackjackbits/bitchat)
+**bitchat‑tui**: Terminal client available at [github.com/vaibhav‑mattoo/bitchat‑tui](https://github.com/vaibhav-mattoo/bitchat-tui)
+- **Terminal Windows/Linux/MacOS ↔ iOS/Android**: Use bitchat‑tui in your shell with full interopoperability
 
 ## Contributing
 


### PR DESCRIPTION
Mention of Bitchat-tui in readme as it is another implementation of bitchat while being terminal based tool built in Rust for Windows/Linux/MacOS environements

# Description
I believe this enhances readme.md but lets see what maintaner thinks. For me, this bitchat-tui was a great find as I prefer to do stuff on computer instead of phone. 
## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x] If it is a core feature, I have added automated tests
