### PR TITLE
Feature/mentions

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -136,7 +136,7 @@ fun ChatScreen(viewModel: ChatViewModel) {
                     )
                 },
                 onMentionSuggestionClick = { mention: String ->
-                    val mentionText = viewModel.selectMentionSuggestion(mention)
+                    val mentionText = viewModel.selectMentionSuggestion(mention, messageText.text)
                     messageText = TextFieldValue(
                         text = mentionText,
                         selection = TextRange(mentionText.length)

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -64,6 +64,8 @@ fun ChatScreen(viewModel: ChatViewModel) {
     val showSidebar by viewModel.showSidebar.observeAsState(false)
     val showCommandSuggestions by viewModel.showCommandSuggestions.observeAsState(false)
     val commandSuggestions by viewModel.commandSuggestions.observeAsState(emptyList())
+    val showMentionSuggestions by viewModel.showMentionSuggestions.observeAsState(false)
+    val mentionSuggestions by viewModel.mentionSuggestions.observeAsState(emptyList())
     val showAppInfo by viewModel.showAppInfo.observeAsState(false)
     
     var messageText by remember { mutableStateOf(TextFieldValue("")) }
@@ -114,6 +116,7 @@ fun ChatScreen(viewModel: ChatViewModel) {
                 onMessageTextChange = { newText: TextFieldValue ->
                     messageText = newText
                     viewModel.updateCommandSuggestions(newText.text)
+                    viewModel.updateMentionSuggestions(newText.text)
                 },
                 onSend = {
                     if (messageText.text.trim().isNotEmpty()) {
@@ -123,11 +126,20 @@ fun ChatScreen(viewModel: ChatViewModel) {
                 },
                 showCommandSuggestions = showCommandSuggestions,
                 commandSuggestions = commandSuggestions,
-                onSuggestionClick = { suggestion: CommandSuggestion ->
+                showMentionSuggestions = showMentionSuggestions,
+                mentionSuggestions = mentionSuggestions,
+                onCommandSuggestionClick = { suggestion: CommandSuggestion ->
                     val commandText = viewModel.selectCommandSuggestion(suggestion)
                     messageText = TextFieldValue(
                         text = commandText,
                         selection = TextRange(commandText.length)
+                    )
+                },
+                onMentionSuggestionClick = { mention: String ->
+                    val mentionText = viewModel.selectMentionSuggestion(mention)
+                    messageText = TextFieldValue(
+                        text = mentionText,
+                        selection = TextRange(mentionText.length)
                     )
                 },
                 selectedPrivatePeer = selectedPrivatePeer,
@@ -202,7 +214,10 @@ private fun ChatInputSection(
     onSend: () -> Unit,
     showCommandSuggestions: Boolean,
     commandSuggestions: List<CommandSuggestion>,
-    onSuggestionClick: (CommandSuggestion) -> Unit,
+    showMentionSuggestions: Boolean,
+    mentionSuggestions: List<String>,
+    onCommandSuggestionClick: (CommandSuggestion) -> Unit,
+    onMentionSuggestionClick: (String) -> Unit,
     selectedPrivatePeer: String?,
     currentChannel: String?,
     nickname: String,
@@ -220,7 +235,18 @@ private fun ChatInputSection(
             if (showCommandSuggestions && commandSuggestions.isNotEmpty()) {
                 CommandSuggestionsBox(
                     suggestions = commandSuggestions,
-                    onSuggestionClick = onSuggestionClick,
+                    onSuggestionClick = onCommandSuggestionClick,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                HorizontalDivider(color = colorScheme.outline.copy(alpha = 0.2f))
+            }
+            
+            // Mention suggestions box
+            if (showMentionSuggestions && mentionSuggestions.isNotEmpty()) {
+                MentionSuggestionsBox(
+                    suggestions = mentionSuggestions,
+                    onSuggestionClick = onMentionSuggestionClick,
                     modifier = Modifier.fillMaxWidth()
                 )
 

--- a/app/src/main/java/com/bitchat/android/ui/ChatState.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatState.kt
@@ -79,6 +79,13 @@ class ChatState {
     private val _commandSuggestions = MutableLiveData<List<CommandSuggestion>>(emptyList())
     val commandSuggestions: LiveData<List<CommandSuggestion>> = _commandSuggestions
     
+    // Mention autocomplete
+    private val _showMentionSuggestions = MutableLiveData(false)
+    val showMentionSuggestions: LiveData<Boolean> = _showMentionSuggestions
+    
+    private val _mentionSuggestions = MutableLiveData<List<String>>(emptyList())
+    val mentionSuggestions: LiveData<List<String>> = _mentionSuggestions
+    
     // Favorites
     private val _favoritePeers = MutableLiveData<Set<String>>(emptySet())
     val favoritePeers: LiveData<Set<String>> = _favoritePeers
@@ -129,6 +136,8 @@ class ChatState {
     fun getShowSidebarValue() = _showSidebar.value ?: false
     fun getShowCommandSuggestionsValue() = _showCommandSuggestions.value ?: false
     fun getCommandSuggestionsValue() = _commandSuggestions.value ?: emptyList()
+    fun getShowMentionSuggestionsValue() = _showMentionSuggestions.value ?: false
+    fun getMentionSuggestionsValue() = _mentionSuggestions.value ?: emptyList()
     fun getFavoritePeersValue() = _favoritePeers.value ?: emptySet()
     fun getPeerSessionStatesValue() = _peerSessionStates.value ?: emptyMap()
     fun getPeerFingerprintsValue() = _peerFingerprints.value ?: emptyMap()
@@ -201,6 +210,14 @@ class ChatState {
     
     fun setCommandSuggestions(suggestions: List<CommandSuggestion>) {
         _commandSuggestions.value = suggestions
+    }
+    
+    fun setShowMentionSuggestions(show: Boolean) {
+        _showMentionSuggestions.value = show
+    }
+    
+    fun setMentionSuggestions(suggestions: List<String>) {
+        _mentionSuggestions.value = suggestions
     }
 
     fun setFavoritePeers(favorites: Set<String>) {

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -355,8 +355,8 @@ class ChatViewModel(
         commandProcessor.updateMentionSuggestions(input, meshService)
     }
     
-    fun selectMentionSuggestion(nickname: String): String {
-        return commandProcessor.selectMentionSuggestion(nickname)
+    fun selectMentionSuggestion(nickname: String, currentText: String): String {
+        return commandProcessor.selectMentionSuggestion(nickname, currentText)
     }
     
     // MARK: - BluetoothMeshDelegate Implementation (delegated)

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -79,6 +79,8 @@ class ChatViewModel(
     val hasUnreadPrivateMessages = state.hasUnreadPrivateMessages
     val showCommandSuggestions: LiveData<Boolean> = state.showCommandSuggestions
     val commandSuggestions: LiveData<List<CommandSuggestion>> = state.commandSuggestions
+    val showMentionSuggestions: LiveData<Boolean> = state.showMentionSuggestions
+    val mentionSuggestions: LiveData<List<String>> = state.mentionSuggestions
     val favoritePeers: LiveData<Set<String>> = state.favoritePeers
     val peerSessionStates: LiveData<Map<String, String>> = state.peerSessionStates
     val peerFingerprints: LiveData<Map<String, String>> = state.peerFingerprints
@@ -345,6 +347,16 @@ class ChatViewModel(
     
     fun selectCommandSuggestion(suggestion: CommandSuggestion): String {
         return commandProcessor.selectCommandSuggestion(suggestion)
+    }
+    
+    // MARK: - Mention Autocomplete
+    
+    fun updateMentionSuggestions(input: String) {
+        commandProcessor.updateMentionSuggestions(input, meshService)
+    }
+    
+    fun selectMentionSuggestion(nickname: String): String {
+        return commandProcessor.selectMentionSuggestion(nickname)
     }
     
     // MARK: - BluetoothMeshDelegate Implementation (delegated)

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -424,10 +424,19 @@ class CommandProcessor(
         }
     }
     
-    fun selectMentionSuggestion(nickname: String): String {
+    fun selectMentionSuggestion(nickname: String, currentText: String): String {
         state.setShowMentionSuggestions(false)
         state.setMentionSuggestions(emptyList())
-        return "@$nickname "
+        
+        // Find the last @ symbol position
+        val atIndex = currentText.lastIndexOf('@')
+        if (atIndex == -1) {
+            return "$currentText@$nickname "
+        }
+        
+        // Replace the text from the @ symbol to the end with the mention
+        val textBeforeAt = currentText.substring(0, atIndex)
+        return "$textBeforeAt@$nickname "
     }
     
     // MARK: - Utility Functions (would access mesh service)

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -380,6 +380,56 @@ class CommandProcessor(
         return "${suggestion.command} "
     }
     
+    // MARK: - Mention Autocomplete
+    
+    fun updateMentionSuggestions(input: String, meshService: Any) {
+        // Check if input contains @ and we're at the end of a word or at the end of input
+        val atIndex = input.lastIndexOf('@')
+        if (atIndex == -1) {
+            state.setShowMentionSuggestions(false)
+            state.setMentionSuggestions(emptyList())
+            return
+        }
+        
+        // Get the text after the @ symbol
+        val textAfterAt = input.substring(atIndex + 1)
+        
+        // If there's a space after @, don't show suggestions
+        if (textAfterAt.contains(' ')) {
+            state.setShowMentionSuggestions(false)
+            state.setMentionSuggestions(emptyList())
+            return
+        }
+        
+        // Get all connected peer nicknames
+        val peerNicknames = try {
+            val method = meshService::class.java.getDeclaredMethod("getPeerNicknames")
+            val peerNicknamesMap = method.invoke(meshService) as? Map<String, String>
+            peerNicknamesMap?.values?.toList() ?: emptyList()
+        } catch (e: Exception) {
+            emptyList()
+        }
+        
+        // Filter nicknames based on the text after @
+        val filteredNicknames = peerNicknames.filter { nickname ->
+            nickname.startsWith(textAfterAt, ignoreCase = true)
+        }.sorted()
+        
+        if (filteredNicknames.isNotEmpty()) {
+            state.setMentionSuggestions(filteredNicknames)
+            state.setShowMentionSuggestions(true)
+        } else {
+            state.setShowMentionSuggestions(false)
+            state.setMentionSuggestions(emptyList())
+        }
+    }
+    
+    fun selectMentionSuggestion(nickname: String): String {
+        state.setShowMentionSuggestions(false)
+        state.setMentionSuggestions(emptyList())
+        return "@$nickname "
+    }
+    
     // MARK: - Utility Functions (would access mesh service)
     
     private fun getPeerIDForNickname(nickname: String, meshService: Any): String? {


### PR DESCRIPTION
# Description
This PR implements the mention autocomplete feature for the Android version of bitchat, bringing it to parity with the iOS version. Users can now type "@" followed by a few characters to see a list of connected users they can mention in their messages.

## Features Added
Mention Autocomplete Suggestions

When typing "@" in the chat input, a suggestions box appears showing connected users
Suggestions are filtered based on the typed characters (e.g., "@jo" shows users whose nicknames start with "jo")
Clicking on a suggestion inserts the mention at the current cursor position
Visual Mentions Highlighting

Mentions are visually highlighted in orange in the chat input field
Mentions in received messages are also highlighted consistently with iOS styling
Both slash commands and mentions can be styled simultaneously
Context-Aware Mention Insertion

Mentions are inserted at the cursor position without replacing existing text
Works correctly even when typing in the middle of a sentence
## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [x] I have run the automated code checks using `./gradlew check` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x]  If it is a core feature, I have added automated tests
