### PR TITLE
feat(geohash): add STATE level (#365)

### DIFF
--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -713,6 +713,7 @@ class MainActivity : ComponentActivity() {
                         6 -> com.bitchat.android.geohash.GeohashChannelLevel.NEIGHBORHOOD
                         5 -> com.bitchat.android.geohash.GeohashChannelLevel.CITY
                         4 -> com.bitchat.android.geohash.GeohashChannelLevel.PROVINCE
+                        3 -> com.bitchat.android.geohash.GeohashChannelLevel.STATE
                         2 -> com.bitchat.android.geohash.GeohashChannelLevel.REGION
                         else -> com.bitchat.android.geohash.GeohashChannelLevel.CITY // Default fallback
                     }

--- a/app/src/main/java/com/bitchat/android/geohash/LocationChannel.kt
+++ b/app/src/main/java/com/bitchat/android/geohash/LocationChannel.kt
@@ -9,6 +9,7 @@ enum class GeohashChannelLevel(val precision: Int, val displayName: String) {
     NEIGHBORHOOD(6, "Neighborhood"),
     CITY(5, "City"),
     PROVINCE(4, "Province"),
+    STATE(3, "State"),
     REGION(2, "REGION");
     
     companion object {

--- a/app/src/main/java/com/bitchat/android/geohash/LocationChannelManager.kt
+++ b/app/src/main/java/com/bitchat/android/geohash/LocationChannelManager.kt
@@ -495,10 +495,15 @@ class LocationChannelManager private constructor(private val context: Context) {
             dict[GeohashChannelLevel.REGION] = it
         }
         
-        // Province (state/province or county)
+        // State (administrative area - state/province level)
         address.adminArea?.takeIf { it.isNotEmpty() }?.let {
+            dict[GeohashChannelLevel.STATE] = it
+        }
+        
+        // Province (county/subadministrative level)
+        address.subAdminArea?.takeIf { it.isNotEmpty() }?.let {
             dict[GeohashChannelLevel.PROVINCE] = it
-        } ?: address.subAdminArea?.takeIf { it.isNotEmpty() }?.let {
+        } ?: address.adminArea?.takeIf { it.isNotEmpty() }?.let {
             dict[GeohashChannelLevel.PROVINCE] = it
         }
         

--- a/app/src/main/java/com/bitchat/android/nostr/NostrGeohashService.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrGeohashService.kt
@@ -1816,7 +1816,8 @@ class NostrGeohashService(
             // Determine the level from geohash length
             val level = when (geohash.length) {
                 in 0..2 -> com.bitchat.android.geohash.GeohashChannelLevel.REGION
-                in 3..4 -> com.bitchat.android.geohash.GeohashChannelLevel.PROVINCE
+                3 -> com.bitchat.android.geohash.GeohashChannelLevel.STATE
+                4 -> com.bitchat.android.geohash.GeohashChannelLevel.PROVINCE
                 5 -> com.bitchat.android.geohash.GeohashChannelLevel.CITY
                 6 -> com.bitchat.android.geohash.GeohashChannelLevel.NEIGHBORHOOD
                 7 -> com.bitchat.android.geohash.GeohashChannelLevel.BLOCK

--- a/app/src/main/java/com/bitchat/android/ui/LocationChannelsSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/LocationChannelsSheet.kt
@@ -568,7 +568,8 @@ private fun validateGeohash(geohash: String): Boolean {
 private fun levelForLength(length: Int): GeohashChannelLevel {
     return when (length) {
         in 0..2 -> GeohashChannelLevel.REGION
-        in 3..4 -> GeohashChannelLevel.PROVINCE
+        3 -> GeohashChannelLevel.STATE
+        4 -> GeohashChannelLevel.PROVINCE
         5 -> GeohashChannelLevel.CITY
         6 -> GeohashChannelLevel.NEIGHBORHOOD
         7 -> GeohashChannelLevel.BLOCK

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -235,7 +235,8 @@ private fun MessageTextWithClickableNicknames(
                                 )
                                 val level = when (geohash.length) {
                                     in 0..2 -> com.bitchat.android.geohash.GeohashChannelLevel.REGION
-                                    in 3..4 -> com.bitchat.android.geohash.GeohashChannelLevel.PROVINCE
+                                    3 -> com.bitchat.android.geohash.GeohashChannelLevel.STATE
+                                    4 -> com.bitchat.android.geohash.GeohashChannelLevel.PROVINCE
                                     5 -> com.bitchat.android.geohash.GeohashChannelLevel.CITY
                                     6 -> com.bitchat.android.geohash.GeohashChannelLevel.NEIGHBORHOOD
                                     else -> com.bitchat.android.geohash.GeohashChannelLevel.BLOCK


### PR DESCRIPTION
# Pull Request: Add `STATE (3, 'State')` geohash level  

## Description  
This PR introduces a new **STATE** geohash level (`3`), positioned between **REGION** (`~1,250 km`) and **PROVINCE** (`~39 km`). The STATE level provides intermediate coverage of **~156 km**, addressing the gap between large regions and fine-grained provinces.  

### Key Changes  
-  Added `STATE(3, "State")` geohash level  
-  Updated geohash length mappings across **6 files** to include STATE  
-  Enhanced location name resolution to differentiate **STATE vs PROVINCE**  
-  Fixed teleport icon display for **3-character geohashes**  
-  Ensured backward compatibility with existing geohash levels  

### Motivation  
Currently, REGION (`#XX`) is often too broad, while PROVINCE (`#XXXX`) can be too detailed. Adding STATE (`#XXX`) fills this missing granularity level, improving location-based features and providing more intuitive geographic grouping.  

### Linked Issue  
Addresses enhancement request: [#365](https://github.com/permissionlesstech/bitchat-android/issues/365)  

## App Version  
`1.2.0`
