### PR TITLE
fix github tests

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -39,13 +39,14 @@ jobs:
     - name: Run unit tests
       run: ./gradlew testDebugUnitTest
 
-    - name: Generate test report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()
+    - name: Upload Test Reports (xml+html)
+      if: always()
+      uses: actions/upload-artifact@v4
       with:
-        name: Unit Test Results
-        path: '**/build/test-results/testDebugUnitTest/TEST-*.xml'
-        reporter: java-junit
+        name: test-reports
+        path: |
+          **/build/test-results/
+          **/build/reports/tests/
 
     - name: Upload test results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description
This PR removes dorny/test-reporter from the CI workflow and replaces it with artifact uploads for test results.

`dorny/test-reporter` fails on PRs from forks because GitHub restricts write permissions to checks/annotations, leading to:

`Error: HttpError: Resource not accessible by integration`

Using actions/upload-artifact ensures test reports are still collected and downloadable, while keeping the workflow OSS-friendly and reliable.

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->