### PR TITLE
fix: sync notification peer count with sidebar

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
@@ -299,8 +299,7 @@ class PeerManager {
      */
     fun isPeerActive(peerID: String): Boolean {
         val info = peers[peerID] ?: return false
-        val now = System.currentTimeMillis()
-        return (now - info.lastSeen) <= stalePeerTimeoutMs && info.isConnected
+        return info.isConnected
     }
     
     /**
@@ -328,8 +327,7 @@ class PeerManager {
      * Get list of active peer IDs
      */
     fun getActivePeerIDs(): List<String> {
-        val now = System.currentTimeMillis()
-        return peers.filterValues { (now - it.lastSeen) <= stalePeerTimeoutMs && it.isConnected }
+        return peers.filterValues { it.isConnected }
             .keys
             .toList()
             .sorted()


### PR DESCRIPTION
## Summary
Fixes a discrepancy between the peer count shown in the sticky notification and the sidebar peer list.

## Changes
- Updated `PeerManager.getActivePeerIDs()` and `isPeerActive()` to remove the redundant time-based staleness check.
- The notification now relies solely on the `peers` map state, which is already managed by the periodic `cleanupStalePeers` job.
- This ensures the notification count matches the sidebar list exactly, as they now use the same source of truth without differing filter logic.