### PR TITLE
add playstore link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This is the **Android port** of the original [bitchat iOS app](https://github.co
 
 You can download the latest version of bitchat for Android from the [GitHub Releases page](https://github.com/permissionlesstech/bitchat-android/releases).
 
+Or you can:
+
+[<img alt="Get it on Google Play" height="60" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"/>](https://play.google.com/store/apps/details?id=com.bitchat.droid)
+
 **Instructions:**
 
 1.  **Download the APK:** On your Android device, navigate to the link above and download the latest `.apk` file. Open it.


### PR DESCRIPTION
# Description
Add link to playstore bitchat

<img width="691" height="240" alt="Screenshot 2025-09-09 at 7 19 05 PM" src="https://github.com/user-attachments/assets/5bf3e58e-5830-41ec-97a4-4edc8e25a2b7" />

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)