### PR TITLE
Add Network permission requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The app requires the following permissions (automatically requested):
 
 - **Bluetooth**: Core BLE functionality
 - **Location**: Required for BLE scanning on Android
+- **Network**: Expand your mesh through public internet relays
 - **Notifications**: Message alerts and background updates
 
 ### Hardware Requirements


### PR DESCRIPTION
It forces Network permission prompt right down your throat, so please explain in readme, I was super irritated as its counter intuitive in regards to apps main selling point!

# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [ ] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
