### PR TITLE
feat: use relay timestamps for Nostr DMs; ignore for sorting

### DIFF
--- a/app/src/main/java/com/bitchat/android/nostr/NostrDirectMessageHandler.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrDirectMessageHandler.kt
@@ -67,7 +67,7 @@ class NostrDirectMessageHandler(
                 if (packet.type != com.bitchat.android.protocol.MessageType.NOISE_ENCRYPTED.value) return@launch
 
                 val noisePayload = com.bitchat.android.model.NoisePayload.decode(packet.payload) ?: return@launch
-                val messageTimestamp = Date(rumorTimestamp * 1000L)
+                val messageTimestamp = Date(giftWrap.createdAt * 1000L)
                 val convKey = "nostr_${senderPubkey.take(16)}"
                 repo.putNostrKeyMapping(convKey, senderPubkey)
                 com.bitchat.android.nostr.GeohashAliasRegistry.put(convKey, senderPubkey)
@@ -173,4 +173,3 @@ class NostrDirectMessageHandler(
         }
     }
 }
-


### PR DESCRIPTION
Implements #317 

- Display Nostr DM timestamps using relay event createdAt
- Keep arrival order for sorting to prevent timestamp cheating
- Update geohash DM participant last-seen with relay time