### PR TITLE
gradle: disable baseline profile for f-droid reproducable builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,3 +5,9 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.compose) apply false
 }
+
+tasks.whenTaskAdded {
+    if (name.contains("ArtProfile")) {
+        enabled = false
+    }
+}


### PR DESCRIPTION
Needed as a workaround for reproducible builds by F-Droid until the baseline.prof is reproducible.
This MR would enable the inclusion of bitchat into F-Droid.

Relevant discussion: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/24907#note_2682765032

# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
