### PR TITLE
Feat/dm 2byte tlv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- feat(dm): add backward-compatible 2-byte TLV for Direct Messages with capability signaling to enable Cashu token DMs. Receive supports both 1B/2B; send uses 2B when peer advertises support.
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- feat(dm): add backward-compatible 2-byte TLV for Direct Messages with capability signaling to enable Cashu token DMs. Receive supports both 1B/2B; send uses 2B when peer advertises support.
+- feat(dm): add backward-compatible 2-byte TLV for Direct Messages with capability signaling to enable Cashu token DMs. Receive supports both 1B/2B; send uses 2B when peer advertises support. Enables integration with [bitpoints.me](https://github.com/bitpoints-cashu/bitpoints.me) for offline peer-to-peer Bitcoin payments.
 
 # Changelog
 

--- a/app/src/main/java/com/bitchat/android/mesh/MessageHandler.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/MessageHandler.kt
@@ -267,7 +267,8 @@ class MessageHandler(private val myPeerID: String, private val appContext: andro
             nickname = nickname,
             noisePublicKey = noisePublicKey,
             signingPublicKey = signingPublicKey,
-            isVerified = true
+            isVerified = true,
+            features = announcement.features
         ) ?: false
 
         // Update peer ID binding with noise public key for identity management
@@ -583,7 +584,7 @@ interface MessageHandlerDelegate {
     fun getNetworkSize(): Int
     fun getMyNickname(): String?
     fun getPeerInfo(peerID: String): PeerInfo?
-    fun updatePeerInfo(peerID: String, nickname: String, noisePublicKey: ByteArray, signingPublicKey: ByteArray, isVerified: Boolean): Boolean
+    fun updatePeerInfo(peerID: String, nickname: String, noisePublicKey: ByteArray, signingPublicKey: ByteArray, isVerified: Boolean, features: Int = 0): Boolean
     
     // Packet operations
     fun sendPacket(packet: BitchatPacket)

--- a/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
@@ -17,7 +17,8 @@ data class PeerInfo(
     var noisePublicKey: ByteArray?,
     var signingPublicKey: ByteArray?,      // NEW: Ed25519 public key for verification
     var isVerifiedNickname: Boolean,       // NEW: Verification status flag
-    var lastSeen: Long  // Using Long instead of Date for simplicity
+    var lastSeen: Long,  // Using Long instead of Date for simplicity
+    var features: Int = 0                  // Feature bitmask from announcements
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -39,6 +40,7 @@ data class PeerInfo(
         } else if (other.signingPublicKey != null) return false
         if (isVerifiedNickname != other.isVerifiedNickname) return false
         if (lastSeen != other.lastSeen) return false
+        if (features != other.features) return false
         
         return true
     }
@@ -52,6 +54,7 @@ data class PeerInfo(
         result = 31 * result + (signingPublicKey?.contentHashCode() ?: 0)
         result = 31 * result + isVerifiedNickname.hashCode()
         result = 31 * result + lastSeen.hashCode()
+        result = 31 * result + features.hashCode()
         return result
     }
 }
@@ -104,7 +107,8 @@ class PeerManager {
         nickname: String,
         noisePublicKey: ByteArray,
         signingPublicKey: ByteArray,
-        isVerified: Boolean
+        isVerified: Boolean,
+        features: Int = 0
     ): Boolean {
         if (peerID == "unknown") return false
         
@@ -121,7 +125,8 @@ class PeerManager {
             noisePublicKey = noisePublicKey,
             signingPublicKey = signingPublicKey,
             isVerifiedNickname = isVerified,
-            lastSeen = now
+            lastSeen = now,
+            features = features
         )
         
         peers[peerID] = peerInfo
@@ -149,6 +154,14 @@ class PeerManager {
      */
     fun getPeerInfo(peerID: String): PeerInfo? {
         return peers[peerID]
+    }
+
+    /**
+     * Check if a peer advertises a feature bit.
+     */
+    fun peerHasFeature(peerID: String, featureBit: Int): Boolean {
+        val f = peers[peerID]?.features ?: 0
+        return (f and featureBit) != 0
     }
 
     /**

--- a/app/src/main/java/com/bitchat/android/protocol/ProtocolFeatures.kt
+++ b/app/src/main/java/com/bitchat/android/protocol/ProtocolFeatures.kt
@@ -1,0 +1,8 @@
+package com.bitchat.android.protocol
+
+object ProtocolFeatures {
+    // Feature bits advertised in announcements (bitmask)
+    const val DM_TLV_2BYTE: Int = 1 shl 0
+}
+
+

--- a/app/src/main/java/com/bitchat/android/protocol/ProtocolFeatures.kt
+++ b/app/src/main/java/com/bitchat/android/protocol/ProtocolFeatures.kt
@@ -4,5 +4,3 @@ object ProtocolFeatures {
     // Feature bits advertised in announcements (bitmask)
     const val DM_TLV_2BYTE: Int = 1 shl 0
 }
-
-

--- a/app/src/test/java/com/bitchat/android/model/PrivateMessagePacketTest.kt
+++ b/app/src/test/java/com/bitchat/android/model/PrivateMessagePacketTest.kt
@@ -1,0 +1,33 @@
+package com.bitchat.android.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class PrivateMessagePacketTest {
+
+    @Test
+    fun encodeDecode1B_roundtrip() {
+        val pm = PrivateMessagePacket(messageID = "abc-123", content = "hello cashu")
+        val tlv = pm.encode()
+        assertNotNull(tlv)
+        val decoded = PrivateMessagePacket.decode(tlv!!)
+        assertNotNull(decoded)
+        assertEquals(pm.messageID, decoded!!.messageID)
+        assertEquals(pm.content, decoded.content)
+    }
+
+    @Test
+    fun encodeDecode2B_roundtrip() {
+        val longContent = "x".repeat(300)
+        val pm = PrivateMessagePacket(messageID = "id-300", content = longContent)
+        val tlv = pm.encode2B()
+        assertNotNull(tlv)
+        val decoded = PrivateMessagePacket.decode(tlv!!)
+        assertNotNull(decoded)
+        assertEquals(pm.messageID, decoded!!.messageID)
+        assertEquals(pm.content, decoded.content)
+    }
+}
+
+

--- a/app/src/test/java/com/bitchat/android/model/PrivateMessagePacketTest.kt
+++ b/app/src/test/java/com/bitchat/android/model/PrivateMessagePacketTest.kt
@@ -29,5 +29,3 @@ class PrivateMessagePacketTest {
         assertEquals(pm.content, decoded.content)
     }
 }
-
-

--- a/docs/dm_tlv.md
+++ b/docs/dm_tlv.md
@@ -1,0 +1,24 @@
+# Direct Message TLV: 1-byte to 2-byte (Backward-Compatible)
+
+This change enables sending and receiving Cashu ecash tokens over Direct Messages by introducing a 2-byte TLV format for DMs while keeping backward compatibility.
+
+Key points:
+- Receive path accepts both 1-byte and 2-byte TLV without negotiation (adaptive parser).
+- Send path uses 2-byte TLV only when the peer advertises feature bit `DM_TLV_2BYTE` in announcements.
+- Broadcast path unchanged.
+
+Formats:
+- Legacy (1B): [type:u8][length:u8][value]
+- New (2B): [type:u16][length:u16][value]
+
+Capability Signaling:
+- Announcements include optional `FEATURES` TLV (type 0x04) carrying a big-endian bitmask.
+- Bit 0 (`DM_TLV_2BYTE`) means peer supports 2-byte TLV for DMs.
+
+Security:
+- Noise/AES-GCM unchanged; strict bounds checks on TLV length.
+
+Interop:
+- Older peers ignore unknown `FEATURES` TLV and continue receiving DMs in legacy format.
+
+

--- a/docs/dm_tlv.md
+++ b/docs/dm_tlv.md
@@ -2,6 +2,8 @@
 
 This change enables sending and receiving Cashu ecash tokens over Direct Messages by introducing a 2-byte TLV format for DMs while keeping backward compatibility.
 
+**Cashu Integration**: This change enables [bitpoints.me](https://github.com/bitpoints-cashu/bitpoints.me), a Cashu ecash wallet that integrates bitchat protocol for offline peer-to-peer Bitcoin payments over Bluetooth mesh.
+
 Key points:
 - Receive path accepts both 1-byte and 2-byte TLV without negotiation (adaptive parser).
 - Send path uses 2-byte TLV only when the peer advertises feature bit `DM_TLV_2BYTE` in announcements.
@@ -20,5 +22,3 @@ Security:
 
 Interop:
 - Older peers ignore unknown `FEATURES` TLV and continue receiving DMs in legacy format.
-
-


### PR DESCRIPTION
# feat(dm): 2-byte TLV for DMs with backward compatibility - Cashu token support

## Summary
Implements backward-compatible 2-byte TLV encoding for Direct Messages to support Cashu ecash token transmission, which can exceed the 255-byte limit of the legacy 1-byte format.

## Motivation
This change enables integration with [bitpoints.me](https://github.com/bitpoints-cashu/bitpoints.me), a Cashu ecash wallet that uses the bitchat protocol for offline peer-to-peer Bitcoin payments over Bluetooth mesh. Cashu tokens frequently exceed 255 bytes and require the extended TLV format.

## Changes
- ✅ **Backward Compatible**: Receive path supports both 1B and 2B TLV formats automatically
- ✅ **Capability Negotiation**: Peers advertise `DM_TLV_2BYTE` feature bit in announcements
- ✅ **Adaptive Encoding**: Send path uses 2B only when peer supports it
- ✅ **Zero Breaking Changes**: Older clients ignore new feature TLV and continue working
- ✅ **Tested**: Unit tests for both encoding formats with roundtrip validation
- ✅ **Documented**: Technical documentation in `docs/dm_tlv.md`

## Technical Details

### Formats
- **Legacy (1B)**: `[type:u8][length:u8][value]` (max 255 bytes)
- **New (2B)**: `[type:u16][length:u16][value]` (max 65535 bytes)

### Feature Negotiation
- New `ProtocolFeatures.DM_TLV_2BYTE` constant (bit 0x01)
- `IdentityAnnouncement` includes optional `FEATURES` TLV field (type 0x04)
- `PeerManager.peerHasFeature()` checks capability before encoding
- Adaptive decode tries 2B first, falls back to 1B automatically

### Implementation Flow
1. **Announcements**: Peer advertises `DM_TLV_2BYTE` feature bit in identity packets
2. **Capability Check**: `peerManager.peerHasFeature()` verifies support before encoding
3. **Send**: `privateMessage.encode2B()` used when peer has feature; `encode()` otherwise
4. **Receive**: `PrivateMessagePacket.decode()` tries 2B first, falls back to 1B
5. **Broadcast**: Unchanged, remains 1B TLV for all peers

### Security
- Noise/AES-GCM encryption unchanged
- Strict bounds checking on all TLV length fields
- No impact on broadcast messages (remain 1B TLV)
- Unknown TLV fields ignored for forward compatibility

## Integration
Enables [bitpoints.me](https://github.com/bitpoints-cashu/bitpoints.me) - A Cashu.me + Bitchat wallet for:
- Peer-to-peer Cashu token transfers over Bluetooth mesh
- Offline Bitcoin payments without internet
- Merchant rewards and point-of-sale systems
- Interoperable with bitchat mesh networking

### About bitpoints.me
bitpoints.me is a full-featured Cashu ecash wallet with:
- Bluetooth mesh networking using bitchat protocol
- Support for multiple mints and token swapping
- Lightning invoices and QR code send/receive
- Nostr integration for token claiming
- Offline-first architecture for mesh payments

## Testing
- ✅ Unit tests for 1B and 2B encoding/decoding roundtrips
- ✅ Backward compatibility verified with adaptive parser
- ✅ Feature negotiation tested with mixed peer capabilities
- ✅ All existing tests pass

## Files Changed
- `BluetoothMeshService.kt` - Adaptive DM encoding based on peer capabilities
- `MessageHandler.kt` - Feature flag propagation from announcements
- `PeerManager.kt` - Peer feature tracking and capability queries
- `IdentityAnnouncement.kt` - Feature bitmask in announcements (optional TLV)
- `NoiseEncrypted.kt` - Dual TLV parsers (1B/2B) with automatic fallback
- `ProtocolFeatures.kt` - **NEW** Feature bit constants
- `PrivateMessagePacketTest.kt` - **NEW** Unit tests for both formats
- `docs/dm_tlv.md` - **NEW** Technical documentation
- `CHANGELOG.md` - Release notes

## Backward Compatibility
✅ Fully backward compatible:
- Old clients ignore unknown `FEATURES` TLV in announcements
- Old clients receive DMs in legacy 1B format
- Old clients send DMs in legacy 1B format
- No protocol version bump required

## Checklist

- [x] I have read the contribution guidelines: https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing
- [x] I have performed a self-review of my code
- [x] I have run the automated code checks (`./gradlew :app:lintDebug`)
- [x] I have added automated tests for this core feature (`PrivateMessagePacketTest.kt`)

## References
- [bitpoints.me Repository](https://github.com/bitpoints-cashu/bitpoints.me)
- Cashu Protocol: https://docs.cashu.space/
- Technical documentation: `docs/dm_tlv.md`

