### PR TITLE
Nip13 pow

### DIFF
--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -42,6 +42,7 @@ import com.bitchat.android.ui.ChatViewModel
 import com.bitchat.android.ui.theme.BitchatTheme
 import com.bitchat.android.ui.theme.ThemePreference
 import com.bitchat.android.ui.theme.ThemePreferenceManager
+import com.bitchat.android.nostr.PoWPreferenceManager
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -590,6 +591,10 @@ class MainActivity : ComponentActivity() {
                 delay(1000) // Give the system time to process permission grants
                 
                 Log.d("MainActivity", "Permissions verified, initializing chat system")
+                
+                // Initialize PoW preferences early in the initialization process
+                PoWPreferenceManager.init(this@MainActivity)
+                Log.d("MainActivity", "PoW preferences initialized")
                 
                 // Ensure all permissions are still granted (user might have revoked in settings)
                 if (!permissionManager.areAllPermissionsGranted()) {

--- a/app/src/main/java/com/bitchat/android/model/BitchatMessage.kt
+++ b/app/src/main/java/com/bitchat/android/model/BitchatMessage.kt
@@ -59,7 +59,8 @@ data class BitchatMessage(
     val channel: String? = null,
     val encryptedContent: ByteArray? = null,
     val isEncrypted: Boolean = false,
-    val deliveryStatus: DeliveryStatus? = null
+    val deliveryStatus: DeliveryStatus? = null,
+    val powDifficulty: Int? = null
 ) : Parcelable {
 
     /**

--- a/app/src/main/java/com/bitchat/android/nostr/NostrGeohashService.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrGeohashService.kt
@@ -1156,6 +1156,16 @@ class NostrGeohashService(
                 return@launch
             }
             
+            // Check Proof of Work validation BEFORE other processing
+            val powSettings = PoWPreferenceManager.getCurrentSettings()
+            if (powSettings.enabled && powSettings.difficulty > 0) {
+                if (!NostrProofOfWork.validateDifficulty(event, powSettings.difficulty)) {
+                    Log.w(TAG, "🚫 Rejecting geohash event ${event.id.take(8)}... due to insufficient PoW (required: ${powSettings.difficulty})")
+                    return@launch
+                }
+                Log.v(TAG, "✅ PoW validation passed for event ${event.id.take(8)}...")
+            }
+            
             // Check if this user is blocked in geohash channels BEFORE any processing
             if (isGeohashUserBlocked(event.pubkey)) {
                 Log.v(TAG, "🚫 Skipping event from blocked geohash user: ${event.pubkey.take(8)}...")

--- a/app/src/main/java/com/bitchat/android/nostr/NostrProofOfWork.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrProofOfWork.kt
@@ -1,0 +1,216 @@
+package com.bitchat.android.nostr
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.security.MessageDigest
+import kotlin.random.Random
+
+/**
+ * Nostr Proof of Work (PoW) implementation following NIP-13
+ * 
+ * This implements the Proof of Work system for Nostr events to provide spam deterrence.
+ * The difficulty is defined as the number of leading zero bits in the event ID.
+ * 
+ * Reference: https://github.com/nostr-protocol/nips/blob/master/13.md
+ */
+object NostrProofOfWork {
+    
+    private const val TAG = "NostrProofOfWork"
+    
+    /**
+     * Calculate the difficulty (number of leading zero bits) of an event ID
+     * @param eventIdHex The hexadecimal event ID
+     * @return The number of leading zero bits
+     */
+    fun calculateDifficulty(eventIdHex: String): Int {
+        var count = 0
+        
+        for (i in eventIdHex.indices) {
+            val nibble = eventIdHex[i].toString().toInt(16)
+            if (nibble == 0) {
+                count += 4
+            } else {
+                // Count leading zeros in the nibble
+                count += when (nibble) {
+                    1 -> 3  // 0001
+                    2, 3 -> 2  // 001x
+                    4, 5, 6, 7 -> 1  // 01xx
+                    else -> 0  // 1xxx
+                }
+                break
+            }
+        }
+        
+        return count
+    }
+    
+    /**
+     * Validate that an event meets the minimum difficulty requirement
+     * @param event The Nostr event to validate
+     * @param minimumDifficulty The minimum required difficulty
+     * @return true if the event meets the difficulty requirement
+     */
+    fun validateDifficulty(event: NostrEvent, minimumDifficulty: Int): Boolean {
+        if (minimumDifficulty <= 0) return true
+        
+        val actualDifficulty = calculateDifficulty(event.id)
+        val committedDifficulty = getCommittedDifficulty(event)
+        
+        Log.d(TAG, "Validating PoW: actual=$actualDifficulty, required=$minimumDifficulty, committed=$committedDifficulty")
+        
+        // Check if actual difficulty meets requirement
+        if (actualDifficulty < minimumDifficulty) {
+            Log.w(TAG, "Event ${event.id.take(16)}... has insufficient difficulty: $actualDifficulty < $minimumDifficulty")
+            return false
+        }
+        
+        // If there's a committed difficulty, it should match or exceed the minimum
+        if (committedDifficulty != null && committedDifficulty < minimumDifficulty) {
+            Log.w(TAG, "Event ${event.id.take(16)}... has committed difficulty $committedDifficulty but achieved $actualDifficulty (possible spam)")
+            return false
+        }
+        
+        return true
+    }
+    
+    /**
+     * Mine a Nostr event to achieve the target difficulty
+     * @param event The event to mine (will be modified with nonce tag)
+     * @param targetDifficulty The target difficulty to achieve
+     * @param maxIterations Maximum number of iterations before giving up (default: 1,000,000)
+     * @return The mined event with nonce tag, or null if mining failed
+     */
+    suspend fun mineEvent(
+        event: NostrEvent,
+        targetDifficulty: Int,
+        maxIterations: Int = 1_000_000
+    ): NostrEvent? = withContext(Dispatchers.Default) {
+        if (targetDifficulty <= 0) return@withContext event
+        
+        Log.d(TAG, "Starting PoW mining for difficulty $targetDifficulty...")
+        val startTime = System.currentTimeMillis()
+        
+        var nonce = Random.nextLong(0, 1_000_000).toString()
+        var iterations = 0
+        
+        while (iterations < maxIterations) {
+            // Create a copy of the event with the nonce tag
+            val eventWithNonce = addNonceTag(event, nonce, targetDifficulty)
+            
+            // Calculate the event ID
+            val eventId = eventWithNonce.computeEventIdHex()
+            val actualDifficulty = calculateDifficulty(eventId)
+            
+            if (actualDifficulty >= targetDifficulty) {
+                val timeElapsed = System.currentTimeMillis() - startTime
+                Log.i(TAG, "✅ PoW mining successful! Difficulty: $actualDifficulty, iterations: $iterations, time: ${timeElapsed}ms")
+                
+                // Return the event with the computed ID
+                return@withContext eventWithNonce.copy(id = eventId)
+            }
+            
+            // Increment nonce and try again
+            nonce = (nonce.toLongOrNull()?.plus(1) ?: Random.nextLong()).toString()
+            iterations++
+            
+            // Log progress every 100,000 iterations
+            if (iterations % 100_000 == 0) {
+                val timeElapsed = System.currentTimeMillis() - startTime
+                Log.d(TAG, "PoW mining progress: $iterations iterations, ${timeElapsed}ms elapsed")
+            }
+        }
+        
+        val timeElapsed = System.currentTimeMillis() - startTime
+        Log.w(TAG, "❌ PoW mining failed after $maxIterations iterations (${timeElapsed}ms)")
+        return@withContext null
+    }
+    
+    /**
+     * Add or update the nonce tag in an event
+     * @param event The original event
+     * @param nonce The nonce value
+     * @param targetDifficulty The target difficulty being attempted
+     * @return A new event with the nonce tag added/updated
+     */
+    private fun addNonceTag(event: NostrEvent, nonce: String, targetDifficulty: Int): NostrEvent {
+        val newTags = event.tags.toMutableList()
+        
+        // Remove existing nonce tag if present
+        newTags.removeAll { tag -> tag.isNotEmpty() && tag[0] == "nonce" }
+        
+        // Add new nonce tag with format: ["nonce", nonce_value, target_difficulty]
+        newTags.add(listOf("nonce", nonce, targetDifficulty.toString()))
+        
+        // Update created_at as recommended by NIP-13
+        val updatedCreatedAt = (System.currentTimeMillis() / 1000).toInt()
+        
+        return event.copy(
+            tags = newTags,
+            createdAt = updatedCreatedAt
+        )
+    }
+    
+    /**
+     * Get the committed difficulty from an event's nonce tag
+     * @param event The event to check
+     * @return The committed difficulty, or null if not present
+     */
+    private fun getCommittedDifficulty(event: NostrEvent): Int? {
+        val nonceTag = event.tags.find { tag -> 
+            tag.isNotEmpty() && tag[0] == "nonce" && tag.size >= 3 
+        }
+        
+        return nonceTag?.get(2)?.toIntOrNull()
+    }
+    
+    /**
+     * Check if an event has a nonce tag (indicating it was mined)
+     * @param event The event to check
+     * @return true if the event has a nonce tag
+     */
+    fun hasNonce(event: NostrEvent): Boolean {
+        return event.tags.any { tag -> tag.isNotEmpty() && tag[0] == "nonce" }
+    }
+    
+    /**
+     * Get the nonce value from an event
+     * @param event The event to check
+     * @return The nonce value, or null if not present
+     */
+    fun getNonce(event: NostrEvent): String? {
+        val nonceTag = event.tags.find { tag -> 
+            tag.isNotEmpty() && tag[0] == "nonce" && tag.size >= 2 
+        }
+        
+        return nonceTag?.get(1)
+    }
+    
+    /**
+     * Estimate the computational work required for a given difficulty
+     * @param difficulty The target difficulty
+     * @return Estimated number of hash operations required
+     */
+    fun estimateWork(difficulty: Int): Long {
+        return if (difficulty <= 0) 1L else 1L shl difficulty
+    }
+    
+    /**
+     * Get a human-readable description of the estimated mining time
+     * @param difficulty The target difficulty
+     * @param hashesPerSecond Estimated hashes per second (default: 100,000)
+     * @return Human-readable time estimate
+     */
+    fun estimateMiningTime(difficulty: Int, hashesPerSecond: Int = 100_000): String {
+        val estimatedHashes = estimateWork(difficulty)
+        val estimatedSeconds = estimatedHashes / hashesPerSecond
+        
+        return when {
+            estimatedSeconds < 1 -> "< 1 second"
+            estimatedSeconds < 60 -> "${estimatedSeconds}s"
+            estimatedSeconds < 3600 -> "${estimatedSeconds / 60}m ${estimatedSeconds % 60}s"
+            estimatedSeconds < 86400 -> "${estimatedSeconds / 3600}h ${(estimatedSeconds % 3600) / 60}m"
+            else -> "${estimatedSeconds / 86400}d ${(estimatedSeconds % 86400) / 3600}h"
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/nostr/NostrProtocol.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrProtocol.kt
@@ -3,6 +3,8 @@ package com.bitchat.android.nostr
 import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.JsonParser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * NIP-17 Protocol Implementation for Private Direct Messages
@@ -90,14 +92,15 @@ object NostrProtocol {
     
     /**
      * Create a geohash-scoped ephemeral public message (kind 20000)
+     * Includes Proof of Work mining if enabled in settings
      */
-    fun createEphemeralGeohashEvent(
+    suspend fun createEphemeralGeohashEvent(
         content: String,
         geohash: String,
         senderIdentity: NostrIdentity,
         nickname: String? = null,
         teleported: Boolean = false
-    ): NostrEvent {
+    ): NostrEvent = withContext(Dispatchers.Default) {
         val tags = mutableListOf<List<String>>()
         tags.add(listOf("g", geohash))
         
@@ -110,7 +113,7 @@ object NostrProtocol {
             tags.add(listOf("t", "teleport"))
         }
         
-        val event = NostrEvent(
+        var event = NostrEvent(
             pubkey = senderIdentity.publicKeyHex,
             createdAt = (System.currentTimeMillis() / 1000).toInt(),
             kind = NostrKind.EPHEMERAL_EVENT,
@@ -118,7 +121,28 @@ object NostrProtocol {
             content = content
         )
         
-        return senderIdentity.signEvent(event)
+        // Check if Proof of Work is enabled
+        val powSettings = PoWPreferenceManager.getCurrentSettings()
+        if (powSettings.enabled && powSettings.difficulty > 0) {
+            Log.d(TAG, "PoW enabled for geohash event: difficulty=${powSettings.difficulty}")
+            
+            // Mine the event before signing
+            val minedEvent = NostrProofOfWork.mineEvent(
+                event = event,
+                targetDifficulty = powSettings.difficulty,
+                maxIterations = 2_000_000 // Allow up to 2M iterations for reasonable mining time
+            )
+            
+            if (minedEvent != null) {
+                event = minedEvent
+                val actualDifficulty = NostrProofOfWork.calculateDifficulty(event.id)
+                Log.d(TAG, "✅ PoW mining successful: target=${powSettings.difficulty}, actual=$actualDifficulty, nonce=${NostrProofOfWork.getNonce(event)}")
+            } else {
+                Log.w(TAG, "❌ PoW mining failed, proceeding without PoW")
+            }
+        }
+        
+        return@withContext senderIdentity.signEvent(event)
     }
     
     // MARK: - Private Methods

--- a/app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
@@ -16,7 +16,7 @@ object PoWPreferenceManager {
     private const val KEY_POW_DIFFICULTY = "pow_difficulty"
     
     // Default values
-    private const val DEFAULT_POW_ENABLED = false
+    private const val DEFAULT_POW_ENABLED = true
     private const val DEFAULT_POW_DIFFICULTY = 10 // Reasonable default for geohash spam prevention
     
     // State flows for reactive UI

--- a/app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
@@ -1,0 +1,124 @@
+package com.bitchat.android.nostr
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Manages Proof of Work preferences for Nostr events
+ */
+object PoWPreferenceManager {
+    
+    private const val PREFS_NAME = "pow_preferences"
+    private const val KEY_POW_ENABLED = "pow_enabled"
+    private const val KEY_POW_DIFFICULTY = "pow_difficulty"
+    
+    // Default values
+    private const val DEFAULT_POW_ENABLED = false
+    private const val DEFAULT_POW_DIFFICULTY = 16 // Reasonable default for geohash spam prevention
+    
+    // State flows for reactive UI
+    private val _powEnabled = MutableStateFlow(DEFAULT_POW_ENABLED)
+    val powEnabled: StateFlow<Boolean> = _powEnabled.asStateFlow()
+    
+    private val _powDifficulty = MutableStateFlow(DEFAULT_POW_DIFFICULTY)
+    val powDifficulty: StateFlow<Int> = _powDifficulty.asStateFlow()
+    
+    private lateinit var sharedPrefs: SharedPreferences
+    private var isInitialized = false
+    
+    /**
+     * Initialize the preference manager with application context
+     * Should be called once during app startup
+     */
+    fun init(context: Context) {
+        if (isInitialized) return
+        
+        sharedPrefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        
+        // Load current values
+        _powEnabled.value = sharedPrefs.getBoolean(KEY_POW_ENABLED, DEFAULT_POW_ENABLED)
+        _powDifficulty.value = sharedPrefs.getInt(KEY_POW_DIFFICULTY, DEFAULT_POW_DIFFICULTY)
+        
+        isInitialized = true
+    }
+    
+    /**
+     * Get current PoW enabled state
+     */
+    fun isPowEnabled(): Boolean {
+        return _powEnabled.value
+    }
+    
+    /**
+     * Set PoW enabled state
+     */
+    fun setPowEnabled(enabled: Boolean) {
+        _powEnabled.value = enabled
+        if (::sharedPrefs.isInitialized) {
+            sharedPrefs.edit().putBoolean(KEY_POW_ENABLED, enabled).apply()
+        }
+    }
+    
+    /**
+     * Get current PoW difficulty setting
+     */
+    fun getPowDifficulty(): Int {
+        return _powDifficulty.value
+    }
+    
+    /**
+     * Set PoW difficulty (clamped between 0 and 32)
+     */
+    fun setPowDifficulty(difficulty: Int) {
+        val clampedDifficulty = difficulty.coerceIn(0, 32)
+        _powDifficulty.value = clampedDifficulty
+        if (::sharedPrefs.isInitialized) {
+            sharedPrefs.edit().putInt(KEY_POW_DIFFICULTY, clampedDifficulty).apply()
+        }
+    }
+    
+    /**
+     * Get current settings as a data class
+     */
+    data class PoWSettings(
+        val enabled: Boolean,
+        val difficulty: Int
+    )
+    
+    /**
+     * Get current settings
+     */
+    fun getCurrentSettings(): PoWSettings {
+        return PoWSettings(
+            enabled = _powEnabled.value,
+            difficulty = _powDifficulty.value
+        )
+    }
+    
+    /**
+     * Reset to default settings
+     */
+    fun resetToDefaults() {
+        setPowEnabled(DEFAULT_POW_ENABLED)
+        setPowDifficulty(DEFAULT_POW_DIFFICULTY)
+    }
+    
+    /**
+     * Get difficulty levels with descriptions for UI
+     */
+    fun getDifficultyLevels(): List<Pair<Int, String>> {
+        return listOf(
+            0 to "Disabled (no PoW)",
+            8 to "Very Low (instant)",
+            12 to "Low (~0.1s)",
+            16 to "Medium (~2s)",
+            20 to "High (~30s)",
+            24 to "Very High (~8m)",
+            28 to "Extreme (~2h)",
+            32 to "Maximum (~8h)"
+        )
+    }
+}

--- a/app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
@@ -26,6 +26,10 @@ object PoWPreferenceManager {
     private val _powDifficulty = MutableStateFlow(DEFAULT_POW_DIFFICULTY)
     val powDifficulty: StateFlow<Int> = _powDifficulty.asStateFlow()
     
+    // Mining state for animated indicators
+    private val _isMining = MutableStateFlow(false)
+    val isMining: StateFlow<Boolean> = _isMining.asStateFlow()
+    
     private lateinit var sharedPrefs: SharedPreferences
     private var isInitialized = false
     
@@ -120,5 +124,26 @@ object PoWPreferenceManager {
             28 to "Extreme (~2h)",
             32 to "Maximum (~8h)"
         )
+    }
+    
+    /**
+     * Get current mining state
+     */
+    fun isMining(): Boolean {
+        return _isMining.value
+    }
+    
+    /**
+     * Start mining state - triggers animated indicators
+     */
+    fun startMining() {
+        _isMining.value = true
+    }
+    
+    /**
+     * Stop mining state - stops animated indicators
+     */
+    fun stopMining() {
+        _isMining.value = false
     }
 }

--- a/app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
@@ -17,7 +17,7 @@ object PoWPreferenceManager {
     
     // Default values
     private const val DEFAULT_POW_ENABLED = false
-    private const val DEFAULT_POW_DIFFICULTY = 16 // Reasonable default for geohash spam prevention
+    private const val DEFAULT_POW_DIFFICULTY = 10 // Reasonable default for geohash spam prevention
     
     // State flows for reactive UI
     private val _powEnabled = MutableStateFlow(DEFAULT_POW_ENABLED)

--- a/app/src/main/java/com/bitchat/android/ui/AboutSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/AboutSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -20,6 +21,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.bitchat.android.nostr.NostrProofOfWork
+import com.bitchat.android.nostr.PoWPreferenceManager
 
 /**
  * About Sheet for bitchat app information
@@ -164,6 +167,136 @@ fun AboutSheet(
                                 onClick = { com.bitchat.android.ui.theme.ThemePreferenceManager.set(context, com.bitchat.android.ui.theme.ThemePreference.Dark) },
                                 label = { Text("dark", fontFamily = FontFamily.Monospace) }
                             )
+                        }
+                    }
+                }
+
+                // Proof of Work section
+                item {
+                    val context = LocalContext.current
+                    
+                    // Initialize PoW preferences if not already done
+                    LaunchedEffect(Unit) {
+                        PoWPreferenceManager.init(context)
+                    }
+                    
+                    val powEnabled by PoWPreferenceManager.powEnabled.collectAsState()
+                    val powDifficulty by PoWPreferenceManager.powDifficulty.collectAsState()
+                    
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = "proof of work",
+                            fontSize = 12.sp,
+                            fontFamily = FontFamily.Monospace,
+                            fontWeight = FontWeight.Medium,
+                            color = colorScheme.onSurface.copy(alpha = 0.8f)
+                        )
+                        
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            FilterChip(
+                                selected = !powEnabled,
+                                onClick = { PoWPreferenceManager.setPowEnabled(false) },
+                                label = { Text("pow off", fontFamily = FontFamily.Monospace) }
+                            )
+                            FilterChip(
+                                selected = powEnabled,
+                                onClick = { PoWPreferenceManager.setPowEnabled(true) },
+                                label = { 
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Text("pow on", fontFamily = FontFamily.Monospace)
+                                        // Show current difficulty
+                                        if (powEnabled) {
+                                            Surface(
+                                                color = if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D),
+                                                shape = RoundedCornerShape(50)
+                                            ) { 
+                                                Text(
+                                                    text = "$powDifficulty",
+                                                    fontSize = 9.sp,
+                                                    fontFamily = FontFamily.Monospace,
+                                                    color = Color.White,
+                                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            )
+                        }
+                        
+                        Text(
+                            text = "add computational proof of work to geohash messages for spam deterrence.",
+                            fontSize = 10.sp,
+                            fontFamily = FontFamily.Monospace,
+                            color = colorScheme.onSurface.copy(alpha = 0.6f)
+                        )
+                        
+                        // Show difficulty slider when enabled
+                        if (powEnabled) {
+                            Column(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Text(
+                                    text = "difficulty: $powDifficulty bits (~${NostrProofOfWork.estimateMiningTime(powDifficulty)})",
+                                    fontSize = 11.sp,
+                                    fontFamily = FontFamily.Monospace,
+                                    color = colorScheme.onSurface.copy(alpha = 0.7f)
+                                )
+                                
+                                Slider(
+                                    value = powDifficulty.toFloat(),
+                                    onValueChange = { PoWPreferenceManager.setPowDifficulty(it.toInt()) },
+                                    valueRange = 0f..32f,
+                                    steps = 31, // 32 discrete values (0-32)
+                                    colors = SliderDefaults.colors(
+                                        thumbColor = if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D),
+                                        activeTrackColor = if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D)
+                                    )
+                                )
+                                
+                                // Show difficulty description
+                                Surface(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    color = colorScheme.surfaceVariant.copy(alpha = 0.25f),
+                                    shape = RoundedCornerShape(8.dp)
+                                ) {
+                                    Column(
+                                        modifier = Modifier.padding(12.dp),
+                                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                                    ) {
+                                        Text(
+                                            text = "difficulty $powDifficulty requires ~${NostrProofOfWork.estimateWork(powDifficulty)} hash attempts",
+                                            fontSize = 10.sp,
+                                            fontFamily = FontFamily.Monospace,
+                                            color = colorScheme.onSurface.copy(alpha = 0.7f)
+                                        )
+                                        Text(
+                                            text = when {
+                                                powDifficulty == 0 -> "no proof of work required"
+                                                powDifficulty <= 8 -> "very low - minimal spam protection"
+                                                powDifficulty <= 12 -> "low - basic spam protection"
+                                                powDifficulty <= 16 -> "medium - good spam protection"
+                                                powDifficulty <= 20 -> "high - strong spam protection"
+                                                powDifficulty <= 24 -> "very high - may cause delays"
+                                                else -> "extreme - significant computation required"
+                                            },
+                                            fontSize = 10.sp,
+                                            fontFamily = FontFamily.Monospace,
+                                            color = colorScheme.onSurface.copy(alpha = 0.6f)
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/bitchat/android/ui/AboutSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/AboutSheet.kt
@@ -226,7 +226,7 @@ fun AboutSheet(
                         }
                         
                         Text(
-                            text = "add computational proof of work to geohash messages for spam deterrence.",
+                            text = "add proof of work to geohash messages for spam deterrence.",
                             fontSize = 10.sp,
                             fontFamily = FontFamily.Monospace,
                             color = colorScheme.onSurface.copy(alpha = 0.6f)

--- a/app/src/main/java/com/bitchat/android/ui/AboutSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/AboutSheet.kt
@@ -218,15 +218,7 @@ fun AboutSheet(
                                             Surface(
                                                 color = if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D),
                                                 shape = RoundedCornerShape(50)
-                                            ) { 
-                                                Text(
-                                                    text = "$powDifficulty",
-                                                    fontSize = 9.sp,
-                                                    fontFamily = FontFamily.Monospace,
-                                                    color = Color.White,
-                                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
-                                                )
-                                            }
+                                            ) { Box(Modifier.size(8.dp)) }
                                         }
                                     }
                                 }
@@ -256,8 +248,8 @@ fun AboutSheet(
                                 Slider(
                                     value = powDifficulty.toFloat(),
                                     onValueChange = { PoWPreferenceManager.setPowDifficulty(it.toInt()) },
-                                    valueRange = 0f..32f,
-                                    steps = 31, // 32 discrete values (0-32)
+                                    valueRange = 0f..20f,
+                                    steps = 21, // 20 discrete values (0-20)
                                     colors = SliderDefaults.colors(
                                         thumbColor = if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D),
                                         activeTrackColor = if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D)

--- a/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
@@ -571,6 +571,12 @@ private fun MainHeader(
 
             // Tor status cable icon when Tor is enabled
             TorStatusIcon(modifier = Modifier.size(14.dp))
+            
+            // PoW status indicator
+            PoWStatusIndicator(
+                modifier = Modifier,
+                style = PoWIndicatorStyle.COMPACT
+            )
 
             PeerCounter(
                 connectedPeers = connectedPeers.filter { it != viewModel.meshService.myPeerID },

--- a/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
@@ -124,11 +124,11 @@ fun formatMessageAsAnnotatedString(
         ))
         builder.append(" [${timeFormatter.format(message.timestamp)}]")
         // If message has valid PoW difficulty, append bits immediately after timestamp with minimal spacing
-        message.powDifficulty?.let { bits ->
-            if (bits > 0) {
-                builder.append(" ${bits}b")
-            }
-        }
+        //message.powDifficulty?.let { bits ->
+        //    if (bits > 0) {
+        //        builder.append(" ${bits}b")
+        //    }
+        //}
         builder.pop()
         
     } else {

--- a/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
@@ -117,11 +117,18 @@ fun formatMessageAsAnnotatedString(
         appendIOSFormattedContent(builder, message.content, message.mentions, currentUserNickname, baseColor, isSelf, isDark)
         
         // iOS-style timestamp at the END (smaller, grey)
+        // Timestamp (and optional PoW badge)
         builder.pushStyle(SpanStyle(
             color = Color.Gray.copy(alpha = 0.7f),
             fontSize = (BASE_FONT_SIZE - 4).sp
         ))
         builder.append(" [${timeFormatter.format(message.timestamp)}]")
+        // If message has valid PoW difficulty, append bits immediately after timestamp with minimal spacing
+        message.powDifficulty?.let { bits ->
+            if (bits > 0) {
+                builder.append(" ${bits}b")
+            }
+        }
         builder.pop()
         
     } else {

--- a/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
@@ -282,14 +282,23 @@ private fun AnimatedMessageDisplay(
     // Create a temporary message with animated content for formatting
     val animatedMessage = message.copy(content = animatedContent)
     
-    // Use the EXACT same formatting function as normal messages, including timestamp
-    val annotatedText = formatMessageAsAnnotatedString(
-        message = animatedMessage,
-        currentUserNickname = currentUserNickname,
-        meshService = meshService,
-        colorScheme = colorScheme,
-        timeFormatter = timeFormatter
-    )
+    // Use formatting function without timestamp during animation
+    val annotatedText = if (isAnimating) {
+        formatMessageAsAnnotatedStringWithoutTimestamp(
+            message = animatedMessage,
+            currentUserNickname = currentUserNickname,
+            meshService = meshService,
+            colorScheme = colorScheme
+        )
+    } else {
+        formatMessageAsAnnotatedString(
+            message = animatedMessage,
+            currentUserNickname = currentUserNickname,
+            meshService = meshService,
+            colorScheme = colorScheme,
+            timeFormatter = timeFormatter
+        )
+    }
     
     // Use IDENTICAL Text composable structure as normal message
     Text(
@@ -305,3 +314,40 @@ private fun AnimatedMessageDisplay(
 }
 
 
+/**
+ * Format message without timestamp and PoW badge for animation phase
+ * Identical to formatMessageAsAnnotatedString but excludes timestamp and PoW badge
+ */
+private fun formatMessageAsAnnotatedStringWithoutTimestamp(
+    message: com.bitchat.android.model.BitchatMessage,
+    currentUserNickname: String,
+    meshService: com.bitchat.android.mesh.BluetoothMeshService,
+    colorScheme: androidx.compose.material3.ColorScheme
+): AnnotatedString {
+    // Get the full formatted text first
+    val timeFormatter = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.getDefault())
+    val fullText = formatMessageAsAnnotatedString(
+        message = message,
+        currentUserNickname = currentUserNickname,
+        meshService = meshService,
+        colorScheme = colorScheme,
+        timeFormatter = timeFormatter
+    )
+    
+    // Find and remove the timestamp and PoW badge at the end
+    val text = fullText.text
+    val timestampPattern = """ \[\d{2}:\d{2}:\d{2}].*$""".toRegex() // Matches " [HH:mm:ss] 12b" or just " [HH:mm:ss]"
+    val match = timestampPattern.find(text)
+    
+    return if (match != null) {
+        // Remove timestamp and PoW portion
+        val endIndex = match.range.first
+        AnnotatedString(
+            text = text.substring(0, endIndex),
+            spanStyles = fullText.spanStyles.filter { it.end <= endIndex },
+            paragraphStyles = fullText.paragraphStyles.filter { it.end <= endIndex }
+        )
+    } else {
+        fullText
+    }
+}

--- a/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
@@ -1,0 +1,275 @@
+package com.bitchat.android.ui
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.TextUnit
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.random.Random
+
+/**
+ * Matrix-style encryption animation for messages during PoW computation
+ * Animates message content with random characters that gradually resolve to real text
+ */
+@Composable
+fun AnimatedMatrixText(
+    targetText: String,
+    isAnimating: Boolean,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null
+) {
+    // Animation state for each character
+    var animatedText by remember(targetText) { mutableStateOf(targetText) }
+    var characterStates by remember(targetText) { mutableStateOf(
+        targetText.indices.map { CharacterAnimationState.ENCRYPTED }.toList()
+    ) }
+    
+    // Start animation when isAnimating becomes true
+    LaunchedEffect(isAnimating, targetText) {
+        if (isAnimating && targetText.isNotEmpty()) {
+            // Reset character states for new animation
+            characterStates = targetText.indices.map { CharacterAnimationState.ENCRYPTED }.toList()
+            
+            // Animate all characters in parallel with staggered start times
+            targetText.forEachIndexed { index, targetChar ->
+                launch { // Use the LaunchedEffect's CoroutineScope
+                    // Stagger character animations (50ms per character like the JS example)
+                    delay(index * 50L)
+                    
+                    animateCharacter(
+                        index = index,
+                        targetChar = targetChar,
+                        currentText = { animatedText },
+                        updateText = { newText -> animatedText = newText },
+                        updateState = { newStates -> characterStates = newStates }
+                    )
+                }
+            }
+        } else {
+            // Not animating, show final text immediately
+            animatedText = targetText
+            characterStates = targetText.indices.map { CharacterAnimationState.FINAL }.toList()
+        }
+    }
+    
+    // Build annotated string with proper styling for each character state
+    val styledText = buildAnnotatedString {
+        animatedText.forEachIndexed { index, char ->
+            val state = characterStates.getOrNull(index) ?: CharacterAnimationState.FINAL
+            val charColor = when (state) {
+                CharacterAnimationState.ENCRYPTED -> Color(0xFF00FF41) // Matrix green
+                CharacterAnimationState.DECRYPTING -> Color(0xFFFFFF41) // Yellow transition
+                CharacterAnimationState.FINAL -> color
+            }
+            
+            withStyle(
+                style = SpanStyle(
+                    color = charColor,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = if (state == CharacterAnimationState.ENCRYPTED) FontWeight.Bold else fontWeight
+                )
+            ) {
+                append(char)
+            }
+        }
+    }
+    
+    Text(
+        text = styledText,
+        modifier = modifier,
+        fontSize = fontSize,
+        fontFamily = FontFamily.Monospace
+    )
+}
+
+/**
+ * Animation state for individual characters
+ */
+private enum class CharacterAnimationState {
+    ENCRYPTED,    // Showing random encrypted characters
+    DECRYPTING,   // Transitioning to final character
+    FINAL         // Showing final decrypted character
+}
+
+/**
+ * Animate a single character from encrypted to final state
+ */
+private suspend fun animateCharacter(
+    index: Int,
+    targetChar: Char,
+    currentText: () -> String,
+    updateText: (String) -> Unit,
+    updateState: (List<CharacterAnimationState>) -> Unit
+) {
+    val encryptedChars = "!@#$%^&*()_+-=[]{}|;:,.<>?~`".toCharArray()
+    val animationDuration = Random.nextLong(1000, 3000) // 1-3 seconds of encryption
+    val startTime = System.currentTimeMillis()
+    
+    // Phase 1: Animate with random encrypted characters
+    while (System.currentTimeMillis() - startTime < animationDuration) {
+        val randomChar = encryptedChars[Random.nextInt(encryptedChars.size)]
+        
+        // Update the character at this index
+        val text = currentText()
+        if (index < text.length) {
+            val newText = text.toCharArray()
+            newText[index] = randomChar
+            updateText(String(newText))
+        }
+        
+        delay(100) // Change character every 100ms
+    }
+    
+    // Phase 2: Brief transition state (yellow)
+    val states = currentText().indices.map { i ->
+        when {
+            i == index -> CharacterAnimationState.DECRYPTING
+            i < index -> CharacterAnimationState.FINAL  // Already revealed
+            else -> CharacterAnimationState.ENCRYPTED   // Still encrypted
+        }
+    }
+    updateState(states)
+    delay(200) // Brief yellow flash
+    
+    // Phase 3: Reveal final character
+    val text = currentText()
+    if (index < text.length) {
+        val newText = text.toCharArray()
+        newText[index] = targetChar
+        updateText(String(newText))
+        
+        val finalStates = currentText().indices.map { i ->
+            when {
+                i <= index -> CharacterAnimationState.FINAL
+                else -> CharacterAnimationState.ENCRYPTED
+            }
+        }
+        updateState(finalStates)
+    }
+}
+
+/**
+ * Check if a message should be animated based on its mining state
+ */
+@Composable
+fun shouldAnimateMessage(messageId: String): Boolean {
+    val miningMessages by PoWMiningTracker.miningMessages.collectAsState()
+    return miningMessages.contains(messageId)
+}
+
+/**
+ * Tracks which messages are currently being mined for PoW
+ * Provides reactive state for UI animations
+ */
+object PoWMiningTracker {
+    private val _miningMessages = MutableStateFlow<Set<String>>(emptySet())
+    val miningMessages: StateFlow<Set<String>> = _miningMessages.asStateFlow()
+    
+    /**
+     * Start tracking a message as mining
+     */
+    fun startMiningMessage(messageId: String) {
+        _miningMessages.value = _miningMessages.value + messageId
+    }
+    
+    /**
+     * Stop tracking a message as mining
+     */
+    fun stopMiningMessage(messageId: String) {
+        _miningMessages.value = _miningMessages.value - messageId
+    }
+    
+    /**
+     * Check if a message is currently mining
+     */
+    fun isMiningMessage(messageId: String): Boolean {
+        return _miningMessages.value.contains(messageId)
+    }
+    
+    /**
+     * Clear all mining messages (for cleanup)
+     */
+    fun clearAllMining() {
+        _miningMessages.value = emptySet()
+    }
+}
+
+/**
+ * Enhanced message display that shows matrix animation during PoW mining
+ * This version integrates with the full message display system
+ */
+@Composable
+fun MessageWithMatrixAnimation(
+    message: com.bitchat.android.model.BitchatMessage,
+    currentUserNickname: String,
+    meshService: com.bitchat.android.mesh.BluetoothMeshService,
+    colorScheme: androidx.compose.material3.ColorScheme,
+    timeFormatter: java.text.SimpleDateFormat,
+    onNicknameClick: ((String) -> Unit)?,
+    onMessageLongPress: ((com.bitchat.android.model.BitchatMessage) -> Unit)?,
+    modifier: Modifier = Modifier
+) {
+    // For simplicity, just animate the entire message content
+    val baseAnnotatedText = formatMessageAsAnnotatedString(
+        message = message,
+        currentUserNickname = currentUserNickname,
+        meshService = meshService,
+        colorScheme = colorScheme,
+        timeFormatter = timeFormatter
+    )
+    
+    // Use matrix animation only for the content
+    AnimatedMatrixText(
+        targetText = message.content,
+        isAnimating = shouldAnimateMessage(message.id),
+        color = colorScheme.onSurface,
+        fontSize = TextUnit.Unspecified,
+        fontWeight = if (message.sender == currentUserNickname || message.sender.startsWith("$currentUserNickname#")) {
+            FontWeight.Bold
+        } else {
+            null
+        },
+        modifier = modifier
+    )
+}
+
+/**
+ * Find the start index of the message content (after timestamp and sender)
+ */
+private fun findContentStartIndex(messageText: String): Int {
+    // Look for pattern like "] <@sender> " to find where content starts
+    val pattern = """] <[^>]+> """.toRegex()
+    val match = pattern.find(messageText)
+    return match?.range?.last?.plus(1) ?: -1
+}
+
+/**
+ * Find the end index of the message content (before final timestamp)
+ */
+private fun findContentEndIndex(messageText: String): Int {
+    // Look for pattern like " [HH:mm:ss]" at the end
+    val pattern = """ \[\d{2}:\d{2}:\d{2}]$""".toRegex()
+    val match = pattern.find(messageText)
+    return match?.range?.first ?: messageText.length
+}

--- a/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
@@ -337,7 +337,11 @@ private fun AnimatedMessageDisplay(
         text = annotatedText,
         modifier = modifier,
         fontFamily = FontFamily.Monospace,
-        softWrap = true
+        softWrap = true,
+        overflow = androidx.compose.ui.text.style.TextOverflow.Visible,
+        style = androidx.compose.ui.text.TextStyle(
+            color = colorScheme.onSurface
+        )
     )
 }
 

--- a/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
@@ -303,7 +303,7 @@ private fun AnimatedMessageDisplay(
                 text = buildAnnotatedString {
                     withStyle(SpanStyle(
                         color = baseColor,
-                        fontSize = com.bitchat.android.ui.theme.BASE_FONT_SIZE.sp,
+                        fontSize = 15.sp, // Use BASE_FONT_SIZE directly
                         fontWeight = if (isSelf) FontWeight.Bold else FontWeight.Medium
                     )) {
                         append("<@")
@@ -319,26 +319,18 @@ private fun AnimatedMessageDisplay(
                 fontFamily = FontFamily.Monospace
             )
             
-            // Animated content portion
+            // Animated content portion (no timestamp during animation)
             AnimatedMatrixText(
                 targetText = message.content,
                 isAnimating = true,
                 color = baseColor,
-                fontSize = com.bitchat.android.ui.theme.BASE_FONT_SIZE.sp,
+                fontSize = 15.sp, // Use BASE_FONT_SIZE directly (15sp)
                 fontWeight = if (isSelf) FontWeight.Bold else FontWeight.Normal,
                 modifier = Modifier.weight(1f)
             )
-            
-            // Timestamp at the end (iOS style)
-            Text(
-                text = " [${timeFormatter.format(message.timestamp)}]",
-                color = Color.Gray.copy(alpha = 0.7f),
-                fontSize = (com.bitchat.android.ui.theme.BASE_FONT_SIZE - 4).sp,
-                fontFamily = FontFamily.Monospace
-            )
         }
     } else {
-        // System message with animation
+        // System message with animation (no timestamp during animation)
         Row(
             modifier = modifier,
             verticalAlignment = androidx.compose.ui.Alignment.Top
@@ -346,7 +338,7 @@ private fun AnimatedMessageDisplay(
             Text(
                 text = "* ",
                 color = Color.Gray,
-                fontSize = (com.bitchat.android.ui.theme.BASE_FONT_SIZE - 2).sp,
+                fontSize = 13.sp, // (BASE_FONT_SIZE - 2).sp = 13sp
                 fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
                 fontFamily = FontFamily.Monospace
             )
@@ -355,14 +347,15 @@ private fun AnimatedMessageDisplay(
                 targetText = message.content,
                 isAnimating = true,
                 color = Color.Gray,
-                fontSize = (com.bitchat.android.ui.theme.BASE_FONT_SIZE - 2).sp,
+                fontSize = 13.sp, // (BASE_FONT_SIZE - 2).sp = 13sp
                 modifier = Modifier.weight(1f)
             )
             
             Text(
-                text = " * [${timeFormatter.format(message.timestamp)}]",
-                color = Color.Gray.copy(alpha = 0.5f),
-                fontSize = (com.bitchat.android.ui.theme.BASE_FONT_SIZE - 4).sp,
+                text = " *",
+                color = Color.Gray,
+                fontSize = 13.sp, // (BASE_FONT_SIZE - 2).sp = 13sp
+                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
                 fontFamily = FontFamily.Monospace
             )
         }

--- a/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
@@ -323,23 +323,14 @@ private fun AnimatedMessageDisplay(
     // Create a temporary message with animated content for formatting
     val animatedMessage = message.copy(content = animatedContent)
     
-    // Use the EXACT same formatting function as normal messages, but without timestamp during animation
-    val annotatedText = if (isAnimating) {
-        formatMessageAsAnnotatedStringWithoutTimestamp(
-            message = animatedMessage,
-            currentUserNickname = currentUserNickname,
-            meshService = meshService,
-            colorScheme = colorScheme
-        )
-    } else {
-        formatMessageAsAnnotatedString(
-            message = animatedMessage,
-            currentUserNickname = currentUserNickname,
-            meshService = meshService,
-            colorScheme = colorScheme,
-            timeFormatter = timeFormatter
-        )
-    }
+    // Use the EXACT same formatting function as normal messages, including timestamp
+    val annotatedText = formatMessageAsAnnotatedString(
+        message = animatedMessage,
+        currentUserNickname = currentUserNickname,
+        meshService = meshService,
+        colorScheme = colorScheme,
+        timeFormatter = timeFormatter
+    )
     
     // Use IDENTICAL Text composable structure as normal message
     Text(
@@ -350,41 +341,4 @@ private fun AnimatedMessageDisplay(
     )
 }
 
-/**
- * Format message without timestamp for animation phase
- * Identical to formatMessageAsAnnotatedString but excludes timestamp
- */
-private fun formatMessageAsAnnotatedStringWithoutTimestamp(
-    message: com.bitchat.android.model.BitchatMessage,
-    currentUserNickname: String,
-    meshService: com.bitchat.android.mesh.BluetoothMeshService,
-    colorScheme: androidx.compose.material3.ColorScheme
-): AnnotatedString {
-    // Simply call the main formatting function with a dummy formatter, 
-    // then remove the timestamp part
-    val timeFormatter = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.getDefault())
-    val fullText = formatMessageAsAnnotatedString(
-        message = message,
-        currentUserNickname = currentUserNickname,
-        meshService = meshService,
-        colorScheme = colorScheme,
-        timeFormatter = timeFormatter
-    )
-    
-    // Find and remove the timestamp at the end
-    val text = fullText.text
-    val timestampPattern = """ \[\d{2}:\d{2}:\d{2}]$""".toRegex()
-    val match = timestampPattern.find(text)
-    
-    return if (match != null) {
-        // Remove timestamp portion
-        val endIndex = match.range.first
-        AnnotatedString(
-            text = text.substring(0, endIndex),
-            spanStyles = fullText.spanStyles.filter { it.end <= endIndex },
-            paragraphStyles = fullText.paragraphStyles.filter { it.end <= endIndex }
-        )
-    } else {
-        fullText
-    }
-}
+

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -166,101 +166,120 @@ private fun MessageTextWithClickableNicknames(
     onMessageLongPress: ((BitchatMessage) -> Unit)?,
     modifier: Modifier = Modifier
 ) {
-    val annotatedText = formatMessageAsAnnotatedString(
-        message = message,
-        currentUserNickname = currentUserNickname,
-        meshService = meshService,
-        colorScheme = colorScheme,
-        timeFormatter = timeFormatter
-    )
+    // Check if this message should be animated during PoW mining
+    val shouldAnimate = shouldAnimateMessage(message.id)
     
-    // Check if this message was sent by self to avoid click interactions on own nickname
-    val isSelf = message.senderPeerID == meshService.myPeerID || 
-                 message.sender == currentUserNickname ||
-                 message.sender.startsWith("$currentUserNickname#")
-    
-    val haptic = LocalHapticFeedback.current
-    val context = LocalContext.current
-    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
-    Text(
-        text = annotatedText,
-        modifier = modifier.pointerInput(message) {
-            detectTapGestures(
-                onTap = { position ->
-                    val layout = textLayoutResult ?: return@detectTapGestures
-                    val offset = layout.getOffsetForPosition(position)
-                    // Nickname click only when not self
-                    if (!isSelf && onNicknameClick != null) {
-                        val nicknameAnnotations = annotatedText.getStringAnnotations(
-                            tag = "nickname_click",
+    // If animation is needed, use the matrix animation component for content only
+    if (shouldAnimate) {
+        // Display message with matrix animation for content
+        MessageWithMatrixAnimation(
+            message = message,
+            currentUserNickname = currentUserNickname,
+            meshService = meshService,
+            colorScheme = colorScheme,
+            timeFormatter = timeFormatter,
+            onNicknameClick = onNicknameClick,
+            onMessageLongPress = onMessageLongPress,
+            modifier = modifier
+        )
+    } else {
+        // Normal message display
+        val annotatedText = formatMessageAsAnnotatedString(
+            message = message,
+            currentUserNickname = currentUserNickname,
+            meshService = meshService,
+            colorScheme = colorScheme,
+            timeFormatter = timeFormatter
+        )
+        
+        // Check if this message was sent by self to avoid click interactions on own nickname
+        val isSelf = message.senderPeerID == meshService.myPeerID || 
+                     message.sender == currentUserNickname ||
+                     message.sender.startsWith("$currentUserNickname#")
+        
+        val haptic = LocalHapticFeedback.current
+        val context = LocalContext.current
+        var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+        Text(
+            text = annotatedText,
+            modifier = modifier.pointerInput(message) {
+                detectTapGestures(
+                    onTap = { position ->
+                        val layout = textLayoutResult ?: return@detectTapGestures
+                        val offset = layout.getOffsetForPosition(position)
+                        // Nickname click only when not self
+                        if (!isSelf && onNicknameClick != null) {
+                            val nicknameAnnotations = annotatedText.getStringAnnotations(
+                                tag = "nickname_click",
+                                start = offset,
+                                end = offset
+                            )
+                            if (nicknameAnnotations.isNotEmpty()) {
+                                val nickname = nicknameAnnotations.first().item
+                                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                onNicknameClick.invoke(nickname)
+                                return@detectTapGestures
+                            }
+                        }
+                        // Geohash teleport (all messages)
+                        val geohashAnnotations = annotatedText.getStringAnnotations(
+                            tag = "geohash_click",
                             start = offset,
                             end = offset
                         )
-                        if (nicknameAnnotations.isNotEmpty()) {
-                            val nickname = nicknameAnnotations.first().item
+                        if (geohashAnnotations.isNotEmpty()) {
+                            val geohash = geohashAnnotations.first().item
+                            try {
+                                val locationManager = com.bitchat.android.geohash.LocationChannelManager.getInstance(
+                                    context
+                                )
+                                val level = when (geohash.length) {
+                                    in 0..2 -> com.bitchat.android.geohash.GeohashChannelLevel.REGION
+                                    in 3..4 -> com.bitchat.android.geohash.GeohashChannelLevel.PROVINCE
+                                    5 -> com.bitchat.android.geohash.GeohashChannelLevel.CITY
+                                    6 -> com.bitchat.android.geohash.GeohashChannelLevel.NEIGHBORHOOD
+                                    else -> com.bitchat.android.geohash.GeohashChannelLevel.BLOCK
+                                }
+                                val channel = com.bitchat.android.geohash.GeohashChannel(level, geohash.lowercase())
+                                locationManager.setTeleported(true)
+                                locationManager.select(com.bitchat.android.geohash.ChannelID.Location(channel))
+                            } catch (_: Exception) { }
                             haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                            onNicknameClick.invoke(nickname)
                             return@detectTapGestures
                         }
+                        // URL open (all messages)
+                        val urlAnnotations = annotatedText.getStringAnnotations(
+                            tag = "url_click",
+                            start = offset,
+                            end = offset
+                        )
+                        if (urlAnnotations.isNotEmpty()) {
+                            val raw = urlAnnotations.first().item
+                            val resolved = if (raw.startsWith("http://", ignoreCase = true) || raw.startsWith("https://", ignoreCase = true)) raw else "https://$raw"
+                            try {
+                                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(resolved))
+                                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                context.startActivity(intent)
+                            } catch (_: Exception) { }
+                            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                            return@detectTapGestures
+                        }
+                    },
+                    onLongPress = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        onMessageLongPress?.invoke(message)
                     }
-                    // Geohash teleport (all messages)
-                    val geohashAnnotations = annotatedText.getStringAnnotations(
-                        tag = "geohash_click",
-                        start = offset,
-                        end = offset
-                    )
-                    if (geohashAnnotations.isNotEmpty()) {
-                        val geohash = geohashAnnotations.first().item
-                        try {
-                            val locationManager = com.bitchat.android.geohash.LocationChannelManager.getInstance(
-                                context
-                            )
-                            val level = when (geohash.length) {
-                                in 0..2 -> com.bitchat.android.geohash.GeohashChannelLevel.REGION
-                                in 3..4 -> com.bitchat.android.geohash.GeohashChannelLevel.PROVINCE
-                                5 -> com.bitchat.android.geohash.GeohashChannelLevel.CITY
-                                6 -> com.bitchat.android.geohash.GeohashChannelLevel.NEIGHBORHOOD
-                                else -> com.bitchat.android.geohash.GeohashChannelLevel.BLOCK
-                            }
-                            val channel = com.bitchat.android.geohash.GeohashChannel(level, geohash.lowercase())
-                            locationManager.setTeleported(true)
-                            locationManager.select(com.bitchat.android.geohash.ChannelID.Location(channel))
-                        } catch (_: Exception) { }
-                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                        return@detectTapGestures
-                    }
-                    // URL open (all messages)
-                    val urlAnnotations = annotatedText.getStringAnnotations(
-                        tag = "url_click",
-                        start = offset,
-                        end = offset
-                    )
-                    if (urlAnnotations.isNotEmpty()) {
-                        val raw = urlAnnotations.first().item
-                        val resolved = if (raw.startsWith("http://", ignoreCase = true) || raw.startsWith("https://", ignoreCase = true)) raw else "https://$raw"
-                        try {
-                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(resolved))
-                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            context.startActivity(intent)
-                        } catch (_: Exception) { }
-                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                        return@detectTapGestures
-                    }
-                },
-                onLongPress = {
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    onMessageLongPress?.invoke(message)
-                }
-            )
-        },
-        fontFamily = FontFamily.Monospace,
-        softWrap = true,
-        overflow = TextOverflow.Visible,
-        style = androidx.compose.ui.text.TextStyle(
-            color = colorScheme.onSurface
-        ),
-        onTextLayout = { result -> textLayoutResult = result }
-    )
+                )
+            },
+            fontFamily = FontFamily.Monospace,
+            softWrap = true,
+            overflow = TextOverflow.Visible,
+            style = androidx.compose.ui.text.TextStyle(
+                color = colorScheme.onSurface
+            ),
+            onTextLayout = { result -> textLayoutResult = result }
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/bitchat/android/ui/PoWStatusIndicator.kt
+++ b/app/src/main/java/com/bitchat/android/ui/PoWStatusIndicator.kt
@@ -68,17 +68,6 @@ fun PoWStatusIndicator(
                         modifier = Modifier.size(12.dp)
                     )
                 }
-                
-                // Difficulty indicator
-                Text(
-                    text = powDifficulty.toString(),
-                    fontSize = 10.sp,
-                    fontFamily = FontFamily.Monospace,
-                    fontWeight = FontWeight.Medium,
-                    color = if (isMining) Color(0xFFFF9500) else {
-                        if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D)
-                    }
-                )
             }
         }
         

--- a/app/src/main/java/com/bitchat/android/ui/PoWStatusIndicator.kt
+++ b/app/src/main/java/com/bitchat/android/ui/PoWStatusIndicator.kt
@@ -23,11 +23,11 @@ import com.bitchat.android.nostr.PoWPreferenceManager
 @Composable
 fun PoWStatusIndicator(
     modifier: Modifier = Modifier,
-    isMining: Boolean = false,
     style: PoWIndicatorStyle = PoWIndicatorStyle.COMPACT
 ) {
     val powEnabled by PoWPreferenceManager.powEnabled.collectAsState()
     val powDifficulty by PoWPreferenceManager.powDifficulty.collectAsState()
+    val isMining by PoWPreferenceManager.isMining.collectAsState()
     val colorScheme = MaterialTheme.colorScheme
     val isDark = colorScheme.background.red + colorScheme.background.green + colorScheme.background.blue < 1.5f
     

--- a/app/src/main/java/com/bitchat/android/ui/PoWStatusIndicator.kt
+++ b/app/src/main/java/com/bitchat/android/ui/PoWStatusIndicator.kt
@@ -1,0 +1,205 @@
+package com.bitchat.android.ui
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Security
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.bitchat.android.nostr.NostrProofOfWork
+import com.bitchat.android.nostr.PoWPreferenceManager
+
+/**
+ * Shows the current Proof of Work status and settings
+ */
+@Composable
+fun PoWStatusIndicator(
+    modifier: Modifier = Modifier,
+    isMining: Boolean = false,
+    style: PoWIndicatorStyle = PoWIndicatorStyle.COMPACT
+) {
+    val powEnabled by PoWPreferenceManager.powEnabled.collectAsState()
+    val powDifficulty by PoWPreferenceManager.powDifficulty.collectAsState()
+    val colorScheme = MaterialTheme.colorScheme
+    val isDark = colorScheme.background.red + colorScheme.background.green + colorScheme.background.blue < 1.5f
+    
+    if (!powEnabled) return
+    
+    when (style) {
+        PoWIndicatorStyle.COMPACT -> {
+            Row(
+                modifier = modifier,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // PoW icon with animation if mining
+                if (isMining) {
+                    val rotation by rememberInfiniteTransition(label = "pow-rotation").animateFloat(
+                        initialValue = 0f,
+                        targetValue = 360f,
+                        animationSpec = infiniteRepeatable(
+                            animation = tween(1000, easing = LinearEasing),
+                            repeatMode = RepeatMode.Restart
+                        ),
+                        label = "pow-icon-rotation"
+                    )
+                    
+                    Icon(
+                        imageVector = Icons.Filled.Security,
+                        contentDescription = "Mining PoW",
+                        tint = Color(0xFFFF9500), // Orange for mining
+                        modifier = Modifier
+                            .size(12.dp)
+                            .graphicsLayer { rotationZ = rotation }
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Filled.Security,
+                        contentDescription = "PoW Enabled",
+                        tint = if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D), // Green when ready
+                        modifier = Modifier.size(12.dp)
+                    )
+                }
+                
+                // Difficulty indicator
+                Text(
+                    text = powDifficulty.toString(),
+                    fontSize = 10.sp,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Medium,
+                    color = if (isMining) Color(0xFFFF9500) else {
+                        if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D)
+                    }
+                )
+            }
+        }
+        
+        PoWIndicatorStyle.DETAILED -> {
+            Surface(
+                modifier = modifier,
+                color = colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp)
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // PoW icon
+                    Icon(
+                        imageVector = Icons.Filled.Security,
+                        contentDescription = "Proof of Work",
+                        tint = if (isMining) Color(0xFFFF9500) else {
+                            if (isDark) Color(0xFF32D74B) else Color(0xFF248A3D)
+                        },
+                        modifier = Modifier.size(14.dp)
+                    )
+                    
+                    // Status text
+                    Text(
+                        text = if (isMining) {
+                            "mining..."
+                        } else {
+                            "pow: ${powDifficulty}bit"
+                        },
+                        fontSize = 11.sp,
+                        fontFamily = FontFamily.Monospace,
+                        color = if (isMining) Color(0xFFFF9500) else {
+                            colorScheme.onSurface.copy(alpha = 0.7f)
+                        }
+                    )
+                    
+                    // Time estimate
+                    if (!isMining && powDifficulty > 0) {
+                        Text(
+                            text = "(~${NostrProofOfWork.estimateMiningTime(powDifficulty)})",
+                            fontSize = 9.sp,
+                            fontFamily = FontFamily.Monospace,
+                            color = colorScheme.onSurface.copy(alpha = 0.5f)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Style options for the PoW status indicator
+ */
+enum class PoWIndicatorStyle {
+    COMPACT,    // Small icon + difficulty number
+    DETAILED    // Icon + status text + time estimate
+}
+
+/**
+ * Shows mining progress with animated indicator
+ */
+@Composable
+fun PoWMiningIndicator(
+    modifier: Modifier = Modifier,
+    difficulty: Int,
+    iterations: Int? = null
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    
+    Surface(
+        modifier = modifier,
+        color = Color(0xFFFF9500).copy(alpha = 0.1f),
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Animated security icon
+            val rotation by rememberInfiniteTransition(label = "mining-rotation").animateFloat(
+                initialValue = 0f,
+                targetValue = 360f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(1000, easing = LinearEasing),
+                    repeatMode = RepeatMode.Restart
+                ),
+                label = "mining-icon-rotation"
+            )
+            
+            Icon(
+                imageVector = Icons.Filled.Security,
+                contentDescription = "Mining Proof of Work",
+                tint = Color(0xFFFF9500),
+                modifier = Modifier
+                    .size(16.dp)
+                    .graphicsLayer { rotationZ = rotation }
+            )
+            
+            Column(
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Text(
+                    text = "mining proof of work...",
+                    fontSize = 12.sp,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Medium,
+                    color = Color(0xFFFF9500)
+                )
+                
+                Text(
+                    text = "difficulty: ${difficulty}bit (~${NostrProofOfWork.estimateMiningTime(difficulty)})" +
+                            if (iterations != null) " • ${iterations} attempts" else "",
+                    fontSize = 10.sp,
+                    fontFamily = FontFamily.Monospace,
+                    color = colorScheme.onSurface.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
NIP-13 proof of work for geohash messages, default on, minimum difficulty is 10

LLM summary:
# NIP-13 PoW for Geohash + Pixel‑perfect Chat Animation Transition

Summary of changes on this branch (nip13-pow) compared to origin/main. Focused, technical, and implementation‑level details.

## Highlights
- Add NIP‑13 Proof‑of‑Work (PoW) support for geohash messages:
  - Mining on outgoing ephemeral geohash events.
  - Validation on incoming events (optional, per user setting).
  - Inline UI badge next to timestamp showing achieved difficulty in “bits”.
- Eliminate chat layout jump between “encrypting” animation and final text:
  - Both animated and normal states render through the same AnnotatedString/Text pipeline and identical modifiers.

## Protocol/Model
- BitchatMessage
  - Added field: `powDifficulty: Int?` (nullable; when > 0 displays “{bits}b” after timestamp).
  - File: app/src/main/java/com/bitchat/android/model/BitchatMessage.kt

- NostrProtocol
  - `createEphemeralGeohashEvent(...)` now suspend and mines PoW when enabled, then signs.
    - Moves to `Dispatchers.Default`.
    - If PoW enabled (via preferences), modifies the event with a nonce tag and updated created_at before signing.
    - Bounded mining loop (`maxIterations = 2_000_000`) to avoid runaway.
  - Starts/stops mining UI state via PoWPreferenceManager.
  - File: app/src/main/java/com/bitchat/android/nostr/NostrProtocol.kt

- NostrProofOfWork (new)
  - Core NIP‑13 helpers:
    - `calculateDifficulty(eventIdHex): Int` (leading zero bits).
    - `validateDifficulty(event, requiredBits): Boolean`.
    - `mineEvent(event, targetDifficulty, maxIterations)`: applies/updates `["nonce", nonce, difficulty]` tag and bumps `created_at`; returns mined event or null.
    - Helpers: `hasNonce`, `getNonce`, `estimateWork`, `estimateMiningTime`.
  - File: app/src/main/java/com/bitchat/android/nostr/NostrProofOfWork.kt

## Inbound/Outbound Behavior
- Outgoing geohash
  - Local echo immediately added with `powDifficulty = currentSetting.difficulty` so the badge appears right away.
  - Matrix animation starts while mining; stops upon completion or error.
  - File: app/src/main/java/com/bitchat/android/nostr/NostrGeohashService.kt

- Incoming geohash
  - If PoW is enabled with difficulty > 0:
    - Reject events below the configured difficulty (fast path validation).
    - Compute actual achieved difficulty from event.id and set `message.powDifficulty` when > 0.
  - Files:
    - app/src/main/java/com/bitchat/android/nostr/NostrClient.kt (validation)
    - app/src/main/java/com/bitchat/android/nostr/NostrGeohashService.kt (validation + message enrichment)

## UI/UX
- Chat UI formatting (single Text/AnnotatedString)
  - Timestamp is always inline at the end: ` [HH:mm:ss]`.
  - If `powDifficulty > 0`, append ` " {bits}b"` directly after the timestamp (single space), same grey style.
  - No icons; text‑only “bits” indicator.
  - Monospace, softWrap=true, overflow=Visible across both code paths.
  - File: app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt

- Animation integration (no layout jump)
  - New composable renders animated “encrypted” characters while mining and hides timestamp/PoW during animation.
  - Uses the same Text with identical modifiers; only difference is formatter function that strips trailing timestamp/PoW.
  - On completion, swaps to the fully formatted string—no baseline/spacing shift.
  - File: app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt

- Header indicator and settings
  - PoW status chip in MainHeader (compact): shows on/off + difficulty/mining state.
  - AboutSheet: enable/disable PoW, adjust difficulty (slider), shows work/time estimates.
  - Default PoW is ON at 10 bits.
  - Files:
    - app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
    - app/src/main/java/com/bitchat/android/ui/PoWStatusIndicator.kt
    - app/src/main/java/com/bitchat/android/ui/AboutSheet.kt

- Message tap behavior cleanups
  - Unified Text pointerInput handler; preserved nickname/geohash/url taps.
  - Prevent nickname tap on self‑messages; minor ordering/robustness fixes.
  - File: app/src/main/java/com/bitchat/android/ui/MessageComponents.kt

## Preferences/Initialization
- PoWPreferenceManager (new)
  - Backed by SharedPreferences + StateFlow.
  - Keys:
    - `pow_enabled` (default true)
    - `pow_difficulty` (default 10; clamped 0..32)
  - Exposes “mining” state for animation indicators.
  - File: app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
- Initialization
  - Initialize PoW preferences in MainActivity early during startup.
  - File: app/src/main/java/com/bitchat/android/MainActivity.kt

## Validation/Enforcement
- When PoW is enabled and `difficulty > 0`:
  - Incoming geohash events below threshold are rejected.
  - Outgoing geohash events attempt mining prior to signing/sending.
- When PoW is disabled or difficulty == 0:
  - Behavior is unchanged (no mining, no inbound enforcement, no UI badge).

## Breaking/Behavioral Changes
- `NostrProtocol.createEphemeralGeohashEvent(...)` is now `suspend`.
  - Call sites updated (runs on Dispatchers.Default).
- Chat timestamp is always inline at the end (removed right‑aligned variant).

## Files Changed
- Added
  - app/src/main/java/com/bitchat/android/nostr/NostrProofOfWork.kt
  - app/src/main/java/com/bitchat/android/nostr/PoWPreferenceManager.kt
  - app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
  - app/src/main/java/com/bitchat/android/ui/PoWStatusIndicator.kt
- Modified
  - app/src/main/java/com/bitchat/android/MainActivity.kt
  - app/src/main/java/com/bitchat/android/model/BitchatMessage.kt
  - app/src/main/java/com/bitchat/android/nostr/NostrClient.kt
  - app/src/main/java/com/bitchat/android/nostr/NostrGeohashService.kt
  - app/src/main/java/com/bitchat/android/nostr/NostrProtocol.kt
  - app/src/main/java/com/bitchat/android/ui/AboutSheet.kt
  - app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
  - app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
  - app/src/main/java/com/bitchat/android/ui/MessageComponents.kt

## Build
- assembleDebug: successful.

## Follow‑ups
- Optional: extend actual PoW calculation/badging to other inbound sources (e.g., NIP‑17 DMs, additional relays) using achieved difficulty.