### PR TITLE
Improve DM Handshake UI and Queue Reliability

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -188,6 +188,12 @@ class BluetoothMeshService(private val context: Context) {
         // SecurityManager delegate for key exchange notifications
         securityManager.delegate = object : SecurityManagerDelegate {
             override fun onKeyExchangeCompleted(peerID: String, peerPublicKeyData: ByteArray) {
+                // Immediate notification for UI updates
+                delegate?.onSessionEstablished(peerID)
+                
+                // Flush router outbox immediately
+                com.bitchat.android.services.MessageRouter.tryGetInstance()?.onSessionEstablished(peerID)
+
                 // Send announcement and cached messages after key exchange
                 serviceScope.launch {
                     Log.d(TAG, "Key exchange completed with $peerID; sending follow-ups")
@@ -1418,5 +1424,6 @@ interface BluetoothMeshDelegate {
     fun decryptChannelMessage(encryptedContent: ByteArray, channel: String): String?
     fun getNickname(): String?
     fun isFavorite(peerID: String): Boolean
-    // registerPeerPublicKey REMOVED - fingerprints now handled centrally in PeerManager
+    fun onSessionEstablished(peerID: String)
 }
+

--- a/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
@@ -26,10 +26,43 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.bitchat.android.core.ui.utils.singleOrTripleClickable
+import androidx.compose.animation.core.*
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.foundation.Canvas
 import androidx.compose.ui.geometry.Offset
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.bitchat.android.core.ui.utils.singleOrTripleClickable
+
+/**
+ * Animated dots for handshake state
+ */
+@Composable
+fun HandshakeAnimatedDots() {
+    val infiniteTransition = rememberInfiniteTransition(label = "handshakeDots")
+    val dotCount by infiniteTransition.animateValue(
+        initialValue = 1,
+        targetValue = 4,
+        typeConverter = Int.VectorConverter,
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                durationMillis = 1500
+                1 at 0
+                2 at 500
+                3 at 1000
+                1 at 1499
+            },
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "dotCount"
+    )
+
+    Text(
+        text = ".".repeat(dotCount),
+        style = MaterialTheme.typography.titleMedium,
+        color = Color(0xFFFF9500),
+        modifier = Modifier.width(20.dp)
+    )
+}
 
 /**
  * Header components for ChatScreen
@@ -92,8 +125,8 @@ fun NoiseSessionIcon(
             stringResource(R.string.cd_ready_for_handshake)
         )
         "handshaking" -> Triple(
-            Icons.Outlined.Sync,
-            Color(0x87878700), // Grey - in progress
+            null,
+            Color.Transparent,
             stringResource(R.string.cd_handshake_in_progress)
         )
         "established" -> Triple(
@@ -110,12 +143,16 @@ fun NoiseSessionIcon(
         }
     }
     
-    Icon(
-        imageVector = icon,
-        contentDescription = contentDescription,
-        modifier = modifier,
-        tint = color
-    )
+    if (icon != null) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            modifier = modifier,
+            tint = color
+        )
+    } else {
+        Spacer(modifier = modifier)
+    }
 }
 
 @Composable
@@ -410,8 +447,14 @@ private fun PrivateChatHeader(
             Text(
                 text = titleText,
                 style = MaterialTheme.typography.titleMedium,
-                color = Color(0xFFFF9500) // Orange
+                color = Color(0xFFFF9500), // Orange
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
+
+            if (sessionState == "handshaking") {
+                HandshakeAnimatedDots()
+            }
 
             Spacer(modifier = Modifier.width(4.dp))
 

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -879,6 +879,10 @@ class ChatViewModel(
     override fun isFavorite(peerID: String): Boolean {
         return meshDelegateHandler.isFavorite(peerID)
     }
+
+    override fun onSessionEstablished(peerID: String) {
+        meshDelegateHandler.onSessionEstablished(peerID)
+    }
     
     // registerPeerPublicKey REMOVED - fingerprints now handled centrally in PeerManager
     

--- a/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
@@ -234,6 +234,15 @@ class MeshDelegateHandler(
     override fun isFavorite(peerID: String): Boolean {
         return privateChatManager.isFavorite(peerID)
     }
+
+    override fun onSessionEstablished(peerID: String) {
+        coroutineScope.launch {
+            val sessionStates = state.getPeerSessionStatesValue().toMutableMap()
+            sessionStates[peerID] = "established"
+            state.setPeerSessionStates(sessionStates)
+            android.util.Log.d("MeshDelegateHandler", "UI: Updated session state to 'established' for $peerID")
+        }
+    }
     
     /**
      * Check for mentions in mesh messages and trigger notifications


### PR DESCRIPTION
## Summary
This PR improves the responsiveness and reliability of private messaging during the Noise session establishment phase.

### Key Changes
- **Animated Handshake Feedback**: Replaced the static "refresh" icon with an animated "..." text indicator in the chat header while a handshake is in progress.
- **Thread-Safe DM Queue**: Refactored `MessageRouter` to use `ConcurrentHashMap` and synchronized lists, ensuring safe concurrent access between the UI and background services.
- **Immediate Delivery**: Implemented instant message flushing upon handshake completion. Messages no longer wait for the 1-second polling cycle.
- **Direct UI Updates**: Added an `onSessionEstablished` callback to the mesh delegate to allow the UI to transition immediately from "handshaking" to "secure" state.

### Verification Results
- Verified that messages sent before a session is established are correctly queued and delivered immediately upon handshake.
- Confirmed the UI remains responsive and the animated indicator works as expected.
- Verified that thread-safety improvements prevent potential race conditions in the `MessageRouter` outbox.

### Reviewer Recommendations
- Focus on the `MessageRouter.kt` changes for thread-safety.
- Check the integration of the new `onSessionEstablished` delegate method in `ChatViewModel` and `MeshDelegateHandler`.