### PR TITLE
fix camera button

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/media/ImagePickerButton.kt
+++ b/app/src/main/java/com/bitchat/android/ui/media/ImagePickerButton.kt
@@ -1,5 +1,7 @@
 package com.bitchat.android.ui.media
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -19,6 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import com.bitchat.android.features.media.ImageUtils
 import java.io.File
@@ -75,12 +78,26 @@ fun ImagePickerButton(
         }
     }
 
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            startCameraCapture()
+        }
+    }
+
     Box(
         modifier = modifier
             .size(32.dp)
             .combinedClickable(
                 onClick = { imagePicker.launch("image/*") },
-                onLongClick = { startCameraCapture() }
+                onLongClick = {
+                    if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
+                        startCameraCapture()
+                    } else {
+                        permissionLauncher.launch(Manifest.permission.CAMERA)
+                    }
+                }
             ),
         contentAlignment = Alignment.Center
     ) {


### PR DESCRIPTION
## 🐛 Fix: Camera Crash on Long Press

**Broken by:** Commit `c663e8e` (Jan 4, 2026) in PR #529 (QR Verification).

**Technical Root Cause:**
The QR Verification feature added `<uses-permission android:name="android.permission.CAMERA" />` to `AndroidManifest.xml`.
*   **Before:** The app did not declare the CAMERA permission. Android allows apps to use `MediaStore.ACTION_IMAGE_CAPTURE` to delegate photo taking to the system camera app without requiring any permissions.
*   **After:** Once the CAMERA permission is declared in the manifest, Android enforces that the app *must* have this permission granted at runtime to use the camera, even when using an external intent like `ACTION_IMAGE_CAPTURE`. Failing to do so results in a `SecurityException`.

**The Fix:**
Updated `ImagePickerButton.kt` to explicitly check for `Manifest.permission.CAMERA` at runtime and request it if not granted, before launching the camera intent.

---
# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [ ] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests