### PR TITLE
Fix: improve formatting for long usernames

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
@@ -156,14 +156,6 @@ fun formatMessageAsAnnotatedString(
     return builder.toAnnotatedString()
 }
 
-fun truncateNickname(nickname: String, maxLength: Int = 16): String {
-    return if (nickname.length > maxLength) {
-        nickname.take(maxLength) + "…"
-    } else {
-        nickname
-    }
-}
-
 /**
  * iOS-style peer color assignment using djb2 hash algorithm
  * Avoids orange (~30°) reserved for self messages

--- a/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
@@ -156,6 +156,14 @@ fun formatMessageAsAnnotatedString(
     return builder.toAnnotatedString()
 }
 
+fun truncateNickname(nickname: String, maxLength: Int = 16): String {
+    return if (nickname.length > maxLength) {
+        nickname.take(maxLength) + "…"
+    } else {
+        nickname
+    }
+}
+
 /**
  * iOS-style peer color assignment using djb2 hash algorithm
  * Avoids orange (~30°) reserved for self messages


### PR DESCRIPTION
# Description
Closes: #319
This PR fixes the formatting issue where long usernames in the **GeohashPersonItem** row were causing strange wrapping and misaligned text.  
- Changed from multiple `Text` composables in a `Row` to a single `AnnotatedString` inside one `Text`.  
- Enabled line breaking and hyphenation for long/no-space names.  

## BEFORE
![long_username_before](https://github.com/user-attachments/assets/c7fa3ae6-16ec-4269-9cb0-0241d8043d44)

## AFTER
![long_username_after](https://github.com/user-attachments/assets/c01d4b84-2917-4b44-a025-935399954611)


## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have performed a self-review of my code
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
<!-- - [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
