### PR TITLE
Getting rid of spam

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -11,6 +11,7 @@ import com.bitchat.android.protocol.BitchatPacket
 import com.bitchat.android.protocol.MessageType
 import com.bitchat.android.protocol.SpecialRecipients
 import com.bitchat.android.util.toHexString
+import com.bitchat.android.services.SpamFilterService
 import kotlinx.coroutines.*
 import java.util.*
 import kotlin.math.sign
@@ -453,6 +454,17 @@ class BluetoothMeshService(private val context: Context) {
      */
     fun sendMessage(content: String, mentions: List<String> = emptyList(), channel: String? = null) {
         if (content.isEmpty()) return
+        
+        // Check if message content is spam before sending
+        val spamFilterService = SpamFilterService.getInstance()
+        if (spamFilterService.isSpamMessage(BitchatMessage(
+            sender = "me",
+            content = content,
+            timestamp = Date()
+        ))) {
+            Log.w(TAG, "Blocked spam message from being sent: $content")
+            return
+        }
         
         serviceScope.launch {
             val packet = BitchatPacket(

--- a/app/src/main/java/com/bitchat/android/nostr/NostrGeohashService.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrGeohashService.kt
@@ -12,6 +12,7 @@ import com.bitchat.android.ui.MeshDelegateHandler
 import com.bitchat.android.ui.PrivateChatManager
 import com.bitchat.android.ui.GeoPerson
 import com.bitchat.android.ui.colorForPeerSeed
+import com.bitchat.android.services.SpamFilterService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -242,6 +243,17 @@ class NostrGeohashService(
     fun sendGeohashMessage(content: String, channel: com.bitchat.android.geohash.GeohashChannel, myPeerID: String, nickname: String?) {
         coroutineScope.launch {
             try {
+                // Check if message content is spam before sending
+                val spamFilterService = SpamFilterService.getInstance()
+                if (spamFilterService.isSpamMessage(BitchatMessage(
+                    sender = nickname ?: myPeerID,
+                    content = content,
+                    timestamp = Date()
+                ))) {
+                    Log.w(TAG, "🚫 Blocked spam message from being sent: $content")
+                    return@launch
+                }
+                
                 val identity = NostrIdentityBridge.deriveIdentity(
                     forGeohash = channel.geohash,
                     context = application
@@ -1249,6 +1261,13 @@ class NostrGeohashService(
                 mentions = null, // mentions need to be passed from outside
                 channel = "#$geohash"
             )
+            
+            // Check if message is spam before processing
+            val spamFilterService = SpamFilterService.getInstance()
+            if (spamFilterService.isSpamMessage(message)) {
+                Log.d(TAG, "Skipping spam message from ${message.sender} in geohash $geohash")
+                return@launch
+            }
             
             // Store in geohash history for persistence across channel switches
             storeGeohashMessage(geohash, message)

--- a/app/src/main/java/com/bitchat/android/services/SpamFilterService.kt
+++ b/app/src/main/java/com/bitchat/android/services/SpamFilterService.kt
@@ -1,0 +1,101 @@
+package com.bitchat.android.services
+
+import android.util.Log
+import com.bitchat.android.model.BitchatMessage
+
+/**
+ * Service for filtering spam messages in geohash channels
+ * Filters out messages from known spam bots and messages with suspicious patterns
+ */
+class SpamFilterService {
+    
+    companion object {
+        private const val TAG = "SpamFilterService"
+        
+                       // Known spam bot nicknames
+               private val SPAM_BOT_NICKNAMES = mutableSetOf(
+                   "spam-tester",
+                   "semicolon"
+               )
+        
+        // Pattern for detecting multiple semicolons in a row
+        private val MULTIPLE_SEMICOLONS_PATTERN = Regex(";{2,}")
+        
+        @Volatile
+        private var INSTANCE: SpamFilterService? = null
+        
+        fun getInstance(): SpamFilterService {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: SpamFilterService().also { INSTANCE = it }
+            }
+        }
+    }
+    
+    /**
+     * Check if a message should be filtered as spam
+     * @param message The message to check
+     * @return true if the message should be filtered, false otherwise
+     */
+    fun isSpamMessage(message: BitchatMessage): Boolean {
+        // Check if sender is a known spam bot
+        if (isSpamBotNickname(message.sender)) {
+            Log.d(TAG, "Filtering message from spam bot: ${message.sender}")
+            return true
+        }
+        
+        // Check if message content contains suspicious patterns
+        if (hasSuspiciousContent(message.content)) {
+            Log.d(TAG, "Filtering message with suspicious content from: ${message.sender}")
+            return true
+        }
+        
+        return false
+    }
+    
+    /**
+     * Check if a nickname belongs to a known spam bot
+     */
+    private fun isSpamBotNickname(nickname: String): Boolean {
+        return SPAM_BOT_NICKNAMES.any { spamBot -> 
+            nickname.contains(spamBot, ignoreCase = true) 
+        }
+    }
+    
+    /**
+     * Check if message content contains suspicious patterns
+     */
+    private fun hasSuspiciousContent(content: String): Boolean {
+        // Check for multiple semicolons in a row
+        if (MULTIPLE_SEMICOLONS_PATTERN.containsMatchIn(content)) {
+            Log.d(TAG, "Detected multiple semicolons in message: ${content.take(50)}...")
+            return true
+        }
+        
+        return false
+    }
+    
+    /**
+     * Add a new spam bot nickname to the filter
+     * @param nickname The nickname to add
+     */
+    fun addSpamBotNickname(nickname: String) {
+        SPAM_BOT_NICKNAMES.add(nickname.lowercase())
+        Log.i(TAG, "Added spam bot nickname: $nickname")
+    }
+    
+    /**
+     * Remove a nickname from the spam bot filter
+     * @param nickname The nickname to remove
+     */
+    fun removeSpamBotNickname(nickname: String) {
+        SPAM_BOT_NICKNAMES.remove(nickname.lowercase())
+        Log.i(TAG, "Removed spam bot nickname: $nickname")
+    }
+    
+    /**
+     * Get all currently blocked spam bot nicknames
+     */
+    fun getSpamBotNicknames(): Set<String> {
+        return SPAM_BOT_NICKNAMES.toSet()
+    }
+} 

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -2,6 +2,7 @@ package com.bitchat.android.ui
 
 import com.bitchat.android.mesh.BluetoothMeshService
 import com.bitchat.android.model.BitchatMessage
+import com.bitchat.android.services.SpamFilterService
 import java.util.*
 
 /**
@@ -24,7 +25,9 @@ class CommandProcessor(
         CommandSuggestion("/m", listOf("/msg"), "<nickname> [message]", "send private message"),
         CommandSuggestion("/slap", emptyList(), "<nickname>", "slap someone with a trout"),
         CommandSuggestion("/unblock", emptyList(), "<nickname>", "unblock a peer"),
-        CommandSuggestion("/w", emptyList(), null, "see who's online")
+        CommandSuggestion("/w", emptyList(), null, "see who's online"),
+        CommandSuggestion("/spam", emptyList(), "[add/remove] [nickname]", "manage spam filter"),
+        CommandSuggestion("/spamlist", emptyList(), null, "list blocked spam bots")
     )
     
     // MARK: - Command Processing
@@ -46,6 +49,8 @@ class CommandProcessor(
             "/hug" -> handleActionCommand(parts, "gives", "a warm hug 🫂", meshService, myPeerID, onSendMessage)
             "/slap" -> handleActionCommand(parts, "slaps", "around a bit with a large trout 🐟", meshService, myPeerID, onSendMessage)
             "/channels" -> handleChannelsCommand()
+            "/spam" -> handleSpamCommand(parts)
+            "/spamlist" -> handleSpamListCommand()
             else -> handleUnknownCommand(cmd)
         }
         
@@ -511,5 +516,117 @@ class CommandProcessor(
     
     private fun sendPrivateMessageVia(meshService: BluetoothMeshService, content: String, peerID: String, recipientNickname: String, messageId: String) {
         meshService.sendPrivateMessage(content, peerID, recipientNickname, messageId)
+    }
+    
+    // MARK: - Spam Filter Commands
+    
+    private fun handleSpamCommand(parts: List<String>) {
+        val spamFilterService = SpamFilterService.getInstance()
+        
+        when {
+            parts.size == 1 -> {
+                // Show usage
+                val systemMessage = BitchatMessage(
+                    sender = "system",
+                    content = "usage: /spam [add/remove] [nickname]",
+                    timestamp = Date(),
+                    isRelay = false
+                )
+                messageManager.addMessage(systemMessage)
+            }
+            parts.size == 2 -> {
+                when (parts[1].lowercase()) {
+                    "add" -> {
+                        val systemMessage = BitchatMessage(
+                            sender = "system",
+                            content = "usage: /spam add <nickname>",
+                            timestamp = Date(),
+                            isRelay = false
+                        )
+                        messageManager.addMessage(systemMessage)
+                    }
+                    "remove" -> {
+                        val systemMessage = BitchatMessage(
+                            sender = "system",
+                            content = "usage: /spam remove <nickname>",
+                            timestamp = Date(),
+                            isRelay = false
+                        )
+                        messageManager.addMessage(systemMessage)
+                    }
+                    else -> {
+                        val systemMessage = BitchatMessage(
+                            sender = "system",
+                            content = "usage: /spam [add/remove] [nickname]",
+                            timestamp = Date(),
+                            isRelay = false
+                        )
+                        messageManager.addMessage(systemMessage)
+                    }
+                }
+            }
+            parts.size == 3 -> {
+                val action = parts[1].lowercase()
+                val nickname = parts[2]
+                
+                when (action) {
+                    "add" -> {
+                        spamFilterService.addSpamBotNickname(nickname)
+                        val systemMessage = BitchatMessage(
+                            sender = "system",
+                            content = "added '$nickname' to spam filter",
+                            timestamp = Date(),
+                            isRelay = false
+                        )
+                        messageManager.addMessage(systemMessage)
+                    }
+                    "remove" -> {
+                        spamFilterService.removeSpamBotNickname(nickname)
+                        val systemMessage = BitchatMessage(
+                            sender = "system",
+                            content = "removed '$nickname' from spam filter",
+                            timestamp = Date(),
+                            isRelay = false
+                        )
+                        messageManager.addMessage(systemMessage)
+                    }
+                    else -> {
+                        val systemMessage = BitchatMessage(
+                            sender = "system",
+                            content = "usage: /spam [add/remove] [nickname]",
+                            timestamp = Date(),
+                            isRelay = false
+                        )
+                        messageManager.addMessage(systemMessage)
+                    }
+                }
+            }
+            else -> {
+                val systemMessage = BitchatMessage(
+                    sender = "system",
+                    content = "usage: /spam [add/remove] [nickname]",
+                    timestamp = Date(),
+                    isRelay = false
+                )
+                messageManager.addMessage(systemMessage)
+            }
+        }
+    }
+    
+    private fun handleSpamListCommand() {
+        val spamFilterService = SpamFilterService.getInstance()
+        val blockedBots = spamFilterService.getSpamBotNicknames()
+        
+        val systemMessage = BitchatMessage(
+            sender = "system",
+            content = if (blockedBots.isEmpty()) {
+                "no spam bots blocked"
+            } else {
+                "blocked spam bots: ${blockedBots.joinToString(", ")}"
+            },
+            timestamp = Date(),
+            isRelay = false
+        )
+        messageManager.addMessage(systemMessage)
     }
 }

--- a/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
@@ -4,6 +4,7 @@ import com.bitchat.android.mesh.BluetoothMeshDelegate
 import com.bitchat.android.mesh.BluetoothMeshService
 import com.bitchat.android.model.BitchatMessage
 import com.bitchat.android.model.DeliveryStatus
+import com.bitchat.android.services.SpamFilterService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.Date
@@ -37,6 +38,12 @@ class MeshDelegateHandler(
                 if (privateChatManager.isPeerBlocked(senderPeerID)) {
                     return@launch
                 }
+            }
+            
+            // Check if message is spam
+            val spamFilterService = SpamFilterService.getInstance()
+            if (spamFilterService.isSpamMessage(message)) {
+                return@launch
             }
             
             // Trigger haptic feedback


### PR DESCRIPTION
Implemented local spam filtering to hide unwanted messages

1. Blocks messages from known spam bots: Automatically hides messages from users with nicknames containing spam-tester or semicolon
2. Filters suspicious content: Hides messages containing two or more consecutive semicolons (;;)
3. Works across all channels: Filters both incoming and outgoing messages in Nostr geohash channels and Bluetooth mesh

User commands:
/spam add <nickname> - Add a nickname to spam filter
/spam remove <nickname> - Remove a nickname from spam filter
/spamlist - Show all blocked spam bot nicknames

![photo_2025-08-31_00-18-28](https://github.com/user-attachments/assets/c043b8cf-8620-48f0-af49-4991da9e5f96)
