### PR TITLE
security: ensure media files are deleted during panic mode

### DIFF
--- a/app/src/main/java/com/bitchat/android/features/file/FileUtils.kt
+++ b/app/src/main/java/com/bitchat/android/features/file/FileUtils.kt
@@ -273,4 +273,54 @@ object FileUtils {
             else -> com.bitchat.android.model.BitchatMessageType.File
         }
     }
+
+    /**
+     * Recursively delete all media files (incoming and outgoing)
+     * Used for Panic Mode cleanup
+     */
+    fun clearAllMedia(context: Context) {
+        try {
+            // Clear files dir subdirectories (legacy storage and outgoing)
+            val filesDir = context.filesDir
+            val dirsToClear = listOf(
+                "files/incoming",
+                "files/outgoing",
+                "images/incoming",
+                "images/outgoing",
+                "voicenotes"
+            )
+
+            dirsToClear.forEach { subDir ->
+                val dir = File(filesDir, subDir)
+                if (dir.exists()) {
+                    dir.deleteRecursively()
+                    Log.d(TAG, "Deleted media directory from filesDir: $subDir")
+                }
+            }
+            
+            // Clear cache dir subdirectories (new incoming storage)
+            // Note: cacheDir.deleteRecursively() below would handle this, but being explicit ensures these
+            // specific media folders are targeted even if full cache clear fails or is modified later.
+            val cacheDir = context.cacheDir
+            val cacheDirsToClear = listOf(
+                "files/incoming",
+                "images/incoming"
+            )
+            
+            cacheDirsToClear.forEach { subDir ->
+                val dir = File(cacheDir, subDir)
+                if (dir.exists()) {
+                    dir.deleteRecursively()
+                    Log.d(TAG, "Deleted media directory from cacheDir: $subDir")
+                }
+            }
+            
+            // Also clear entire cache dir as a catch-all
+            context.cacheDir.deleteRecursively()
+            Log.d(TAG, "Cleared entire cache directory")
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to clear media files", e)
+        }
+    }
 }

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -926,6 +926,9 @@ class ChatViewModel(
         
         // Clear all notifications
         notificationManager.clearAllNotifications()
+
+        // Clear all media files
+        com.bitchat.android.features.file.FileUtils.clearAllMedia(getApplication())
         
         // Clear Nostr/geohash state, keys, connections, bookmarks, and reinitialize from scratch
         try {


### PR DESCRIPTION
## Summary
Fixes #591

This PR addresses the issue where unencrypted media files persisted after Panic Mode was activated.
- Implemented `FileUtils.clearAllMedia()` to recursively delete `files/incoming`, `files/outgoing`, `images/incoming`, `images/outgoing`, `voice_notes`, and the app cache.
- Integrated this cleanup into `ChatViewModel.panicClearAllData()`.

This ensures that sensitive media content is removed along with other data when the user triggers Panic Mode.