### PR TITLE
fix: clear channel messages on reset

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/MessageManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageManager.kt
@@ -37,6 +37,7 @@ class MessageManager(private val state: ChatState) {
     
     fun clearMessages() {
         state.setMessages(emptyList())
+        state.setChannelMessages(emptyMap())
     }
     
     // MARK: - Channel Message Management


### PR DESCRIPTION
Closes [422](https://github.com/permissionlesstech/bitchat-android/issues/422)
When `clearMessages` is called, it now also clears the `channelMessages` in the state, ensuring that messages from specific channels are also removed.

# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [x] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x] If it is a core feature, I have added automated tests
