### PR TITLE
security: prevent screenshots of recent apps list

### DIFF
--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -3,6 +3,7 @@ package com.bitchat.android
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.WindowManager
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -76,6 +77,8 @@ class MainActivity : OrientationAwareActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         
         // Register receiver for force finish signal from shutdown coordinator
         val filter = android.content.IntentFilter(com.bitchat.android.util.AppConstants.UI.ACTION_FORCE_FINISH)


### PR DESCRIPTION
### Closes #595
Added `FLAG_SECURE` to `MainActivity` window to prevent sensitive chat content from appearing in app switcher snapshots.