### PR TITLE
Fix location updates in notes and Nostr subscription leaks

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/LocationNotesSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/LocationNotesSheet.kt
@@ -89,6 +89,11 @@ fun LocationNotesSheet(
         label = "topBarAlpha"
     )
 
+    // Refresh location when sheet opens
+    LaunchedEffect(Unit) {
+        locationManager.refreshChannels()
+    }
+
     // Effect to set geohash when sheet opens
     LaunchedEffect(geohash) {
         notesManager.setGeohash(geohash)


### PR DESCRIPTION
## Summary
This PR addresses two critical issues related to location handling and Nostr subscription management.

### Fixes
- **Fixes #634**: Location not updated when opening Location Notes sheet
- **Fixes #635**: Nostr subscription leak and redundant REQ storm during geohash sampling

## Changes

### 1. Location Notes Update (Issue #634)
In `LocationNotesSheet.kt`, added a `LaunchedEffect` to explicitly trigger `locationManager.refreshChannels()` when the sheet is opened. This ensures the displayed location name (Building/Block) reflects the user's current position instead of stale data.

```kotlin
// LocationNotesSheet.kt
LaunchedEffect(Unit) {
    locationManager.refreshChannels()
}
```

### 2. Nostr Subscription Management (Issue #635)
In `GeohashViewModel.kt`, overhauled the `beginGeohashSampling` and `endGeohashSampling` methods to prevent subscription leaks and redundant network requests.

- **Tracking**: Added `activeSamplingGeohashes` set to track active subscriptions.
- **Diffing**: `beginGeohashSampling` now calculates the difference between requested geohashes and active ones. It only subscribes to *new* geohashes and unsubscribes from *removed* ones.
- **Cleanup**: `endGeohashSampling` now properly unsubscribes from all active sampling IDs and clears the tracking set.

## Notes for Reviewer
- Verify that opening the Location Notes sheet updates the location header text if you have moved.
- Monitor Logcat with tag `GeohashViewModel` to verify "Updating sampling" logs show correct +add/-remove counts when moving around in the Location Channels sheet.
- Confirm that "Ending geohash sampling" is logged when the sheet closes.