### PR TITLE
Fix: Add @ConscryptMode annotation to resolve test failures

### DIFF
--- a/app/src/test/kotlin/com/bitchat/FileTransferTest.kt
+++ b/app/src/test/kotlin/com/bitchat/FileTransferTest.kt
@@ -8,12 +8,14 @@ import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.ConscryptMode
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.Date
 
 @RunWith(RobolectricTestRunner::class)
+@ConscryptMode(ConscryptMode.Mode.OFF) // Disable Conscrypt to avoid native library loading issues
 class FileTransferTest {
 
     @Test


### PR DESCRIPTION
## Problem

Unit tests were failing with `UnsatisfiedLinkError` when running Robolectric tests. The error occurred when Conscrypt tried to load its native library during test setup.

All 9 tests in `FileTransferTest` were failing with:
```
java.lang.UnsatisfiedLinkError: Failed creating temp file (/tmp/libconscrypt_openjdk_jni-linux-x86_64...)
    at org.conscrypt.NativeLibraryLoader.loadFromWorkdir(NativeLibraryLoader.java:205)
```

## Solution

Added the `@ConscryptMode(Mode.OFF)` annotation to `FileTransferTest` class. This annotation (available in Robolectric 4.9+) disables Conscrypt and makes Robolectric use BouncyCastle instead, which doesn't require native libraries.

## Changes

- Added `@ConscryptMode(ConscryptMode.Mode.OFF)` annotation to `FileTransferTest`
- Added import for `org.robolectric.annotation.ConscryptMode`

## Testing

- ✅ All 9 tests in FileTransferTest now pass
- ✅ Full build (`./gradlew build`) is successful
- ✅ No dependency upgrades required (Robolectric 4.15 already supports this annotation)

## References

- Fixes #542
- Uses officially supported Robolectric feature per [documentation](https://robolectric.org/configuring/)

