### PR TITLE
Fix scroll bug(#568)

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -71,19 +71,14 @@ fun MessagesList(
     
     // Track if this is the first time messages are being loaded
     var hasScrolledToInitialPosition by remember { mutableStateOf(false) }
+    var followIncomingMessages by remember { mutableStateOf(true) }
     
-    // Smart scroll: auto-scroll to bottom for initial load, then only when user is at or near the bottom
+    // Smart scroll: auto-scroll to bottom for initial load, then follow unless user scrolls away
     LaunchedEffect(messages.size) {
         if (messages.isNotEmpty()) {
-            val layoutInfo = listState.layoutInfo
-            val firstVisibleIndex = layoutInfo.visibleItemsInfo.firstOrNull()?.index ?: -1
-            
-            // With reverseLayout=true and reversed data, index 0 is the latest message at the bottom
             val isFirstLoad = !hasScrolledToInitialPosition
-            val isNearLatest = firstVisibleIndex <= 2
-            
-            if (isFirstLoad || isNearLatest) {
-                listState.animateScrollToItem(0)
+            if (isFirstLoad || followIncomingMessages) {
+                listState.scrollToItem(0)
                 if (isFirstLoad) {
                     hasScrolledToInitialPosition = true
                 }
@@ -99,6 +94,7 @@ fun MessagesList(
         }
     }
     LaunchedEffect(isAtLatest) {
+        followIncomingMessages = isAtLatest
         onScrolledUpChanged?.invoke(!isAtLatest)
     }
     
@@ -106,7 +102,8 @@ fun MessagesList(
     LaunchedEffect(forceScrollToBottom) {
         if (messages.isNotEmpty()) {
             // With reverseLayout=true and reversed data, latest is at index 0
-            listState.animateScrollToItem(0)
+            followIncomingMessages = true
+            listState.scrollToItem(0)
         }
     }
     


### PR DESCRIPTION
# Description
Fix bug(https://github.com/permissionlesstech/bitchat-android/issues/568) scroll down 

Replaced the "smart scroll" mechanism with a simpler "follow" behavior. The message list now automatically scrolls to the latest message unless the user has scrolled up.

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [ ] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
