### PR TITLE
fix(readme): Fix link to GitHub Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Contributions are welcome! Key areas for enhancement:
 ## Support & Issues
 
 - **Bug Reports**: [Create an issue](../../issues) with device info and logs
-- **Feature Requests**: [Start a discussion](../../discussions)
+- **Feature Requests**: [Start a discussion](https://github.com/orgs/permissionlesstech/discussions)
 - **Security Issues**: Email security concerns privately
 - **iOS Compatibility**: Cross-reference with [original iOS repo](https://github.com/jackjackbits/bitchat)
 


### PR DESCRIPTION
# Description

The current GitHub Discussions link points to https://github.com/permissionlesstech/bitchat-android/discussions, which do not exist.

Update the link to point to the org-wide discussions https://github.com/orgs/permissionlesstech/discussions instead.

## Checklist
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
