### PR TITLE
fix(ui): prevent sender color of past messages

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
@@ -54,7 +54,7 @@ fun formatMessageAsAnnotatedString(
     if (message.sender != "system") {
         // Sender
         val senderColor = when {
-            message.sender == currentUserNickname -> colorScheme.primary
+            message.senderPeerID == meshService.myPeerID -> colorScheme.primary
             else -> {
                 val peerID = message.senderPeerID
                 val rssi = peerID?.let { meshService.getPeerRSSI()[it] } ?: -60


### PR DESCRIPTION
Closes https://github.com/permissionlesstech/bitchat-android/issues/200

# Description

Previously, the sender was identified by comparing `message.sender` (a nickname string) to `currentUserNickname`. This caused issues when the nickname changed, since past messages would then match or not match incorrectly, leading to inconsistent color assignments.

The updated logic compares `message.senderPeerID` to `meshService.myPeerID`, which is a unique and stable identifier for the user. This ensures that the correct color (`colorScheme.primary`) is applied consistently to the user's own messages, regardless of any nickname changes.

# Why this matters

- Fixes a bug where changing your nickname would retroactively change the color of your past messages.

- Prevents conflicts where multiple users with the same nickname might get the same sender color.

- Makes message ownership checks more reliable by using a unique ID instead of a mutable nickname.

# Screenshots/Screen recordings

https://github.com/user-attachments/assets/c53e2dbd-d652-4c3a-b9a3-19a27364dde1

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x] If it is a core feature, I have added automated tests
