### PR TITLE
fix: Resolve debug settings bottom sheet crash on some devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+## [1.4.0] - 2025-10-15
+### Fixed
+- fix: Resolve debug settings bottom sheet crash on some devices (Issue #472)
+  - Fixed IllegalFormatConversionException in DebugSettingsSheet.kt when scrolling through debug settings
+  - Corrected string formatting for debug_target_fpr_fmt and debug_derived_p_fmt string resources
+  - Improved string resource parameter handling for numeric values
+
 ## [0.7.2] - 2025-07-20
 ### Fixed
 - fix: battery optimization screen content scrollable with fixed buttons

--- a/app/src/main/java/com/bitchat/android/ui/debug/DebugSettingsSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/debug/DebugSettingsSheet.kt
@@ -301,14 +301,17 @@ fun DebugSettingsSheet(
                         Slider(value = seenCapacity.toFloat(), onValueChange = { manager.setSeenPacketCapacity(it.toInt()) }, valueRange = 10f..1000f, steps = 99)
                         Text(stringResource(R.string.debug_max_gcs_filter_size_fmt, gcsMaxBytes), fontFamily = FontFamily.Monospace, fontSize = 11.sp, color = colorScheme.onSurface.copy(alpha = 0.7f))
                         Slider(value = gcsMaxBytes.toFloat(), onValueChange = { manager.setGcsMaxBytes(it.toInt()) }, valueRange = 128f..1024f, steps = 0)
-                        Text(stringResource(R.string.debug_target_fpr_fmt, String.format("%.2f", gcsFpr)), fontFamily = FontFamily.Monospace, fontSize = 11.sp, color = colorScheme.onSurface.copy(alpha = 0.7f))
+                        Text(stringResource(R.string.debug_target_fpr_fmt, gcsFpr), fontFamily = FontFamily.Monospace, fontSize = 11.sp, color = colorScheme.onSurface.copy(alpha = 0.7f))
                         Slider(value = gcsFpr.toFloat(), onValueChange = { manager.setGcsFprPercent(it.toDouble()) }, valueRange = 0.1f..5.0f, steps = 49)
                         val p = remember(gcsFpr) { com.bitchat.android.sync.GCSFilter.deriveP(gcsFpr / 100.0) }
                         val nmax = remember(gcsFpr, gcsMaxBytes) { com.bitchat.android.sync.GCSFilter.estimateMaxElementsForSize(gcsMaxBytes, p) }
-                        Text(stringResource(R.string.debug_derived_p_fmt, p, nmax), fontFamily = FontFamily.Monospace, fontSize = 11.sp, color = colorScheme.onSurface.copy(alpha = 0.7f))
+                        Text(stringResource(R.string.debug_derived_p_fmt, p.toString(), nmax.toString()), fontFamily = FontFamily.Monospace, fontSize = 11.sp, color = colorScheme.onSurface.copy(alpha = 0.7f))
                     }
                 }
             }
+
+
+
 
             // Connected devices
             item {


### PR DESCRIPTION
# Fixes #472 - App crashing in debug settings
## Description

### The issue was in ui/debug/DebugSettingsSheet.kt:
- Issue: #472 App crashing in debug settings
- Line 304: Code was pre-formatting double value with String.format() then passing to string resource that expected raw double parameter
- Line 307: Numeric values weren't properly converted to strings for string resource that expected string parameters Changes made:

### Fix:
- Changed stringResource(R.string.debug_target_fpr_fmt, String.format("%.2f", gcsFpr)) to stringResource(R.string.debug_target_fpr_fmt, gcsFpr) - passes raw double value
- Changed stringResource(R.string.debug_derived_p_fmt, p, nmax) to stringResource(R.string.debug_derived_p_fmt, p.toString(), nmax.toString()) - properly converts numeric values to strings This resolves the IllegalFormatConversionException: f != java.lang.String crash when scrolling through the debug settings bottom sheet.


## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x] If it is a core feature, I have added automated tests
