### PR TITLE
fix: messages not sending to joined channel from public or private chat

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -211,7 +211,9 @@ class ChatViewModel(
         channels.forEach { channel ->
             if (!state.getJoinedChannelsValue().contains(channel)) {
                 joinChannel(channel)
+                return@forEach
             }
+            switchToChannel(channel)
         }
         
         val selectedPeer = state.getSelectedPrivateChatPeerValue()


### PR DESCRIPTION
Closes https://github.com/permissionlesstech/bitchat-android/issues/234

# Description

This PR addresses an issue where:

- Messages sent to a channel (from public or private chats) that the user has already joined are not being delivered.

The issue stemmed from missing or incorrect handling of channel switching logic.

# Why this matters

- Ensures that users can send messages to channels they’ve already joined.

# What’s changed

- If a channel is not joined, the app now calls `joinChannel(channel)` and exits the current iteration using `return@forEach`.

- If the channel is already joined, the app calls `switchToChannel(channel)` before sending the message.

# 🔍 How to Test

- Open the app.
- Join any channel. Example: `#test_channel Join in channel`
- From a public or private channel, send a message to the joined channel. Example: `#test_channel Second message`
- Verify that the message is successfully delivered and appears in the target channel.

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x] If it is a core feature, I have added automated tests
