### PR TITLE
Fix favorite icon not updating on first Sidebar open

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -118,7 +118,7 @@ class ChatViewModel(
         
         // Load other data
         dataManager.loadFavorites()
-        state.setFavoritePeers(dataManager.favoritePeers)
+        state.setFavoritePeers(dataManager.favoritePeers.toSet())
         dataManager.loadBlockedUsers()
         
         // Log all favorites at startup


### PR DESCRIPTION
# Description

Fixes [this](https://github.com/permissionlesstech/bitchat-android/pull/228#issuecomment-3156554639) issue. This is caused by the fact that the `ChatViewModel` state is initially set with the reference to `dataManager.favoritePeers` instead of defensive copy, which I believe messes up the `LiveData` equality checks.

**Demo with the fix:**

https://github.com/user-attachments/assets/6b1a895c-c586-4a96-8a17-0fc8c6e78b18

## Checklist
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
