### PR TITLE
feat: `MAX_MESSAGE_LENGTH` and `MAX_DISPLAY_NAME_LENGTH` limits

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
@@ -113,7 +113,7 @@ fun NicknameEditor(
         
         BasicTextField(
             value = value,
-            onValueChange = onValueChange,
+            onValueChange = { onValueChange(capDisplayName(it)) },
             textStyle = MaterialTheme.typography.bodyMedium.copy(
                 color = colorScheme.primary,
                 fontFamily = FontFamily.Monospace
@@ -327,7 +327,7 @@ private fun PrivateChatHeader(
         val geohash = (selectedLocationChannel as? com.bitchat.android.geohash.ChannelID.Location)?.channel?.geohash
         val shortId = peerID.removePrefix("nostr_").removePrefix("nostr:")
         val person = geohashPeople.firstOrNull { it.id.startsWith(shortId, ignoreCase = true) }
-        val baseName = person?.displayName?.substringBefore('#') ?: peerNicknames[peerID] ?: "unknown"
+        val baseName = capDisplayName(person?.displayName?.substringBefore('#') ?: peerNicknames[peerID] ?: "unknown")
         val geoPart = geohash?.let { "#$it" } ?: "#geohash"
         "$geoPart/@$baseName"
     } else {

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -149,9 +149,13 @@ fun ChatScreen(viewModel: ChatViewModel) {
             ChatInputSection(
                 messageText = messageText,
                 onMessageTextChange = { newText: TextFieldValue ->
-                    messageText = newText
-                    viewModel.updateCommandSuggestions(newText.text)
-                    viewModel.updateMentionSuggestions(newText.text)
+                val limitedText = newText.text.take(MAX_MESSAGE_LENGTH)
+                val adjusted = if (limitedText.length != newText.text.length) {
+                    TextFieldValue(text = limitedText, selection = TextRange(limitedText.length))
+                } else newText
+                messageText = adjusted
+                viewModel.updateCommandSuggestions(adjusted.text)
+                viewModel.updateMentionSuggestions(adjusted.text)
                 },
                 onSend = {
                     if (messageText.text.trim().isNotEmpty()) {

--- a/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
@@ -19,6 +19,13 @@ import java.util.*
  * Extracted from ChatScreen.kt for better organization
  */
 
+// Global limits
+const val MAX_MESSAGE_LENGTH = 280
+const val MAX_DISPLAY_NAME_LENGTH = 80
+
+fun capMessageContent(content: String): String = content.take(MAX_MESSAGE_LENGTH)
+fun capDisplayName(name: String): String = name.take(MAX_DISPLAY_NAME_LENGTH)
+
 /**
  * Get RSSI-based color for signal strength visualization
  */

--- a/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
@@ -21,10 +21,14 @@ import java.util.*
 
 // Global limits
 const val MAX_MESSAGE_LENGTH = 280
-const val MAX_DISPLAY_NAME_LENGTH = 80
+const val MAX_DISPLAY_NAME_LENGTH = 30
 
 fun capMessageContent(content: String): String = content.take(MAX_MESSAGE_LENGTH)
-fun capDisplayName(name: String): String = name.take(MAX_DISPLAY_NAME_LENGTH)
+fun capDisplayName(name: String): String {
+    val (base, suffix) = splitSuffix(name)
+    val allowedBase = (MAX_DISPLAY_NAME_LENGTH - suffix.length).coerceAtLeast(0)
+    return base.take(allowedBase) + suffix
+}
 
 /**
  * Get RSSI-based color for signal strength visualization

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -120,7 +120,7 @@ class ChatViewModel(
     
     private fun loadAndInitialize() {
         // Load nickname
-        val nickname = dataManager.loadNickname()
+        val nickname = capDisplayName(dataManager.loadNickname())
         state.setNickname(nickname)
         
         // Load data
@@ -190,8 +190,9 @@ class ChatViewModel(
     // MARK: - Nickname Management
     
     fun setNickname(newNickname: String) {
-        state.setNickname(newNickname)
-        dataManager.saveNickname(newNickname)
+        val capped = capDisplayName(newNickname)
+        state.setNickname(capped)
+        dataManager.saveNickname(capped)
         meshService.sendBroadcastAnnounce()
     }
     

--- a/app/src/main/java/com/bitchat/android/ui/GeohashPeopleList.kt
+++ b/app/src/main/java/com/bitchat/android/ui/GeohashPeopleList.kt
@@ -199,7 +199,8 @@ private fun GeohashPersonItem(
         Spacer(modifier = Modifier.width(8.dp))
         
         // Display name with suffix handling (matches iOS splitSuffix logic)
-        val (baseName, suffix) = com.bitchat.android.ui.splitSuffix(person.displayName)
+        var (baseName, suffix) = com.bitchat.android.ui.splitSuffix(person.displayName)
+        baseName = capDisplayName(baseName)
         
         // Get consistent peer color (matches iOS color assignment exactly)
         val isDark = colorScheme.background.red + colorScheme.background.green + colorScheme.background.blue < 1.5f

--- a/app/src/main/java/com/bitchat/android/ui/GeohashPeopleList.kt
+++ b/app/src/main/java/com/bitchat/android/ui/GeohashPeopleList.kt
@@ -201,6 +201,7 @@ private fun GeohashPersonItem(
         // Display name with suffix handling (matches iOS splitSuffix logic)
         var (baseName, suffix) = com.bitchat.android.ui.splitSuffix(person.displayName)
         baseName = capDisplayName(baseName)
+        Log.d("GeohashPersonItem", "basename = ${baseName}, suffix = ${suffix}")
         
         // Get consistent peer color (matches iOS color assignment exactly)
         val isDark = colorScheme.background.red + colorScheme.background.green + colorScheme.background.blue < 1.5f

--- a/app/src/main/java/com/bitchat/android/ui/InputComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/InputComponents.kt
@@ -171,41 +171,43 @@ fun MessageInput(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        // Text input with placeholder
+        val counterReservedWidth = 56.dp
         Box(
-            modifier = Modifier.weight(1f)
-        ) {
-        // Handle max length for input (visual + logical)
-        val cappedValue = if (value.text.length > MAX_MESSAGE_LENGTH) {
-            value.copy(text = value.text.take(MAX_MESSAGE_LENGTH), selection = androidx.compose.ui.text.TextRange(MAX_MESSAGE_LENGTH))
-        } else value
-        BasicTextField(
-            value = cappedValue,
-            onValueChange = { newValue ->
-                val limited = if (newValue.text.length > MAX_MESSAGE_LENGTH) {
-                    newValue.copy(text = newValue.text.take(MAX_MESSAGE_LENGTH), selection = androidx.compose.ui.text.TextRange(MAX_MESSAGE_LENGTH))
-                } else newValue
-                onValueChange(limited)
-            },
-            textStyle = MaterialTheme.typography.bodyMedium.copy(
-                color = colorScheme.primary,
-                fontFamily = FontFamily.Monospace
-            ),
-            cursorBrush = SolidColor(colorScheme.primary),
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-            keyboardActions = KeyboardActions(onSend = { 
-                if (hasText) onSend() // Only send if there's text
-            }),
-            visualTransformation = CombinedVisualTransformation(
-                listOf(SlashCommandVisualTransformation(), MentionVisualTransformation())
-            ),
             modifier = Modifier
-                .fillMaxWidth()
-                .onFocusChanged { focusState ->
-                    isFocused.value = focusState.isFocused
-                }
-        )
-            
+                .weight(1f)
+        ) {
+            // Handle max length for input (visual + logical)
+            val cappedValue = if (value.text.length > MAX_MESSAGE_LENGTH) {
+                value.copy(text = value.text.take(MAX_MESSAGE_LENGTH), selection = androidx.compose.ui.text.TextRange(MAX_MESSAGE_LENGTH))
+            } else value
+            BasicTextField(
+                value = cappedValue,
+                onValueChange = { newValue ->
+                    val limited = if (newValue.text.length > MAX_MESSAGE_LENGTH) {
+                        newValue.copy(text = newValue.text.take(MAX_MESSAGE_LENGTH), selection = androidx.compose.ui.text.TextRange(MAX_MESSAGE_LENGTH))
+                    } else newValue
+                    onValueChange(limited)
+                },
+                textStyle = MaterialTheme.typography.bodyMedium.copy(
+                    color = colorScheme.primary,
+                    fontFamily = FontFamily.Monospace
+                ),
+                cursorBrush = SolidColor(colorScheme.primary),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                keyboardActions = KeyboardActions(onSend = { 
+                    if (hasText) onSend() // Only send if there's text
+                }),
+                visualTransformation = CombinedVisualTransformation(
+                    listOf(SlashCommandVisualTransformation(), MentionVisualTransformation())
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(end = counterReservedWidth)
+                    .onFocusChanged { focusState ->
+                        isFocused.value = focusState.isFocused
+                    }
+            )
+
             // Show placeholder when there's no text
             if (value.text.isEmpty()) {
                 Text(
@@ -214,7 +216,7 @@ fun MessageInput(
                         fontFamily = FontFamily.Monospace
                     ),
                     color = colorScheme.onSurface.copy(alpha = 0.5f), // Muted grey
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth().padding(end = counterReservedWidth)
                 )
             }
             // Live character counter (always visible)

--- a/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
@@ -54,11 +54,11 @@ class MeshDelegateHandler(
                 // Show notification with enhanced information - now includes senderPeerID 
                 message.senderPeerID?.let { senderPeerID ->
                     // Use nickname if available, fall back to sender or senderPeerID
-                    val senderNickname = message.sender.takeIf { it != senderPeerID } ?: senderPeerID
+                    val senderNickname = capDisplayName(message.sender.takeIf { it != senderPeerID } ?: senderPeerID)
                     notificationManager.showPrivateMessageNotification(
                         senderPeerID = senderPeerID, 
                         senderNickname = senderNickname, 
-                        messageContent = message.content
+                        messageContent = capMessageContent(message.content)
                     )
                 }
             } else if (message.channel != null) {
@@ -227,8 +227,8 @@ class MeshDelegateHandler(
                 android.util.Log.d("MeshDelegateHandler", "🔔 Triggering mesh mention notification from ${message.sender}")
 
                 notificationManager.showMeshMentionNotification(
-                    senderNickname = message.sender,
-                    messageContent = message.content,
+                    senderNickname = capDisplayName(message.sender),
+                    messageContent = capMessageContent(message.content),
                     senderPeerID = message.senderPeerID
                 )
             }

--- a/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
@@ -63,15 +63,17 @@ class MeshDelegateHandler(
                 }
             } else if (message.channel != null) {
                 // Channel message
-                if (state.getJoinedChannelsValue().contains(message.channel)) {
+                if (message.content.length <= MAX_MESSAGE_LENGTH && state.getJoinedChannelsValue().contains(message.channel)) {
                     channelManager.addChannelMessage(message.channel, message, message.senderPeerID)
                 }
             } else {
                 // Public message
-                messageManager.addMessage(message)
+                if (message.content.length <= MAX_MESSAGE_LENGTH) {
+                    messageManager.addMessage(message)
 
-                // Check for mentions in mesh chat
-                checkAndTriggerMeshMentionNotification(message)
+                    // Check for mentions in mesh chat
+                    checkAndTriggerMeshMentionNotification(message)
+                }
             }
             
             // Periodic cleanup

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -185,13 +185,15 @@ private fun MessageTextWithClickableNicknames(
     onMessageLongPress: ((BitchatMessage) -> Unit)?,
     modifier: Modifier = Modifier
 ) {
-    val annotatedText = formatMessageAsAnnotatedString(
-        message = message,
-        currentUserNickname = currentUserNickname,
-        meshService = meshService,
-        colorScheme = colorScheme,
-        timeFormatter = timeFormatter
-    )
+        val safeSender = capDisplayName(message.sender)
+        val safeMessage = capMessageContent(message.content)
+        val annotatedText = formatMessageAsAnnotatedString(
+            message = message.copy(sender = safeSender, content = safeMessage),
+            currentUserNickname = currentUserNickname,
+            meshService = meshService,
+            colorScheme = colorScheme,
+            timeFormatter = timeFormatter
+        )
     
     // Check if this message was sent by self to avoid click interactions on own nickname
     val isSelf = message.senderPeerID == meshService.myPeerID || 

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -185,7 +185,8 @@ private fun MessageTextWithClickableNicknames(
     onMessageLongPress: ((BitchatMessage) -> Unit)?,
     modifier: Modifier = Modifier
 ) {
-        val safeSender = capDisplayName(message.sender)
+    val displaySender = message.originalSender ?: message.sender
+        val safeSender = capDisplayName(displaySender)
         val safeMessage = capMessageContent(message.content)
         val annotatedText = formatMessageAsAnnotatedString(
             message = message.copy(sender = safeSender, content = safeMessage),

--- a/app/src/main/java/com/bitchat/android/ui/MessageManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageManager.kt
@@ -19,6 +19,9 @@ class MessageManager(private val state: ChatState) {
     // MARK: - Public Message Management
     
     fun addMessage(message: BitchatMessage) {
+        if (message.sender != "system" && message.content.length > MAX_MESSAGE_LENGTH) {
+            return
+        }
         val safeMessage = message.copy(
             sender = capDisplayName(message.sender),
             content = capMessageContent(message.content)
@@ -35,6 +38,9 @@ class MessageManager(private val state: ChatState) {
     // MARK: - Channel Message Management
     
     fun addChannelMessage(channel: String, message: BitchatMessage) {
+        if (message.content.length > MAX_MESSAGE_LENGTH) {
+            return
+        }
         val safeMessage = message.copy(
             sender = capDisplayName(message.sender),
             content = capMessageContent(message.content)

--- a/app/src/main/java/com/bitchat/android/ui/MessageManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageManager.kt
@@ -19,8 +19,12 @@ class MessageManager(private val state: ChatState) {
     // MARK: - Public Message Management
     
     fun addMessage(message: BitchatMessage) {
+        val safeMessage = message.copy(
+            sender = capDisplayName(message.sender),
+            content = capMessageContent(message.content)
+        )
         val currentMessages = state.getMessagesValue().toMutableList()
-        currentMessages.add(message)
+        currentMessages.add(safeMessage)
         state.setMessages(currentMessages)
     }
     
@@ -31,13 +35,17 @@ class MessageManager(private val state: ChatState) {
     // MARK: - Channel Message Management
     
     fun addChannelMessage(channel: String, message: BitchatMessage) {
+        val safeMessage = message.copy(
+            sender = capDisplayName(message.sender),
+            content = capMessageContent(message.content)
+        )
         val currentChannelMessages = state.getChannelMessagesValue().toMutableMap()
         if (!currentChannelMessages.containsKey(channel)) {
             currentChannelMessages[channel] = mutableListOf()
         }
         
         val channelMessageList = currentChannelMessages[channel]?.toMutableList() ?: mutableListOf()
-        channelMessageList.add(message)
+        channelMessageList.add(safeMessage)
         currentChannelMessages[channel] = channelMessageList
         state.setChannelMessages(currentChannelMessages)
         
@@ -74,18 +82,22 @@ class MessageManager(private val state: ChatState) {
     // MARK: - Private Message Management
 
     fun addPrivateMessage(peerID: String, message: BitchatMessage) {
+        val safeMessage = message.copy(
+            sender = capDisplayName(message.sender),
+            content = capMessageContent(message.content)
+        )
         val currentPrivateChats = state.getPrivateChatsValue().toMutableMap()
         if (!currentPrivateChats.containsKey(peerID)) {
             currentPrivateChats[peerID] = mutableListOf()
         }
         
         val chatMessages = currentPrivateChats[peerID]?.toMutableList() ?: mutableListOf()
-        chatMessages.add(message)
+        chatMessages.add(safeMessage)
         currentPrivateChats[peerID] = chatMessages
         state.setPrivateChats(currentPrivateChats)
         
         // Mark as unread if not currently viewing this chat
-        if (state.getSelectedPrivateChatPeerValue() != peerID && message.sender != state.getNicknameValue()) {
+        if (state.getSelectedPrivateChatPeerValue() != peerID && safeMessage.sender != state.getNicknameValue()) {
             val currentUnread = state.getUnreadPrivateMessagesValue().toMutableSet()
             currentUnread.add(peerID)
             state.setUnreadPrivateMessages(currentUnread)

--- a/app/src/main/java/com/bitchat/android/ui/PrivateChatManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/PrivateChatManager.kt
@@ -99,8 +99,8 @@ class PrivateChatManager(
         }
 
         val message = BitchatMessage(
-            sender = senderNickname ?: myPeerID,
-            content = content,
+            sender = capDisplayName(senderNickname ?: myPeerID),
+            content = capMessageContent(content),
             timestamp = Date(),
             isRelay = false,
             isPrivate = true,

--- a/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
@@ -335,7 +335,7 @@ fun PeopleSection(
 
             PeerItem(
                 peerID = peerID,
-                displayName = if (peerID == nickname) "You" else (peerNicknames[peerID] ?: (privateChats[peerID]?.lastOrNull()?.sender ?: peerID.take(12))),
+                displayName = capDisplayName(if (peerID == nickname) "You" else (peerNicknames[peerID] ?: (privateChats[peerID]?.lastOrNull()?.sender ?: peerID.take(12)))),
                 signalStrength = convertRSSIToSignalStrength(peerRSSI[peerID]),
                 isSelected = peerID == selectedPrivatePeer,
                 isFavorite = isFavorite,


### PR DESCRIPTION
# Description
- Enforces a maximum limit of 280 char per message, 30 char per display name.
- Message input shows a live “xx/280” counter with currently used chars
- Incoming messages that are larger than 280 character are automatically dropped 
