### PR TITLE
Add warning if network unavailable

### DIFF
--- a/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
@@ -24,6 +24,39 @@ class NostrRelayManager private constructor() {
         val shared = NostrRelayManager()
         
         private const val TAG = "NostrRelayManager"
+        private const val NETWORK_ERROR_MESSAGE = "Network unreachable. Please ensure the device is connected and has all necessary permissions."
+        
+        // Network error callback for reporting failures to UI
+        @Volatile
+        private var networkErrorCallback: ((String) -> Unit)? = null
+        @Volatile
+        private var hasReportedNetworkError = false
+        
+        /**
+         * Set callback for network error reporting
+         * Throws IllegalStateException if a callback is already set
+         */
+        fun setNetworkErrorCallback(callback: (String) -> Unit) {
+            if (networkErrorCallback != null) {
+                throw IllegalStateException("Network error callback already set. Only one service instance should be active.")
+            }
+            networkErrorCallback = callback
+        }
+        
+        /**
+         * Clear the network error callback (should be called when service is destroyed)
+         */
+        fun clearNetworkErrorCallback() {
+            networkErrorCallback = null
+            hasReportedNetworkError = false
+        }
+        
+        /**
+         * Reset network error flag (e.g., when network comes back)
+         */
+        fun resetNetworkErrorFlag() {
+            hasReportedNetworkError = false
+        }
         
         /**
          * Get instance for Android compatibility (context-aware calls)

--- a/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
@@ -677,8 +677,18 @@ class NostrRelayManager private constructor() {
                 val relay = relaysList.find { it.url == relayUrl }
                 relay?.messagesSent = (relay?.messagesSent ?: 0) + 1
                 updateRelaysList()
+                // Reset error flag on successful send
+                hasReportedNetworkError = false
             } else {
                 Log.e(TAG, "❌ Failed to send event to $relayUrl: WebSocket send failed")
+                
+                // Check if all relays are disconnected (likely network issue)
+                if (connections.isEmpty() || relaysList.none { it.isConnected }) {
+                    if (!hasReportedNetworkError) {
+                        hasReportedNetworkError = true
+                        networkErrorCallback?.invoke(NETWORK_ERROR_MESSAGE)
+                    }
+                }
             }
         } catch (e: Exception) {
             Log.e(TAG, "❌ Failed to send event to $relayUrl: ${e.message}")

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -184,6 +184,8 @@ class ChatViewModel(
     
     override fun onCleared() {
         super.onCleared()
+        // Clean up NostrGeohashService
+        nostrGeohashService.cleanup()
         // Note: Mesh service lifecycle is now managed by MainActivity
     }
     


### PR DESCRIPTION
This PR adds a warning if Nostr relays cannot be reached. This resolves https://github.com/permissionlesstech/bitchat-android/issues/322

There are existing build errors on main, so I am unable to test. Happy to test once those are resolved.

[edit] The original issue asks for a permission check. That is not possible, as there is no API to check the network permission. The best we can do is detect disconnection (ALL relays unreachable) and prompt the user to check their connection settings.
