### PR TITLE
Nickname Collision Handling and Mention Coloring

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -47,7 +47,7 @@ class BluetoothMeshService(private val context: Context) {
 
     // My peer identification - derived from persisted Noise identity fingerprint (first 16 hex chars)
     val myPeerID: String = encryptionService.getIdentityFingerprint().take(16)
-    private val peerManager = PeerManager()
+    private val peerManager = PeerManager().apply { myPeerID = this@BluetoothMeshService.myPeerID }
     private val fragmentManager = FragmentManager()
     private val securityManager = SecurityManager(encryptionService, myPeerID)
     private val storeForwardManager = StoreForwardManager()

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -636,6 +636,10 @@ class BluetoothMeshService(private val context: Context) {
         if (connectionManager.startServices()) {
             isActive = true
             
+            // Add ourselves to peer manager for collision detection
+            val myNickname = try { com.bitchat.android.services.NicknameProvider.getNickname(context, myPeerID) } catch (_: Exception) { myPeerID }
+            peerManager.addOrUpdatePeer(myPeerID, myNickname)
+
             // Start periodic announcements for peer discovery and connectivity
             sendPeriodicBroadcastAnnounce()
             Log.d(TAG, "Started periodic broadcast announcements (every 30 seconds)")
@@ -697,6 +701,14 @@ class BluetoothMeshService(private val context: Context) {
         return reusable
     }
     
+    /**
+     * Update our own nickname in peer manager and announce it
+     */
+    fun updateSelfNickname(newNickname: String) {
+        peerManager.addOrUpdatePeer(myPeerID, newNickname)
+        sendBroadcastAnnounce()
+    }
+
     /**
      * Send public message
      */
@@ -1175,6 +1187,11 @@ class BluetoothMeshService(private val context: Context) {
      * Get peer nicknames
      */
     fun getPeerNicknames(): Map<String, String> = peerManager.getAllPeerNicknames()
+
+    /**
+     * Get disambiguated peer nickname (nickname#suffix if collisions exist)
+     */
+    fun getDisambiguatedNickname(peerID: String): String = peerManager.getDisambiguatedNickname(peerID)
     
     /**
      * Get peer RSSI values  

--- a/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
@@ -89,6 +89,9 @@ class PeerManager {
     // Callback to check if a peer is directly connected (injected by BluetoothMeshService)
     var isPeerDirectlyConnected: ((String) -> Boolean)? = null
 
+    // My own Peer ID (to treat specially in disambiguation and cleanup)
+    var myPeerID: String? = null
+
     // Coroutines
     private val managerScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     
@@ -305,7 +308,9 @@ class PeerManager {
         val info = peers[peerID] ?: return peerID
         val nick = info.nickname.trim()
         val isAmbiguous = peers.values.count { it.nickname.trim().equals(nick, ignoreCase = true) } > 1
-        return if (isAmbiguous) "$nick#${peerID.takeLast(4)}" else nick
+        
+        // Suffix is appended if ambiguous, UNLESS this is our own Peer ID
+        return if (isAmbiguous && peerID != myPeerID) "$nick#${peerID.takeLast(4)}" else nick
     }
     
     /**
@@ -428,7 +433,9 @@ class PeerManager {
     private fun cleanupStalePeers() {
         val now = System.currentTimeMillis()
         
-        val peersToRemove = peers.filterValues { (now - it.lastSeen) > stalePeerTimeoutMs }
+        val peersToRemove = peers.filterValues { 
+            it.id != myPeerID && (now - it.lastSeen) > stalePeerTimeoutMs 
+        }
             .keys
             .toList()
         

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -167,9 +167,13 @@ fun ChatScreen(viewModel: ChatViewModel) {
                 },
                 onMessageLongPress = { message ->
                     // Message long press - open user action sheet with message context
-                    // Extract base nickname from message sender (contains all necessary info)
-                    val (baseName, _) = splitSuffix(message.sender)
-                    selectedUserForSheet = baseName
+                    // Use disambiguated name so actions like /block work with suffixes if collisions exist
+                    val disambiguated = if (message.senderPeerID != null && !message.senderPeerID.startsWith("nostr_")) {
+                        viewModel.meshService.getDisambiguatedNickname(message.senderPeerID)
+                    } else {
+                        message.sender
+                    }
+                    selectedUserForSheet = disambiguated
                     selectedMessageForSheet = message
                     showUserSheet = true
                 },

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -130,6 +130,7 @@ fun ChatScreen(viewModel: ChatViewModel) {
             )
 
             // Messages area - takes up available space, will compress when keyboard appears
+            val peerNicknames by viewModel.peerNicknames.collectAsStateWithLifecycle()
             MessagesList(
                 messages = displayMessages,
                 currentUserNickname = nickname,
@@ -137,6 +138,7 @@ fun ChatScreen(viewModel: ChatViewModel) {
                 modifier = Modifier.weight(1f),
                 forceScrollToBottom = forceScrollToBottom,
                 onScrolledUpChanged = { isUp -> isScrolledUp = isUp },
+                peerNicknames = peerNicknames,
                 onNicknameClick = { fullSenderName ->
                     // Single click - mention user in text input
                     val currentText = messageText.text

--- a/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
@@ -51,9 +51,12 @@ fun formatMessageAsAnnotatedString(
     val isDark = colorScheme.background.red + colorScheme.background.green + colorScheme.background.blue < 1.5f
     
     // Determine if this message was sent by self
-    val isSelf = message.senderPeerID == meshService.myPeerID || 
-                 message.sender == currentUserNickname ||
-                 message.sender.startsWith("$currentUserNickname#")
+    val isSelf = if (message.senderPeerID != null) {
+        message.senderPeerID == meshService.myPeerID
+    } else {
+        message.sender == currentUserNickname ||
+        message.sender.startsWith("$currentUserNickname#")
+    }
     
     if (message.sender != "system") {
         // Resolve disambiguated sender name if it's a mesh message
@@ -183,9 +186,12 @@ fun formatMessageHeaderAnnotatedString(
     val builder = AnnotatedString.Builder()
     val isDark = colorScheme.background.red + colorScheme.background.green + colorScheme.background.blue < 1.5f
 
-    val isSelf = message.senderPeerID == meshService.myPeerID ||
-            message.sender == currentUserNickname ||
-            message.sender.startsWith("$currentUserNickname#")
+    val isSelf = if (message.senderPeerID != null) {
+        message.senderPeerID == meshService.myPeerID
+    } else {
+        message.sender == currentUserNickname ||
+        message.sender.startsWith("$currentUserNickname#")
+    }
 
     if (message.sender != "system") {
         // Resolve disambiguated sender name if it's a mesh message
@@ -493,14 +499,14 @@ private fun appendIOSFormattedContent(
                 val mentionWithoutAt = matchText.removePrefix("@")
                 val (mBase, mSuffix) = splitSuffix(mentionWithoutAt)
                 
-                // Check if this mention targets current user
-                val isMentionToMe = mBase.equals(currentUserNickname, ignoreCase = true)
+                // Resolve PeerID to check strict identity match
+                val resolvedID = resolvePeerIDFromDisplayName(mentionWithoutAt, nicknameMap)
+                val isMentionToMe = resolvedID == meshService.myPeerID
                 
                 // Resolve mention color based on mentioned user's actual color
                 val mentionColor = if (isMentionToMe) {
                     Color(0xFFFF9500) // Orange for mentions to self
                 } else {
-                    val resolvedID = resolvePeerIDFromDisplayName(mentionWithoutAt, nicknameMap)
                     colorForPeer(resolvedID, mentionWithoutAt, isDark)
                 }
                 

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -317,7 +317,7 @@ class ChatViewModel(
     fun setNickname(newNickname: String) {
         state.setNickname(newNickname)
         dataManager.saveNickname(newNickname)
-        meshService.sendBroadcastAnnounce()
+        meshService.updateSelfNickname(newNickname)
     }
     
     /**
@@ -519,7 +519,7 @@ class ChatViewModel(
                 }
             }
             // Send private message
-            val recipientNickname = meshService.getPeerNicknames()[selectedPeer]
+            val recipientNickname = meshService.getDisambiguatedNickname(selectedPeer)
             privateChatManager.sendPrivateMessage(
                 content, 
                 selectedPeer, 
@@ -580,10 +580,6 @@ class ChatViewModel(
     }
 
     // MARK: - Utility Functions
-    
-    fun getPeerIDForNickname(nickname: String): String? {
-        return meshService.getPeerNicknames().entries.find { it.value == nickname }?.key
-    }
     
     fun toggleFavorite(peerID: String) {
         Log.d("ChatViewModel", "toggleFavorite called for peerID: $peerID")

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -578,11 +578,10 @@ class CommandProcessor(
     private fun resolvePeerIDForNickname(targetName: String, meshService: BluetoothMeshService): PeerResolutionResult {
         val nicknames = meshService.getPeerNicknames()
         
-        val parts = targetName.split("#")
-        val baseName = parts[0]
-        val suffix = if (parts.size > 1) parts[1] else null
+        val (baseName, suffixWithHash) = splitSuffix(targetName)
         
-        if (suffix != null) {
+        if (suffixWithHash.isNotEmpty()) {
+            val suffix = suffixWithHash.removePrefix("#")
             val peerID = nicknames.entries.find { (id, nick) -> 
                 nick.equals(baseName, ignoreCase = true) && id.takeLast(4).equals(suffix, ignoreCase = true)
             }?.key

--- a/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MatrixEncryptionAnimation.kt
@@ -251,7 +251,8 @@ private fun formatMessageAsAnnotatedStringWithoutTimestamp(
         currentUserNickname = currentUserNickname,
         meshService = meshService,
         colorScheme = colorScheme,
-        timeFormatter = timeFormatter
+        timeFormatter = timeFormatter,
+        peerNicknames = emptyMap() // Can't easily get map here without refactoring AnimatedMessageDisplay
     )
     
     // Find and remove the timestamp and PoW badge at the end

--- a/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshDelegateHandler.kt
@@ -54,8 +54,8 @@ class MeshDelegateHandler(
                 
                 // Show notification with enhanced information - now includes senderPeerID 
                 message.senderPeerID?.let { senderPeerID ->
-                    // Use nickname if available, fall back to sender or senderPeerID
-                    val senderNickname = message.sender.takeIf { it != senderPeerID } ?: senderPeerID
+                    // Use disambiguated nickname for notifications
+                    val senderNickname = getMeshService().getDisambiguatedNickname(senderPeerID)
                     val preview = NotificationTextUtils.buildPrivateMessagePreview(message)
                     notificationManager.showPrivateMessageNotification(
                         senderPeerID = senderPeerID,
@@ -250,10 +250,11 @@ class MeshDelegateHandler(
             val isMention = checkForMeshMention(message.content, currentNickname)
 
             if (isMention) {
-                android.util.Log.d("MeshDelegateHandler", "🔔 Triggering mesh mention notification from ${message.sender}")
+                val senderNickname = message.senderPeerID?.let { getMeshService().getDisambiguatedNickname(it) } ?: message.sender
+                android.util.Log.d("MeshDelegateHandler", "🔔 Triggering mesh mention notification from $senderNickname")
 
                 notificationManager.showMeshMentionNotification(
-                    senderNickname = message.sender,
+                    senderNickname = senderNickname,
                     messageContent = message.content,
                     senderPeerID = message.senderPeerID
                 )

--- a/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
@@ -839,7 +839,8 @@ fun PrivateChatSheet(
                         onNicknameClick = { /* handle mention */ },
                         onMessageLongPress = { /* handle long press */ },
                         onCancelTransfer = { msg -> viewModel.cancelMediaSend(msg.id) },
-                        onImageClick = { _, _, _ -> /* handle image click */ }
+                        onImageClick = { _, _, _ -> /* handle image click */ },
+                        peerNicknames = peerNicknames
                     )
 
                     HorizontalDivider(color = colorScheme.outline.copy(alpha = 0.3f))

--- a/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
@@ -34,6 +34,7 @@ import com.bitchat.android.geohash.ChannelID
 import com.bitchat.android.ui.theme.BASE_FONT_SIZE
 import com.bitchat.android.nostr.GeohashAliasRegistry
 import com.bitchat.android.nostr.GeohashConversationRegistry
+import com.bitchat.android.util.toHexString
 
 
 /**
@@ -367,7 +368,7 @@ fun PeopleSection(
         // Offline favorites (exclude ones mapped to connected)
         val offlineFavorites = com.bitchat.android.favorites.FavoritesPersistenceService.shared.getOurFavorites()
         offlineFavorites.forEach { fav ->
-            val favPeerID = fav.peerNoisePublicKey.joinToString("") { b -> "%02x".format(b) }
+            val favPeerID = fav.peerNoisePublicKey.toHexString()
             val isMappedToConnected = noiseHexByPeerID.values.any { it.equals(favPeerID, ignoreCase = true) }
             if (!isMappedToConnected) {
                 val dn = peerNicknames[favPeerID] ?: fav.peerNickname
@@ -435,7 +436,7 @@ fun PeopleSection(
 
         // Append offline favorites we actively favorite (and not currently connected)
         offlineFavorites.forEach { fav ->
-            val favPeerID = fav.peerNoisePublicKey.joinToString("") { b -> "%02x".format(b) }
+            val favPeerID = fav.peerNoisePublicKey.toHexString()
             // If any connected peer maps to this noise key, skip showing the offline entry
             val isMappedToConnected = noiseHexByPeerID.values.any { it.equals(favPeerID, ignoreCase = true) }
             if (isMappedToConnected) return@forEach
@@ -560,7 +561,7 @@ private fun PeerItem(
     // Split display name for hashtag suffix support (iOS-compatible)
     val (baseNameRaw, suffixRaw) = splitSuffix(displayName)
     val baseName = truncateNickname(baseNameRaw)
-    val suffix = if (showHashSuffix) suffixRaw else ""
+    val suffix = if (showHashSuffix && suffixRaw.isEmpty()) "#${peerID.takeLast(4)}" else if (showHashSuffix) suffixRaw else ""
     val isMe = displayName == "You" || peerID == currentNickname
 
     // Get consistent peer color (iOS-compatible)

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -384,9 +384,12 @@ fun MessageItem(
         )
         
         // Check if this message was sent by self to avoid click interactions on own nickname
-        val isSelf = message.senderPeerID == meshService.myPeerID || 
-                     message.sender == currentUserNickname ||
-                     message.sender.startsWith("$currentUserNickname#")
+        val isSelf = if (message.senderPeerID != null) {
+            message.senderPeerID == meshService.myPeerID
+        } else {
+            message.sender == currentUserNickname ||
+            message.sender.startsWith("$currentUserNickname#")
+        }
         
         val haptic = LocalHapticFeedback.current
         val context = LocalContext.current

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -65,7 +65,8 @@ fun MessagesList(
     onNicknameClick: ((String) -> Unit)? = null,
     onMessageLongPress: ((BitchatMessage) -> Unit)? = null,
     onCancelTransfer: ((BitchatMessage) -> Unit)? = null,
-    onImageClick: ((String, List<String>, Int) -> Unit)? = null
+    onImageClick: ((String, List<String>, Int) -> Unit)? = null,
+    peerNicknames: Map<String, String> = emptyMap()
 ) {
     val listState = rememberLazyListState()
     
@@ -126,7 +127,8 @@ fun MessagesList(
                     onNicknameClick = onNicknameClick,
                     onMessageLongPress = onMessageLongPress,
                     onCancelTransfer = onCancelTransfer,
-                    onImageClick = onImageClick
+                    onImageClick = onImageClick,
+                    peerNicknames = peerNicknames
                 )
         }
     }
@@ -142,7 +144,8 @@ fun MessageItem(
     onNicknameClick: ((String) -> Unit)? = null,
     onMessageLongPress: ((BitchatMessage) -> Unit)? = null,
     onCancelTransfer: ((BitchatMessage) -> Unit)? = null,
-    onImageClick: ((String, List<String>, Int) -> Unit)? = null
+    onImageClick: ((String, List<String>, Int) -> Unit)? = null,
+    peerNicknames: Map<String, String> = emptyMap()
 ) {
     val colorScheme = MaterialTheme.colorScheme
     val timeFormatter = remember { SimpleDateFormat("HH:mm:ss", Locale.getDefault()) }
@@ -171,6 +174,7 @@ fun MessageItem(
                     onMessageLongPress = onMessageLongPress,
                     onCancelTransfer = onCancelTransfer,
                     onImageClick = onImageClick,
+                    peerNicknames = peerNicknames,
                     modifier = Modifier
                         .weight(1f)
                         .padding(end = endPad)
@@ -208,6 +212,7 @@ fun MessageItem(
         onMessageLongPress: ((BitchatMessage) -> Unit)?,
         onCancelTransfer: ((BitchatMessage) -> Unit)?,
         onImageClick: ((String, List<String>, Int) -> Unit)?,
+        peerNicknames: Map<String, String> = emptyMap(),
         modifier: Modifier = Modifier
     ) {
     // Image special rendering
@@ -223,6 +228,7 @@ fun MessageItem(
             onMessageLongPress = onMessageLongPress,
             onCancelTransfer = onCancelTransfer,
             onImageClick = onImageClick,
+            peerNicknames = peerNicknames,
             modifier = modifier
         )
         return
@@ -239,6 +245,7 @@ fun MessageItem(
             onNicknameClick = onNicknameClick,
             onMessageLongPress = onMessageLongPress,
             onCancelTransfer = onCancelTransfer,
+            peerNicknames = peerNicknames,
             modifier = modifier
         )
         return
@@ -263,7 +270,8 @@ fun MessageItem(
                 currentUserNickname = currentUserNickname,
                 meshService = meshService,
                 colorScheme = colorScheme,
-                timeFormatter = timeFormatter
+                timeFormatter = timeFormatter,
+                peerNicknames = peerNicknames
             )
             val haptic = LocalHapticFeedback.current
             var headerLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
@@ -371,7 +379,8 @@ fun MessageItem(
             currentUserNickname = currentUserNickname,
             meshService = meshService,
             colorScheme = colorScheme,
-            timeFormatter = timeFormatter
+            timeFormatter = timeFormatter,
+            peerNicknames = peerNicknames
         )
         
         // Check if this message was sent by self to avoid click interactions on own nickname

--- a/app/src/main/java/com/bitchat/android/ui/PrivateChatManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/PrivateChatManager.kt
@@ -193,7 +193,7 @@ class PrivateChatManager(
         if (fingerprint != null) {
             dataManager.addBlockedUser(fingerprint)
 
-            val peerNickname = getPeerNickname(peerID, meshService)
+            val peerNickname = meshService.getDisambiguatedNickname(peerID)
             val systemMessage = BitchatMessage(
                 sender = "system",
                 content = "blocked user $peerNickname",
@@ -217,7 +217,7 @@ class PrivateChatManager(
         if (fingerprint != null && dataManager.isUserBlocked(fingerprint)) {
             dataManager.removeBlockedUser(fingerprint)
 
-            val peerNickname = getPeerNickname(peerID, meshService)
+            val peerNickname = meshService.getDisambiguatedNickname(peerID)
             val systemMessage = BitchatMessage(
                 sender = "system",
                 content = "unblocked user $peerNickname",
@@ -228,52 +228,6 @@ class PrivateChatManager(
             return true
         }
         return false
-    }
-
-    fun blockPeerByNickname(targetName: String, meshService: BluetoothMeshService): Boolean {
-        val peerID = getPeerIDForNickname(targetName, meshService)
-
-        if (peerID != null) {
-            return blockPeer(peerID, meshService)
-        } else {
-            val systemMessage = BitchatMessage(
-                sender = "system",
-                content = "user '$targetName' not found",
-                timestamp = Date(),
-                isRelay = false
-            )
-            messageManager.addMessage(systemMessage)
-            return false
-        }
-    }
-
-    fun unblockPeerByNickname(targetName: String, meshService: BluetoothMeshService): Boolean {
-        val peerID = getPeerIDForNickname(targetName, meshService)
-
-        if (peerID != null) {
-            val fingerprint = fingerprintManager.getFingerprintForPeer(peerID)
-            if (fingerprint != null && dataManager.isUserBlocked(fingerprint)) {
-                return unblockPeer(peerID, meshService)
-            } else {
-                val systemMessage = BitchatMessage(
-                    sender = "system",
-                    content = "user '$targetName' is not blocked",
-                    timestamp = Date(),
-                    isRelay = false
-                )
-                messageManager.addMessage(systemMessage)
-                return false
-            }
-        } else {
-            val systemMessage = BitchatMessage(
-                sender = "system",
-                content = "user '$targetName' not found",
-                timestamp = Date(),
-                isRelay = false
-            )
-            messageManager.addMessage(systemMessage)
-            return false
-        }
     }
 
     fun listBlockedUsers(): String {
@@ -413,12 +367,8 @@ class PrivateChatManager(
 
     // MARK: - Utility Functions
 
-    private fun getPeerIDForNickname(nickname: String, meshService: BluetoothMeshService): String? {
-        return meshService.getPeerNicknames().entries.find { it.value == nickname }?.key
-    }
-
     private fun getPeerNickname(peerID: String, meshService: BluetoothMeshService): String {
-        return meshService.getPeerNicknames()[peerID] ?: peerID
+        return meshService.getDisambiguatedNickname(peerID)
     }
 
     // MARK: - Consolidation

--- a/app/src/main/java/com/bitchat/android/ui/media/AudioMessageItem.kt
+++ b/app/src/main/java/com/bitchat/android/ui/media/AudioMessageItem.kt
@@ -36,6 +36,7 @@ fun AudioMessageItem(
     onNicknameClick: ((String) -> Unit)?,
     onMessageLongPress: ((BitchatMessage) -> Unit)?,
     onCancelTransfer: ((BitchatMessage) -> Unit)?,
+    peerNicknames: Map<String, String> = emptyMap(),
     modifier: Modifier = Modifier
 ) {
     val path = message.content.trim()
@@ -55,7 +56,8 @@ fun AudioMessageItem(
             currentUserNickname = currentUserNickname,
             meshService = meshService,
             colorScheme = colorScheme,
-            timeFormatter = timeFormatter
+            timeFormatter = timeFormatter,
+            peerNicknames = peerNicknames
         )
         val haptic = LocalHapticFeedback.current
         var headerLayout by remember { mutableStateOf<TextLayoutResult?>(null) }

--- a/app/src/main/java/com/bitchat/android/ui/media/ImageMessageItem.kt
+++ b/app/src/main/java/com/bitchat/android/ui/media/ImageMessageItem.kt
@@ -46,6 +46,7 @@ fun ImageMessageItem(
     onMessageLongPress: ((BitchatMessage) -> Unit)?,
     onCancelTransfer: ((BitchatMessage) -> Unit)?,
     onImageClick: ((String, List<String>, Int) -> Unit)?,
+    peerNicknames: Map<String, String> = emptyMap(),
     modifier: Modifier = Modifier
 ) {
     val path = message.content.trim()
@@ -55,7 +56,8 @@ fun ImageMessageItem(
             currentUserNickname = currentUserNickname,
             meshService = meshService,
             colorScheme = colorScheme,
-            timeFormatter = timeFormatter
+            timeFormatter = timeFormatter,
+            peerNicknames = peerNicknames
         )
         val haptic = LocalHapticFeedback.current
         var headerLayout by remember { mutableStateOf<TextLayoutResult?>(null) }


### PR DESCRIPTION
## Summary
This PR implements comprehensive nickname collision handling and identity-aware mention coloring to prevent impersonation and improve chat clarity.

### Key Changes
- **Nickname Disambiguation**: Automatically appends a short ID suffix (last 4 chars of Peer ID) to nicknames in the peer list, chat timeline, and notifications when a collision is detected (e.g., `alice` vs `alice#1234`).
- **Identity-Aware Coloring**: Refactored `ChatUIUtils` to resolve mentions back to Peer IDs. Mentions are now rendered in the actual color of the mentioned user rather than the sender's color.
- **Secure Slash Commands**: Updated `/msg`, `/block`, and `/unblock` to detect ambiguous nicknames and prompt the user to use the unique `#suffix` identifier.
- **Performance Optimization**: Optimized the message rendering pipeline by passing stable nickname snapshots, reducing redundant service calls during scrolling.
- **Self-Collision Support**: The system now detects when another user adopts your nickname and disambiguates their display name while keeping yours clean.
- **Bug Fixes**: Fixed a `ClassCastException` in the sidebar and made the mention autocomplete deterministic.

Fixes https://github.com/permissionlesstech/bitchat-android/issues/589