### PR TITLE
Fix header alignment on Samsung Flip 7

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
@@ -566,7 +566,8 @@ private fun MainHeader(
         // Right section with location channels button and peer counter
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(5.dp)
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+            modifier = Modifier.offset(x = (-8).dp) // Shift left to fix alignment on some phones (e.g. Flip 7)
         ) {
 
             // Unread private messages badge (click to open most recent DM)


### PR DESCRIPTION
Add negative offset to right section of MainHeader to correct alignment issue where user count and icons appeared too far to the right on some devices (e.g. Samsung Galaxy Z Flip 7). The offset shifts the entire right section 8dp to the left to match alignment on other devices.