### PR TITLE
security: prevent storage exhaustion by saving incoming files to cache

### DIFF
--- a/app/src/main/java/com/bitchat/android/features/file/FileUtils.kt
+++ b/app/src/main/java/com/bitchat/android/features/file/FileUtils.kt
@@ -197,7 +197,9 @@ object FileUtils {
     ): String {
         val lowerMime = file.mimeType.lowercase()
         val isImage = lowerMime.startsWith("image/")
-        val baseDir = context.filesDir
+        // FIX: Use cacheDir instead of filesDir to prevent storage exhaustion attacks (Issue #592)
+        // Files in cacheDir are eligible for automatic system cleanup when space is low
+        val baseDir = context.cacheDir
         val subdir = if (isImage) "images/incoming" else "files/incoming"
         val dir = java.io.File(baseDir, subdir).apply { mkdirs() }
 


### PR DESCRIPTION
## Summary
Fixes #592

This PR mitigates the risk of storage exhaustion attacks (DoS) by changing the default storage location for incoming files.
- Files are now saved to `context.cacheDir` instead of `context.filesDir`.
- This ensures that the OS can reclaim space if needed, preventing the app from filling up the user's permanent storage with automatically downloaded files.

This addresses the "Automatic File Persistence Facilitates DoS" vulnerability found in the audit.