### PR TITLE
feat: Stable BLE Peer Identity via Scan Response

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
@@ -70,7 +70,7 @@ class BluetoothConnectionManager(
     }
     
     private val serverManager = BluetoothGattServerManager(
-        context, connectionScope, connectionTracker, permissionManager, powerManager, componentDelegate
+        context, connectionScope, connectionTracker, permissionManager, powerManager, componentDelegate, myPeerID
     )
     private val clientManager = BluetoothGattClientManager(
         context, connectionScope, connectionTracker, permissionManager, powerManager, componentDelegate

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionTracker.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionTracker.kt
@@ -51,7 +51,8 @@ class BluetoothConnectionTracker(
         val characteristic: BluetoothGattCharacteristic? = null,
         val rssi: Int = Int.MIN_VALUE,
         val isClient: Boolean = false,
-        val connectedAt: Long = System.currentTimeMillis()
+        val connectedAt: Long = System.currentTimeMillis(),
+        val peerID: String? = null
     )
     
     /**
@@ -169,6 +170,14 @@ class BluetoothConnectionTracker(
      */
     fun isDeviceConnected(deviceAddress: String): Boolean {
         return connectedDevices.containsKey(deviceAddress)
+    }
+
+    /**
+     * Check if a peer is already connected (by PeerID)
+     */
+    fun isPeerConnected(peerID: String): Boolean {
+        // Only consider actual connected devices that have identified themselves
+        return connectedDevices.values.any { it.peerID == peerID }
     }
     
     /**


### PR DESCRIPTION
## Summary
This PR solves the issue of duplicate BLE connections caused by Android/iOS MAC address randomization. It embeds a stable `peerID` into the BLE Scan Response, allowing scanners to identify and deduplicate peers regardless of their current MAC address.

## Rationale
- **Problem**: Android and iOS randomize Bluetooth MAC addresses for privacy. A scanner seeing a rotated MAC address would previously treat it as a new device and attempt a redundant connection, wasting resources and potentially creating mesh topology loops.
- **Solution**: We now place the first 8 bytes of the device's `peerID` into the **Service Data** field of the **Scan Response** packet. This ID is stable for the lifetime of the identity key.

## Key Changes

### 1. `BluetoothGattServerManager.kt`
- Now accepts `myPeerID` in the constructor.
- Advertises the Bitchat Service UUID in the main Advertisement Packet (maintaining backwards compatibility).
- Adds a **Scan Response** packet containing the `peerID` (first 8 bytes) in the Service Data.

### 2. `BluetoothGattClientManager.kt`
- Parses the Service Data from the Scan Record.
- Extracts the `peerID` if present.
- Checks `BluetoothConnectionTracker.isPeerConnected(peerID)` before connecting.
- If the peer is already connected (under any MAC address), the new advertisement is ignored.

### 3. `BluetoothConnectionTracker.kt`
- `DeviceConnection` now stores an optional `peerID`.
- Added `isPeerConnected(peerID)` helper to check for existing connections by identity.

## Backwards Compatibility
- **Old Clients**: Will see the Service UUID in the main packet and connect. They will ignore the extra data in the Scan Response.
- **Old Servers**: Will not include the `peerID` in the Scan Response. The client will treat `peerID` as null and fall back to the standard MAC address-based connection logic.

## Guidance for Reviewer
- Verify that the `peerID` extraction logic (first 8 bytes) matches between Server and Client.
- Confirm that the `isPeerConnected` check correctly handles the `null` case (legacy peers).
