### PR TITLE
fix: action message routing and duplicate local echo in geohash channels

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -249,9 +249,21 @@ class ChatViewModel(
         
         // Check for commands
         if (content.startsWith("/")) {
+            val selectedLocationForCommand = state.selectedLocationChannel.value
             commandProcessor.processCommand(content, meshService, meshService.myPeerID, { messageContent, mentions, channel ->
-                meshService.sendMessage(messageContent, mentions, channel)
-            }, this)
+                if (selectedLocationForCommand is com.bitchat.android.geohash.ChannelID.Location) {
+                    // Route command-generated public messages via Nostr in geohash channels
+                    nostrGeohashService.sendGeohashMessage(
+                        messageContent,
+                        selectedLocationForCommand.channel,
+                        meshService.myPeerID,
+                        state.getNicknameValue()
+                    )
+                } else {
+                    // Default: route via mesh
+                    meshService.sendMessage(messageContent, mentions, channel)
+                }
+            })
             return
         }
         


### PR DESCRIPTION

## Summary
- Ensure action commands (/hug, /slap) are sent to the correct destination based on the currently selected chat context.
- Prevent duplicate local echoes when sending action messages in location (geohash) channels.

## Background
Previously:
- Action commands were sometimes routed to the wrong chat transport, causing them to show up in the wrong place.
- In geohash channels, the sender saw action messages twice. This happened because we added a local echo in CommandProcessor and then NostrGeohashService added another one.

## What changed
1) Route command-generated messages correctly in geohash channels
- File: app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
- Behavior:
  - When the user enters a command (content.startsWith("/")), we capture the selected location context before invoking CommandProcessor:
    - If selectedLocationForCommand is a location (geohash) channel, we route the command-generated message via NostrGeohashService.sendGeohashMessage(...).
    - Otherwise, we route via Bluetooth mesh (meshService.sendMessage(...)).

2) Avoid double local echo for action messages in geohash channels
- File: app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
- Behavior:
  - In handleActionCommand, detect if the current channel is a location (geohash) channel.
  - If in a location channel:
    - Do not add a local echo in CommandProcessor.
    - Only call the onSendMessage transport callback; NostrGeohashService will add exactly one local echo
  - If in a private chat: unchanged (local echo added via PrivateChatManager).
  - If in a mesh (non-location) public chat: unchanged (CommandProcessor adds local echo and sends via mesh).
