### PR TITLE
Fix direct peer detection by binding on per-connection first ANNOUNCE and never dropping ANNOUNCE as duplicates

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
@@ -84,6 +84,10 @@ class BluetoothConnectionManager(
     
     // Public property for address-peer mapping
     val addressPeerMap get() = connectionTracker.addressPeerMap
+
+    // Expose first-announce helpers to higher layers
+    fun noteAnnounceReceived(address: String) { connectionTracker.noteAnnounceReceived(address) }
+    fun hasSeenFirstAnnounce(address: String): Boolean = connectionTracker.hasSeenFirstAnnounce(address)
     
     init {
         powerManager.delegate = this

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionTracker.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionTracker.kt
@@ -30,6 +30,8 @@ class BluetoothConnectionTracker(
     private val connectedDevices = ConcurrentHashMap<String, DeviceConnection>()
     private val subscribedDevices = CopyOnWriteArrayList<BluetoothDevice>()
     val addressPeerMap = ConcurrentHashMap<String, String>()
+    // Track whether we have seen the first ANNOUNCE on a given device connection
+    private val firstAnnounceSeen = ConcurrentHashMap<String, Boolean>()
     
     // RSSI tracking from scan results (for devices we discover but may connect as servers)
     private val scanRSSI = ConcurrentHashMap<String, Int>()
@@ -91,6 +93,8 @@ class BluetoothConnectionTracker(
         Log.d(TAG, "Tracker: Adding device connection for $deviceAddress (isClient: ${deviceConn.isClient}")
         connectedDevices[deviceAddress] = deviceConn
         pendingConnections.remove(deviceAddress)
+        // Mark as awaiting first ANNOUNCE on this connection
+        firstAnnounceSeen[deviceAddress] = false
     }
     
     /**
@@ -280,6 +284,7 @@ class BluetoothConnectionTracker(
             addressPeerMap.remove(deviceAddress)
         }
         pendingConnections.remove(deviceAddress)
+        firstAnnounceSeen.remove(deviceAddress)
         Log.d(TAG, "Cleaned up device connection for $deviceAddress")
     }
     
@@ -313,6 +318,21 @@ class BluetoothConnectionTracker(
         addressPeerMap.clear()
         pendingConnections.clear()
         scanRSSI.clear()
+        firstAnnounceSeen.clear()
+    }
+
+    /**
+     * Mark that we have received the first ANNOUNCE over this device connection.
+     */
+    fun noteAnnounceReceived(deviceAddress: String) {
+        firstAnnounceSeen[deviceAddress] = true
+    }
+
+    /**
+     * Check whether the first ANNOUNCE has been seen for a device connection.
+     */
+    fun hasSeenFirstAnnounce(deviceAddress: String): Boolean {
+        return firstAnnounceSeen[deviceAddress] == true
     }
     
     /**

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -408,25 +408,17 @@ class BluetoothMeshService(private val context: Context) {
                     val deviceAddress = routed.relayAddress
                     val pid = routed.peerID
                     if (deviceAddress != null && pid != null) {
-                        // Only set mapping if not already mapped
-                        if (!connectionManager.addressPeerMap.containsKey(deviceAddress)) {
+                        // First ANNOUNCE over a device connection defines a direct neighbor.
+                        if (!connectionManager.hasSeenFirstAnnounce(deviceAddress)) {
+                            // Bind or rebind this device address to the announcing peer
                             connectionManager.addressPeerMap[deviceAddress] = pid
-                            Log.d(TAG, "Mapped device $deviceAddress to peer $pid on ANNOUNCE")
+                            connectionManager.noteAnnounceReceived(deviceAddress)
+                            Log.d(TAG, "Mapped device $deviceAddress to peer $pid on FIRST-ANNOUNCE for this connection")
 
-                            // Mark this peer as directly connected for UI
-                            try {
-                                peerManager.getPeerInfo(pid)?.let {
-                                    // Set direct connection flag
-                                    // (This will also trigger a peer list update)
-                                    peerManager.setDirectConnection(pid, true)
-                                    // Also push reactive directness state to UI (best-effort)
-                                    try {
-                                        // Note: UI observes via didUpdatePeerList, but we can also update ChatState on a timer
-                                    } catch (_: Exception) { }
-                                }
-                            } catch (_: Exception) { }
+                            // Mark as directly connected (upgrades from routed if needed)
+                            try { peerManager.setDirectConnection(pid, true) } catch (_: Exception) { }
 
-                            // Schedule initial sync for this new directly connected peer only
+                            // Initial sync for this newly direct peer
                             try { gossipSyncManager.scheduleInitialSyncToPeer(pid, 1_000) } catch (_: Exception) { }
                         }
                     }


### PR DESCRIPTION
- Problem: Sometimes peers that are directly connected appear as “routed” or don’t show up in the sidebar as active. Root cause is a race between relayed vs direct ANNOUNCE
handling and aggressive duplicate filtering that can drop the direct copy.
- Solution: Treat the first ANNOUNCE received on a BLE device connection as the direct-binding event and mark the peer as direct. Ensure ANNOUNCE packets are never dropped by the
duplicate filter so we can’t miss the per-connection first-announce event.

Background and Symptoms

- Logs show we verify ANNOUNCE from a peer but still fail to mark them as direct or show them as active. Duplicates around type 1 (ANNOUNCE) are dropped:
    - “Dropping duplicate packet: ...”
    - “Packet failed security validation …”
- ANNOUNCE can arrive over multiple paths:
    - Direct: from the device we are connected to.
    - Relayed: via a neighbor, then to us. This can be seen before the direct path delivers its copy.
- Existing logic only binds device address→peer in the ANNOUNCE handler and may bind using the first copy (possibly relayed), or drop the later direct copy as a duplicate.

Design

- Protocol truth: The first ANNOUNCE received over a specific BLE device connection indicates a direct neighbor on that link.
- Implementation:
    - Track “first ANNOUNCE” per BLE device connection (per MAC).
    - On the first ANNOUNCE over that MAC, bind deviceAddress→peerID and mark the peer as direct (upgrade from routed).
    - Never deduplicate ANNOUNCE at the SecurityManager layer; they are signed/idempotent and must always be processed to guarantee per-connection binding.

Changes

- BluetoothConnectionTracker
    - Added firstAnnounceSeen: ConcurrentHashMap<String, Boolean>.
    - Set to false in addDeviceConnection; remove/reset on cleanup and clear.
    - Added noteAnnounceReceived(address) and hasSeenFirstAnnounce(address).
- BluetoothConnectionManager
    - Exposed noteAnnounceReceived(address) and hasSeenFirstAnnounce(address) to higher layers.
- BluetoothMeshService
    - In PacketProcessor.delegate.handleAnnounce(routed):
        - If deviceAddress and peerID are non-null and hasSeenFirstAnnounce(address) is false:
            - Bind addressPeerMap[deviceAddress] = peerID.
            - Call noteAnnounceReceived(address).
            - Mark peer as direct via PeerManager.setDirectConnection(peerID, true).
            - Schedule initial sync to the newly direct peer.
- SecurityManager
    - Duplicate detection: Skip deduplication for ANNOUNCE so we never drop it. Other message types remain deduplicated as before.

What to review

- Correctness of per-connection tracking:
    - BluetoothConnectionTracker properly initializes firstAnnounceSeen to false on connection and clears it on disconnect and global clear paths.
    - BluetoothMeshService only binds on the very first ANNOUNCE for a given device address and upgrades the peer’s directness.
- ANNOUNCE dedup implications:
    - SecurityManager validatePacket now allows multiple ANNOUNCE copies; confirm this cannot cause performance or security issues. ANNOUNCE is idempotent and signature-checked
downstream.
    - Verify that skipping ANNOUNCE dedup doesn’t regress any component relying on deduplication behavior.
- Peer life cycle on disconnect:
    - On disconnect, we already set direct=false when the last address mapping for that peer is removed; we do not remove the peer until stale timeout. Validate that this behavior
is intact with the new binding.
- Concurrency and thread safety:
    - All new data structures are ConcurrentHashMap; usage follows existing patterns.
    - The binding and marking direct are performed in the same coroutine flow as packet handling; safe for our current architecture.
- Edge cases:
    - Multiple devices from the same peer (rare): first-announce-per-MAC ensures we map each MAC to the peer on its own first ANNOUNCE.
    - Receiving relayed ANNOUNCE before direct: skipped binding until the first ANNOUNCE arrives on the connected device’s MAC; when it does, we upgrade to direct.
    - Reconnects: firstAnnounceSeen is reset on addDeviceConnection, so we’ll bind again on the first ANNOUNCE for the new connection.
    
    Testing plan

- Single direct connection:
    - Connect two devices directly, verify ANNOUNCE is processed and the peer shows as direct, mapped to the MAC.
- Relayed first, then direct:
    - A connects to B; B connects to C. A receives C’s relayed ANNOUNCE via B. Then A connects directly to C:
        - Verify that on the first ANNOUNCE over A↔C MAC, we bind device→peer and mark C as direct (upgrade from routed).
- Disconnect handling:
    - Disconnect the MAC; confirm address→peer mapping is removed and direct flag clears for that peer if no other mapping exists. Peer should remain listed until stale timeout
expires.
- Flood of ANNOUNCE:
    - With dedup disabled for ANNOUNCE, verify no noticeable CPU/memory impact and that identity updates stay idempotent.

Potential risks

- More ANNOUNCE processing under high churn. Mitigated by idempotent peer updates and small processing cost.
- If a device never sends an ANNOUNCE on a connection, mapping won’t occur. This is by design and consistent with the protocol; upstream docs already imply a timeout and cleanup
path.

Files touched

- app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionTracker.kt
- app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
- app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
- app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt

Reviewer checklist

- Verify first-announce logic executes exactly once per device connection (check logs).
- Confirm that peers upgrade to direct when the first direct ANNOUNCE arrives even if a routed path existed.
- Ensure peers are not removed on disconnect; removal only after stale timeout.
- Confirm UI reflects directness changes and the peer appears active when expected.
- Sanity-check SecurityManager change for ANNOUNCE dedup skipping.

This change is minimal and surgical, aligns with the protocol rule (“first ANNOUNCE per connection indicates direct neighbor”), and prevents missing or misbinding direct peers.