### PR TITLE
Fix geohash blocking case sensitivity

### DIFF
--- a/app/src/main/java/com/bitchat/android/nostr/NostrDirectMessageHandler.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrDirectMessageHandler.kt
@@ -62,7 +62,8 @@ class NostrDirectMessageHandler(
                     return@launch
                 }
 
-                val (content, senderPubkey, rumorTimestamp) = decryptResult
+                val (content, rawSenderPubkey, rumorTimestamp) = decryptResult
+                val senderPubkey = rawSenderPubkey.lowercase()
 
                 // If sender is blocked for geohash contexts, drop any events from this pubkey
                 // Applies to both geohash DMs (geohash != "") and account DMs (geohash == "")


### PR DESCRIPTION
Fixes #641 

Fixes a bug where blocking users in geohash chatrooms was ineffective due to case sensitivity mismatches in public keys. Incoming public keys are now normalized to lowercase before checking against the block list.