### PR TITLE
fix truncated list in sidebar

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
@@ -123,6 +123,7 @@ fun SidebarOverlay(
                             else -> {
                                 // Show mesh peer list when in mesh channel (default)
                                 PeopleSection(
+                                    modifier = modifier.padding(bottom = 16.dp),
                                     connectedPeers = connectedPeers,
                                     peerNicknames = peerNicknames,
                                     peerRSSI = peerRSSI,
@@ -248,6 +249,7 @@ fun ChannelsSection(
 
 @Composable
 fun PeopleSection(
+    modifier: Modifier  = Modifier,
     connectedPeers: List<String>,
     peerNicknames: Map<String, String>,
     peerRSSI: Map<String, Int>,
@@ -257,7 +259,7 @@ fun PeopleSection(
     viewModel: ChatViewModel,
     onPrivateChatStart: (String) -> Unit
 ) {
-    Column {
+    Column(modifier = modifier) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -327,8 +329,6 @@ fun PeopleSection(
         fun computeDisplayNameForPeerId(key: String): String {
             return if (key == nickname) "You" else (peerNicknames[key] ?: (privateChats[key]?.lastOrNull()?.sender ?: key.take(12)))
         }
-
-        
 
         val baseNameCounts = mutableMapOf<String, Int>()
 


### PR DESCRIPTION
# Description
When the peer list is long, at the bottom it's truncated

while chatting:
<img width="288" height="634" alt="Screenshot 2025-09-09 at 11 50 17 PM" src="https://github.com/user-attachments/assets/0d741502-0444-4eb1-b9e3-87074b3ceffb" />

replicated the issue:

https://github.com/user-attachments/assets/e5521297-5a9e-44af-ac36-67567ecd6680

fix:

https://github.com/user-attachments/assets/ab571804-55dd-41a4-95ed-ffadc310bc2e

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->