### PR TITLE
show media buttons only in mesh

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -99,6 +99,13 @@ fun ChatScreen(viewModel: ChatViewModel) {
         }
     }
 
+    // Determine whether to show media buttons (only hide in geohash location chats)
+    val showMediaButtons = when {
+        selectedPrivatePeer != null -> true
+        currentChannel != null -> true
+        else -> selectedLocationChannel !is com.bitchat.android.geohash.ChannelID.Location
+    }
+
     // Use WindowInsets to handle keyboard properly
     Box(
         modifier = Modifier
@@ -227,7 +234,8 @@ fun ChatScreen(viewModel: ChatViewModel) {
                 selectedPrivatePeer = selectedPrivatePeer,
                 currentChannel = currentChannel,
                 nickname = nickname,
-                colorScheme = colorScheme
+                colorScheme = colorScheme,
+                showMediaButtons = showMediaButtons
             )
         }
 
@@ -386,7 +394,8 @@ private fun ChatInputSection(
     selectedPrivatePeer: String?,
     currentChannel: String?,
     nickname: String,
-    colorScheme: ColorScheme
+    colorScheme: ColorScheme,
+    showMediaButtons: Boolean
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -422,6 +431,7 @@ private fun ChatInputSection(
                 selectedPrivatePeer = selectedPrivatePeer,
                 currentChannel = currentChannel,
                 nickname = nickname,
+                showMediaButtons = showMediaButtons,
                 modifier = Modifier.fillMaxWidth()
             )
         }

--- a/app/src/main/java/com/bitchat/android/ui/InputComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/InputComponents.kt
@@ -170,6 +170,7 @@ fun MessageInput(
     selectedPrivatePeer: String?,
     currentChannel: String?,
     nickname: String,
+    showMediaButtons: Boolean,
     modifier: Modifier = Modifier
 ) {
     val colorScheme = MaterialTheme.colorScheme
@@ -252,8 +253,8 @@ fun MessageInput(
         
         Spacer(modifier = Modifier.width(8.dp)) // Reduced spacing
         
-        // Voice and image buttons when no text (always visible for mesh + channels + private)
-        if (value.text.isEmpty()) {
+        // Voice and image buttons when no text (only visible in Mesh chat)
+        if (value.text.isEmpty() && showMediaButtons) {
             // Hold-to-record microphone
             val bg = if (colorScheme.background == Color.Black) Color(0xFF00FF00).copy(alpha = 0.75f) else Color(0xFF008000).copy(alpha = 0.75f)
 


### PR DESCRIPTION
# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [ ] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
