### PR TITLE
[Proof of Concept] Add a persistent mesh network option

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,11 @@
     
     <!-- Notification permissions -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <!-- Foreground + boot -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     
     <!-- Haptic feedback permission -->
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -50,5 +55,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".services.PersistentMeshService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
+        <receiver
+            android:name=".services.BootCompletedReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -686,6 +686,11 @@ class BluetoothMeshService(private val context: Context) {
      * Get peer RSSI values  
      */
     fun getPeerRSSI(): Map<String, Int> = peerManager.getAllPeerRSSI()
+
+    /**
+     * Get current active peer IDs for immediate UI sync on attach
+     */
+    fun getActivePeers(): List<String> = peerManager.getActivePeerIDs()
     
     /**
      * Check if we have an established Noise session with a peer  

--- a/app/src/main/java/com/bitchat/android/mesh/MeshServiceHolder.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/MeshServiceHolder.kt
@@ -1,0 +1,19 @@
+package com.bitchat.android.mesh
+
+import android.content.Context
+
+/**
+ * Holds a single shared instance of BluetoothMeshService so the app UI
+ * and background service can operate on the same mesh without duplication.
+ */
+object MeshServiceHolder {
+    @Volatile
+    private var instance: BluetoothMeshService? = null
+
+    fun get(context: Context): BluetoothMeshService {
+        return instance ?: synchronized(this) {
+            instance ?: BluetoothMeshService(context.applicationContext).also { instance = it }
+        }
+    }
+}
+

--- a/app/src/main/java/com/bitchat/android/services/AppVisibilityState.kt
+++ b/app/src/main/java/com/bitchat/android/services/AppVisibilityState.kt
@@ -1,0 +1,15 @@
+package com.bitchat.android.services
+
+/**
+ * Process-wide visibility + focus state used by background service
+ * to avoid duplicate notifications when the app is foregrounded or
+ * the user is already viewing a specific private chat.
+ */
+object AppVisibilityState {
+    @Volatile
+    var isAppInBackground: Boolean = true
+
+    @Volatile
+    var currentPrivateChatPeer: String? = null
+}
+

--- a/app/src/main/java/com/bitchat/android/services/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/services/BootCompletedReceiver.kt
@@ -1,0 +1,45 @@
+package com.bitchat.android.services
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
+import androidx.core.content.ContextCompat
+
+/**
+ * Starts the mesh foreground service on device boot if enabled and permissions are satisfied.
+ */
+class BootCompletedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+
+        val prefs = context.getSharedPreferences("bitchat_prefs", Context.MODE_PRIVATE)
+        val persistentEnabled = prefs.getBoolean("persistent_mesh_enabled", false)
+        val startOnBoot = prefs.getBoolean("start_on_boot_enabled", false)
+
+        if (!persistentEnabled || !startOnBoot) {
+            return
+        }
+
+        if (!hasRequiredPermissions(context)) {
+            Log.w("BootCompletedReceiver", "Missing permissions; not starting mesh on boot")
+            return
+        }
+
+        PersistentMeshService.start(context)
+    }
+
+    private fun hasRequiredPermissions(context: Context): Boolean {
+        val required = listOf(
+            android.Manifest.permission.BLUETOOTH_SCAN,
+            android.Manifest.permission.BLUETOOTH_CONNECT,
+            android.Manifest.permission.BLUETOOTH_ADVERTISE,
+            android.Manifest.permission.ACCESS_FINE_LOCATION
+        )
+        return required.all { perm ->
+            ContextCompat.checkSelfPermission(context, perm) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+}
+

--- a/app/src/main/java/com/bitchat/android/services/InMemoryMessageBuffer.kt
+++ b/app/src/main/java/com/bitchat/android/services/InMemoryMessageBuffer.kt
@@ -1,0 +1,40 @@
+package com.bitchat.android.services
+
+import com.bitchat.android.model.BitchatMessage
+import java.util.LinkedList
+
+/**
+ * Process-local, in-memory message buffer used while the UI is closed.
+ * - Never touches disk
+ * - Cleared on process death, reboot, or panic
+ */
+object InMemoryMessageBuffer {
+    private const val MAX_MESSAGES = 500
+    private val lock = Any()
+    private val queue: LinkedList<BitchatMessage> = LinkedList()
+
+    fun add(message: BitchatMessage) {
+        synchronized(lock) {
+            // Deduplicate by id
+            if (queue.any { it.id == message.id }) return
+            queue.addLast(message)
+            while (queue.size > MAX_MESSAGES) {
+                queue.removeFirst()
+            }
+        }
+    }
+
+    fun drain(): List<BitchatMessage> {
+        synchronized(lock) {
+            if (queue.isEmpty()) return emptyList()
+            val copy = ArrayList<BitchatMessage>(queue)
+            queue.clear()
+            return copy
+        }
+    }
+
+    fun clear() {
+        synchronized(lock) { queue.clear() }
+    }
+}
+

--- a/app/src/main/java/com/bitchat/android/services/PersistentMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/services/PersistentMeshService.kt
@@ -1,0 +1,214 @@
+package com.bitchat.android.services
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.bitchat.android.MainActivity
+import com.bitchat.android.R
+import com.bitchat.android.mesh.BluetoothMeshDelegate
+import com.bitchat.android.mesh.BluetoothMeshService
+import com.bitchat.android.mesh.MeshServiceHolder
+import com.bitchat.android.model.BitchatMessage
+import com.bitchat.android.ui.NotificationManager as DMNotificationManager
+
+/**
+ * Foreground service that keeps the Bluetooth mesh alive in the background
+ * and delivers PM notifications when the app UI is not active.
+ */
+class PersistentMeshService : Service() {
+
+    companion object {
+        private const val TAG = "PersistentMeshService"
+        private const val CHANNEL_ID = "bitchat_mesh_foreground"
+        private const val NOTIFICATION_ID = 1337
+
+        fun start(context: Context) {
+            val intent = Intent(context, PersistentMeshService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, PersistentMeshService::class.java))
+        }
+    }
+
+    private lateinit var mesh: BluetoothMeshService
+    private lateinit var dmNotifications: DMNotificationManager
+
+    // Minimal headless delegate to surface PMs as notifications when UI is not attached
+    private val backgroundDelegate = object : BluetoothMeshDelegate {
+        override fun didReceiveMessage(message: BitchatMessage) {
+            // Buffer messages in-memory while UI is closed (no disk persistence)
+            try { InMemoryMessageBuffer.add(message) } catch (_: Exception) {}
+
+            // Only show notifications when app is in background and not focused on this PM
+            if (message.isPrivate) {
+                val senderPeer = message.senderPeerID ?: return
+                val isBg = AppVisibilityState.isAppInBackground
+                val focusedPeer = AppVisibilityState.currentPrivateChatPeer
+                if (isBg || (focusedPeer != senderPeer)) {
+                    val senderName = if (message.senderPeerID == message.sender) senderPeer else message.sender
+                    dmNotifications.setAppBackgroundState(isBg)
+                    dmNotifications.setCurrentPrivateChatPeer(focusedPeer)
+                    dmNotifications.showPrivateMessageNotification(senderPeer, senderName, message.content)
+                }
+            }
+        }
+
+        override fun didUpdatePeerList(peers: List<String>) {}
+        override fun didReceiveChannelLeave(channel: String, fromPeer: String) {}
+        override fun didReceiveDeliveryAck(messageID: String, recipientPeerID: String) {}
+        override fun didReceiveReadReceipt(messageID: String, recipientPeerID: String) {}
+        override fun decryptChannelMessage(encryptedContent: ByteArray, channel: String): String? = null
+        override fun getNickname(): String? = loadNickname()
+        override fun isFavorite(peerID: String): Boolean = false
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        dmNotifications = DMNotificationManager(applicationContext)
+        mesh = MeshServiceHolder.get(applicationContext)
+        createNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildOngoingNotification())
+
+        // Ensure mesh is running and delegate includes background notifications without
+        // disrupting any existing UI delegate.
+        try {
+            val existing = mesh.delegate
+            if (existing != null && existing !== backgroundDelegate) {
+                mesh.delegate = CombinedDelegate(existing, backgroundDelegate)
+            } else {
+                mesh.delegate = backgroundDelegate
+            }
+            // App may be in background; let PowerManager manage based on state updates
+            mesh.startServices()
+            // Immediately broadcast with the proper nickname so others see us correctly
+            mesh.sendBroadcastAnnounce()
+            Log.i(TAG, "Mesh started in foreground service")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start mesh in service", e)
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Do not stop mesh here; UI or settings control lifecycle.
+        Log.i(TAG, "Foreground service destroyed")
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        // App task removed; ensure background delegate handles callbacks
+        try {
+            mesh.delegate = backgroundDelegate
+            AppVisibilityState.isAppInBackground = true
+            Log.i(TAG, "Task removed: reattached background delegate")
+        } catch (_: Exception) {}
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Mesh Background",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Keeps the bitchat mesh running in the background"
+                setShowBadge(false)
+            }
+            val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildOngoingNotification(): Notification {
+        val intent = Intent(this, MainActivity::class.java)
+        val pi = PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText("Mesh running in background")
+            .setContentIntent(pi)
+            .setOngoing(true)
+            .build()
+    }
+
+    /**
+     * Forwards all callbacks to two delegates.
+     */
+    private class CombinedDelegate(
+        private val a: BluetoothMeshDelegate?,
+        private val b: BluetoothMeshDelegate?
+    ) : BluetoothMeshDelegate {
+        override fun didReceiveMessage(message: BitchatMessage) {
+            a?.didReceiveMessage(message)
+            b?.didReceiveMessage(message)
+        }
+
+        override fun didUpdatePeerList(peers: List<String>) {
+            a?.didUpdatePeerList(peers)
+            b?.didUpdatePeerList(peers)
+        }
+
+        override fun didReceiveChannelLeave(channel: String, fromPeer: String) {
+            a?.didReceiveChannelLeave(channel, fromPeer)
+            b?.didReceiveChannelLeave(channel, fromPeer)
+        }
+
+        override fun didReceiveDeliveryAck(messageID: String, recipientPeerID: String) {
+            a?.didReceiveDeliveryAck(messageID, recipientPeerID)
+            b?.didReceiveDeliveryAck(messageID, recipientPeerID)
+        }
+
+        override fun didReceiveReadReceipt(messageID: String, recipientPeerID: String) {
+            a?.didReceiveReadReceipt(messageID, recipientPeerID)
+            b?.didReceiveReadReceipt(messageID, recipientPeerID)
+        }
+
+        override fun decryptChannelMessage(encryptedContent: ByteArray, channel: String): String? {
+            // Prefer result from a; fall back to b
+            return a?.decryptChannelMessage(encryptedContent, channel)
+                ?: b?.decryptChannelMessage(encryptedContent, channel)
+        }
+
+        override fun getNickname(): String? {
+            return a?.getNickname() ?: b?.getNickname()
+        }
+
+        override fun isFavorite(peerID: String): Boolean {
+            return (a?.isFavorite(peerID) == true) || (b?.isFavorite(peerID) == true)
+        }
+    }
+
+    private fun loadNickname(): String {
+        return try {
+            val prefs = applicationContext.getSharedPreferences("bitchat_prefs", Context.MODE_PRIVATE)
+            prefs.getString("nickname", null) ?: mesh.myPeerID
+        } catch (_: Exception) {
+            mesh.myPeerID
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/ui/DataManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/DataManager.kt
@@ -202,4 +202,22 @@ class DataManager(private val context: Context) {
         _channelMembers.clear()
         prefs.edit().clear().apply()
     }
+
+    // MARK: - Persistent Mesh Settings
+
+    fun isPersistentMeshEnabled(): Boolean {
+        return prefs.getBoolean("persistent_mesh_enabled", false)
+    }
+
+    fun setPersistentMeshEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("persistent_mesh_enabled", enabled).apply()
+    }
+
+    fun isStartOnBootEnabled(): Boolean {
+        return prefs.getBoolean("start_on_boot_enabled", false)
+    }
+
+    fun setStartOnBootEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean("start_on_boot_enabled", enabled).apply()
+    }
 }


### PR DESCRIPTION
# Description
This is an idea I've been testing that enables bitchat to run in the background with the app closed, while maintaining connection to other users, and still handling PM notifications and new messages. There's also an option to have the network start up automatically after a device restart. Having this as an option will make users more likely to have bitchat running at any given moment, improving mesh size and usability for everyone.

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
