### PR TITLE
Fix: Unicast source-routed packets at origin instead of broadcasting

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
@@ -37,7 +37,7 @@ class BluetoothConnectionManager(
     // Component managers
     private val permissionManager = BluetoothPermissionManager(context)
     private val connectionTracker = BluetoothConnectionTracker(connectionScope, powerManager)
-    private val packetBroadcaster = BluetoothPacketBroadcaster(connectionScope, connectionTracker, fragmentManager)
+    private val packetBroadcaster = BluetoothPacketBroadcaster(connectionScope, connectionTracker, fragmentManager, myPeerID)
     
     // Delegate for component managers to call back to main manager
     private val componentDelegate = object : BluetoothConnectionManagerDelegate {

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothPacketBroadcaster.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothPacketBroadcaster.kt
@@ -42,7 +42,8 @@ import kotlinx.coroutines.channels.actor
 class BluetoothPacketBroadcaster(
     private val connectionScope: CoroutineScope,
     private val connectionTracker: BluetoothConnectionTracker,
-    private val fragmentManager: FragmentManager?
+    private val fragmentManager: FragmentManager?,
+    private val myPeerID: String
 ) {
     
     companion object {
@@ -349,6 +350,47 @@ class BluetoothPacketBroadcaster(
         val senderNick = senderPeerID.let { pid -> nicknameResolver?.invoke(pid) }
         val route = packet.route
         val routeInfo = if (!route.isNullOrEmpty()) "routed: ${route.size} hops" else null
+
+        // Source Routing for Originating Packets
+        // If we are the sender and a source route is defined, we must send ONLY to the first hop.
+        if (packet.senderID.toHexString() == myPeerID && !packet.route.isNullOrEmpty()) {
+            val firstHop = packet.route!![0].toHexString()
+            Log.d(TAG, "Source Routing: Packet has explicit route, attempting to send to first hop: $firstHop")
+
+            var sent = false
+
+            // Try to find first hop in server connections (subscribedDevices)
+            val serverTarget = connectionTracker.getSubscribedDevices()
+                .firstOrNull { connectionTracker.addressPeerMap[it.address] == firstHop }
+            
+            if (serverTarget != null) {
+                Log.d(TAG, "Source Routing: sending directly to first hop (server conn) $firstHop: ${serverTarget.address}")
+                if (notifyDevice(serverTarget, data, gattServer, characteristic)) {
+                    val toPeer = connectionTracker.addressPeerMap[serverTarget.address]
+                    logPacketRelay(typeName, senderPeerID, senderNick, incomingPeer, incomingAddr, toPeer, serverTarget.address, packet.ttl, packet.version, routeInfo)
+                    sent = true
+                }
+            }
+
+            // Try to find first hop in client connections if not sent yet
+            if (!sent) {
+                val clientTarget = connectionTracker.getConnectedDevices().values
+                    .firstOrNull { connectionTracker.addressPeerMap[it.device.address] == firstHop }
+                
+                if (clientTarget != null) {
+                    Log.d(TAG, "Source Routing: sending directly to first hop (client conn) $firstHop: ${clientTarget.device.address}")
+                    if (writeToDeviceConn(clientTarget, data)) {
+                        val toPeer = connectionTracker.addressPeerMap[clientTarget.device.address]
+                        logPacketRelay(typeName, senderPeerID, senderNick, incomingPeer, incomingAddr, toPeer, clientTarget.device.address, packet.ttl, packet.version, routeInfo)
+                        sent = true
+                    }
+                }
+            }
+
+            if (sent) return
+            
+            Log.w(TAG, "Source Routing: First hop $firstHop not connected. Falling back to standard broadcast logic.")
+        }
         
         if (packet.recipientID != SpecialRecipients.BROADCAST) {
             val recipientID = packet.recipientID?.let {


### PR DESCRIPTION
## Summary
This PR fixes an issue where source-routed packets were being broadcasted (flood-filled) to the entire network by the originating device, instead of being unicast strictly to the first hop defined in the route.

## Changes
- Modified `BluetoothPacketBroadcaster` to check if an outgoing packet originates from the local device (`senderID == myPeerID`) and has a non-empty `route`.
- If a route is present, the broadcaster now identifies the first hop from the route list.
- Attempts to unicast the packet directly to that first hop (checking both server and client connections).
- If the unicast succeeds, the function returns early, preventing the packet from being broadcast to other neighbors.
- If the first hop is not connected, it falls back to the standard broadcast mechanism to ensure delivery attempts continue (though robust source routing implies the first hop should be known).
- Updated `BluetoothConnectionManager` to pass `myPeerID` to the broadcaster for sender verification.

## Impact
- **Reduced Network Congestion:** Source-routed packets (used for specific, targeted delivery) no longer flood the immediate neighborhood unnecessarily.
- **Privacy/Security:** Packets meant for a specific path are not immediately shared with all neighbors, adhering closer to the intent of source routing.
- **Protocol Compliance:** Aligns behavior with standard source routing principles where the path is strictly followed starting from the source.