### PR TITLE
feat: Add Password-Protected Channel Auto-Discovery UX

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -214,6 +214,10 @@ class BluetoothMeshService(private val context: Context) {
             override fun onReadReceiptReceived(receipt: ReadReceipt) {
                 delegate?.didReceiveReadReceipt(receipt)
             }
+            
+            override fun markChannelAsPasswordProtected(channel: String) {
+                delegate?.markChannelAsPasswordProtected(channel)
+            }
         }
         
         // PacketProcessor delegates
@@ -597,5 +601,6 @@ interface BluetoothMeshDelegate {
     fun decryptChannelMessage(encryptedContent: ByteArray, channel: String): String?
     fun getNickname(): String?
     fun isFavorite(peerID: String): Boolean
+    fun markChannelAsPasswordProtected(channel: String)
     fun registerPeerPublicKey(peerID: String, publicKeyData: ByteArray)
 }

--- a/app/src/main/java/com/bitchat/android/mesh/MessageHandler.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/MessageHandler.kt
@@ -108,6 +108,11 @@ class MessageHandler(private val myPeerID: String) {
                     timestamp = Date() // Use current time instead of original timestamp
                 )
                 
+                // Auto-detect password-protected channels
+                if (message.channel != null && message.isEncrypted && message.encryptedContent != null) {
+                    delegate?.markChannelAsPasswordProtected(message.channel)
+                }
+                
                 delegate?.onMessageReceived(messageWithCurrentTime)
             }
             
@@ -354,6 +359,7 @@ interface MessageHandlerDelegate {
     
     // Callbacks
     fun onMessageReceived(message: BitchatMessage)
+    fun markChannelAsPasswordProtected(channel: String)
     fun onChannelLeave(channel: String, fromPeer: String)
     fun onPeerDisconnected(nickname: String)
     fun onDeliveryAckReceived(ack: DeliveryAck)

--- a/app/src/main/java/com/bitchat/android/ui/ChannelManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChannelManager.kt
@@ -301,6 +301,27 @@ class ChannelManager(
         )
     }
     
+    fun markChannelAsPasswordProtected(channel: String) {
+        // Mark as password protected if not already
+        if (!state.getPasswordProtectedChannelsValue().contains(channel)) {
+            state.setPasswordProtectedChannels(
+                state.getPasswordProtectedChannelsValue().plus(channel)
+            )
+        }
+        
+        // Track as discovered if not joined
+        if (!state.getJoinedChannelsValue().contains(channel)) {
+            state.setDiscoveredChannels(
+                state.getDiscoveredChannelsValue().plus(channel)
+            )
+        }
+        
+        // Save state
+        saveChannelData()
+    }
+    
+    fun getDiscoveredChannels(): Set<String> = state.getDiscoveredChannelsValue()
+    
     // MARK: - Emergency Clear
     
     fun clearAllChannels() {

--- a/app/src/main/java/com/bitchat/android/ui/ChatState.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatState.kt
@@ -62,6 +62,9 @@ class ChatState {
     private val _passwordProtectedChannels = MutableLiveData<Set<String>>(emptySet())
     val passwordProtectedChannels: LiveData<Set<String>> = _passwordProtectedChannels
     
+    private val _discoveredChannels = MutableLiveData<Set<String>>(emptySet())
+    val discoveredChannels: LiveData<Set<String>> = _discoveredChannels
+    
     private val _showPasswordPrompt = MutableLiveData<Boolean>(false)
     val showPasswordPrompt: LiveData<Boolean> = _showPasswordPrompt
     
@@ -116,6 +119,7 @@ class ChatState {
     fun getChannelMessagesValue() = _channelMessages.value ?: emptyMap()
     fun getUnreadChannelMessagesValue() = _unreadChannelMessages.value ?: emptyMap()
     fun getPasswordProtectedChannelsValue() = _passwordProtectedChannels.value ?: emptySet()
+    fun getDiscoveredChannelsValue() = _discoveredChannels.value ?: emptySet()
     fun getShowPasswordPromptValue() = _showPasswordPrompt.value ?: false
     fun getPasswordPromptChannelValue() = _passwordPromptChannel.value
     fun getShowSidebarValue() = _showSidebar.value ?: false
@@ -171,6 +175,10 @@ class ChatState {
     
     fun setPasswordProtectedChannels(channels: Set<String>) {
         _passwordProtectedChannels.value = channels
+    }
+    
+    fun setDiscoveredChannels(channels: Set<String>) {
+        _discoveredChannels.value = channels
     }
     
     fun setShowPasswordPrompt(show: Boolean) {

--- a/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
@@ -156,4 +156,10 @@ class MeshDelegateHandler(
     override fun registerPeerPublicKey(peerID: String, publicKeyData: ByteArray) {
         privateChatManager.registerPeerPublicKey(peerID, publicKeyData)
     }
+    
+    override fun markChannelAsPasswordProtected(channel: String) {
+        coroutineScope.launch {
+            channelManager.markChannelAsPasswordProtected(channel)
+        }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="back">Back</string>
     <string name="people">People</string>
     <string name="channels">Channels</string>
+    <string name="discovered_channels">Discovered Channels</string>
     <string name="online_users">Online Users</string>
     <string name="no_one_connected">No one connected</string>
     <string name="emergency_clear_hint">Triple tap to clear all data</string>


### PR DESCRIPTION
# Add Password-Protected Channel Auto-Discovery

## Description
Closes https://github.com/permissionlesstech/bitchat-android/issues/177

Adds automatic discovery of password-protected channels when encrypted messages are received. Channels now appear in a "Discovered Channels" section with lock icons (🔒) and clicking them shows a password prompt.

## Changes
- Auto-detect password-protected channels from encrypted messages
- Add "Discovered Channels" section to sidebar with lock icons
- Fix password prompt dialog to properly show when clicking discovered channels
- Add visual distinction between joined and discovered channels

## Screenshots
- Before: Users had to manually type `/join #secret password`
- After: Click discovered channel → password prompt → join
<img width="304" height="683" alt="image" src="https://github.com/user-attachments/assets/ccc757c1-c8de-45db-af81-dcf644add571" />
<img width="304" height="683" alt="image" src="https://github.com/user-attachments/assets/6c45c3f3-7fc5-47b0-9f57-1091a61caa2f" />

## Testing
1. On another bitchat device, create a new channel and add a password to it: `/pass mypassword`
2. On that other bitchat device, send message in that newly created password-protected channel
3. Check Android - channel appears in "Discovered Channels" with 🔒
4. Click channel - password prompt appears
5. Enter password - join and see decrypted messages

## Privacy
- [X] No broadcasting since it only discovers from actual messages
- [X] All discovery is local to device
- [X] No protocol changes

## Code Quality
- [X] Ran `./gradlew lint` - existing baseline warnings only
- [ ] No new tests added - UI feature tested manually with bitchat android

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [X] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [X] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [X] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
