### PR TITLE
Make Sidebar react to the nickname and RSSI changes.

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
@@ -211,6 +211,7 @@ fun ChatHeaderContent(
             val favoritePeers by viewModel.favoritePeers.observeAsState(emptySet())
             val peerFingerprints by viewModel.peerFingerprints.observeAsState(emptyMap())
             val peerSessionStates by viewModel.peerSessionStates.observeAsState(emptyMap())
+            val peerNicknames by viewModel.peerNicknames.observeAsState(emptyMap())
             
             // Reactive favorite computation - no more static lookups!
             val isFavorite = isFavoriteReactive(
@@ -224,7 +225,7 @@ fun ChatHeaderContent(
             
             PrivateChatHeader(
                 peerID = selectedPrivatePeer,
-                peerNicknames = viewModel.meshService.getPeerNicknames(),
+                peerNicknames = peerNicknames,
                 isFavorite = isFavorite,
                 sessionState = sessionState,
                 onBackClick = onBackClick,

--- a/app/src/main/java/com/bitchat/android/ui/ChatState.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatState.kt
@@ -90,6 +90,12 @@ class ChatState {
     // Peer fingerprint state for reactive favorites (for reactive UI updates)
     private val _peerFingerprints = MutableLiveData<Map<String, String>>(emptyMap())
     val peerFingerprints: LiveData<Map<String, String>> = _peerFingerprints
+
+    private val _peerNicknames = MutableLiveData<Map<String, String>>(emptyMap())
+    val peerNicknames: LiveData<Map<String, String>> = _peerNicknames
+
+    private val _peerRSSI = MutableLiveData<Map<String, Int>>(emptyMap())
+    val peerRSSI: LiveData<Map<String, Int>> = _peerRSSI
     
     // peerIDToPublicKeyFingerprint REMOVED - fingerprints now handled centrally in PeerManager
     
@@ -223,6 +229,14 @@ class ChatState {
     
     fun setPeerFingerprints(fingerprints: Map<String, String>) {
         _peerFingerprints.value = fingerprints
+    }
+
+    fun setPeerNicknames(nicknames: Map<String, String>) {
+        _peerNicknames.value = nicknames
+    }
+
+    fun setPeerRSSI(rssi: Map<String, Int>) {
+        _peerRSSI.value = rssi
     }
     
     fun setShowAppInfo(show: Boolean) {

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -86,6 +86,8 @@ class ChatViewModel(
     val favoritePeers: LiveData<Set<String>> = state.favoritePeers
     val peerSessionStates: LiveData<Map<String, String>> = state.peerSessionStates
     val peerFingerprints: LiveData<Map<String, String>> = state.peerFingerprints
+    val peerNicknames: LiveData<Map<String, String>> = state.peerNicknames
+    val peerRSSI: LiveData<Map<String, Int>> = state.peerRSSI
     val showAppInfo: LiveData<Boolean> = state.showAppInfo
     
     init {
@@ -301,7 +303,7 @@ class ChatViewModel(
     }
     
     /**
-     * Update reactive states for all connected peers (session states and fingerprints)
+     * Update reactive states for all connected peers (session states, fingerprints, nicknames, RSSI)
      */
     private fun updateReactiveStates() {
         val currentPeers = state.getConnectedPeersValue()
@@ -311,10 +313,15 @@ class ChatViewModel(
             meshService.getSessionState(peerID).toString()
         }
         state.setPeerSessionStates(sessionStates)
-        
         // Update fingerprint mappings from centralized manager
         val fingerprints = privateChatManager.getAllPeerFingerprints()
         state.setPeerFingerprints(fingerprints)
+
+        val nicknames = meshService.getPeerNicknames()
+        state.setPeerNicknames(nicknames)
+
+        val rssiValues = meshService.getPeerRSSI()
+        state.setPeerRSSI(rssiValues)
     }
     
     // MARK: - Debug and Troubleshooting

--- a/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
@@ -40,11 +40,9 @@ fun SidebarOverlay(
     val selectedPrivatePeer by viewModel.selectedPrivateChatPeer.observeAsState()
     val nickname by viewModel.nickname.observeAsState("")
     val unreadChannelMessages by viewModel.unreadChannelMessages.observeAsState(emptyMap())
-    
-    // Get peer data from mesh service
-    val peerNicknames = viewModel.meshService.getPeerNicknames()
-    val peerRSSI = viewModel.meshService.getPeerRSSI()
-    
+    val peerNicknames by viewModel.peerNicknames.observeAsState(emptyMap())
+    val peerRSSI by viewModel.peerRSSI.observeAsState(emptyMap())
+
     Box(
         modifier = modifier
             .background(Color.Black.copy(alpha = 0.5f))


### PR DESCRIPTION
# Description

If someone joins the network while the sidebar is open, their peer ID is displayed instead of their nickname until the Sidebar is reopened:

https://github.com/user-attachments/assets/484a38d0-e29f-4c1a-88cb-74e7aa9513cc

This change updates the Sidebar to react to the nickname and RSSI value changes so that the nickname is updated without having to reopen it:

https://github.com/user-attachments/assets/2730c9cf-0feb-4247-a720-e336cc3906eb

## Checklist
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
