### PR TITLE
Add new relay URL to NostrRelayManager

### DIFF
--- a/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
@@ -37,7 +37,8 @@ class NostrRelayManager private constructor() {
             "wss://relay.damus.io",
             "wss://relay.primal.net",
             "wss://offchain.pub",
-            "wss://nostr21.com"
+            "wss://nostr21.com",
+            "wss://sendit.nosflare.com"
         )
         
         // Exponential backoff configuration (same as iOS)
@@ -223,7 +224,8 @@ class NostrRelayManager private constructor() {
                 "wss://relay.damus.io",
                 "wss://relay.primal.net",
                 "wss://offchain.pub",
-                "wss://nostr21.com"
+                "wss://nostr21.com",
+                "wss://sendit.nosflare.com"
             )
             relaysList.addAll(defaultRelayUrls.map { Relay(it) })
             _relays.postValue(relaysList.toList())


### PR DESCRIPTION
Add the blaster relay so that outgoing messages in geohash channels for teleported users are sent to bridged bitchat clients. Perhaps, also add as a blaster for all geohash channels that leverage the GPS-related relays with some regex pattern to ensure all locations use the `wss://sendit.nosflare.com` blaster relay when `app/src/main/assets/nostr_relays.csv` is used.

Closes: https://github.com/permissionlesstech/bitchat-android/issues/495

# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [X ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [X ] I have performed a self-review of my code
<!-- - [ N/A] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ X] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [N/A ] If it is a core feature, I have added automated tests
