### PR TITLE
Feat/request sync manager

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/PeerManager.kt
@@ -332,6 +332,13 @@ class PeerManager {
             .toList()
             .sorted()
     }
+
+    /**
+     * Get list of active peer IDs (alias for getActivePeerIDs for consistency)
+     */
+    fun getActivePeers(): List<String> {
+        return getActivePeerIDs()
+    }
     
     /**
      * Get active peer count

--- a/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
@@ -75,8 +75,7 @@ class SecurityManager(
                 skipTimestampCheck = true
             } else {
                 // Only strict reject if it was EXPLICITLY marked RSR
-                // If it's just TTL=0 (legacy), it might be a legitimate neighbor broadcast (unlikely for ANNOUNCE/MESSAGE but possible)
-                // However, the requirement is "ignore RSR packets incoming from peer we didn't request it from"
+                // The requirement is "ignore RSR packets incoming from peer we didn't request it from"
                 // And we want to enforce timestamp on normal packets.
                 // If a legacy packet has TTL=0 and is OLD, it MUST be a sync response. 
                 // If it's NEW, it passes timestamp check anyway.

--- a/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
@@ -5,17 +5,23 @@ import com.bitchat.android.crypto.EncryptionService
 import com.bitchat.android.protocol.BitchatPacket
 import com.bitchat.android.protocol.MessageType
 import com.bitchat.android.model.RoutedPacket
+import com.bitchat.android.sync.RequestSyncManager
 import com.bitchat.android.util.toHexString
 import kotlinx.coroutines.*
 import java.util.*
 import kotlin.collections.mutableSetOf
+import kotlin.math.abs
 
 /**
  * Manages security aspects of the mesh network including duplicate detection,
  * replay attack protection, and key exchange handling
  * Extracted from BluetoothMeshService for better separation of concerns
  */
-class SecurityManager(private val encryptionService: EncryptionService, private val myPeerID: String) {
+class SecurityManager(
+    private val encryptionService: EncryptionService,
+    private val myPeerID: String,
+    private val requestSyncManager: RequestSyncManager
+) {
     
     companion object {
         private const val TAG = "SecurityManager"
@@ -23,6 +29,9 @@ class SecurityManager(private val encryptionService: EncryptionService, private 
         private const val CLEANUP_INTERVAL = com.bitchat.android.util.AppConstants.Security.CLEANUP_INTERVAL_MS // 5 minutes
         private const val MAX_PROCESSED_MESSAGES = com.bitchat.android.util.AppConstants.Security.MAX_PROCESSED_MESSAGES
         private const val MAX_PROCESSED_KEY_EXCHANGES = com.bitchat.android.util.AppConstants.Security.MAX_PROCESSED_KEY_EXCHANGES
+        
+        // Max allowed timestamp skew (2 minutes)
+        private const val MAX_TIMESTAMP_SKEW_MS = 120_000L
     }
     
     // Security tracking
@@ -50,9 +59,36 @@ class SecurityManager(private val encryptionService: EncryptionService, private 
             return false
         }
         
-        // Replay attack protection (same 5-minute window as iOS)
         val currentTime = System.currentTimeMillis()
         val messageType = MessageType.fromValue(packet.type)
+
+        // 1. Timestamp Validation (Skipped for valid RSR packets)
+        val isRSR = packet.isRSR
+        var skipTimestampCheck = false
+
+        if (isRSR) {
+            if (requestSyncManager.isValidResponse(peerID, isRSR = true)) {
+                Log.d(TAG, "Valid RSR packet from $peerID - skipping timestamp check")
+                skipTimestampCheck = true
+            } else {
+                Log.w(TAG, "Invalid or unsolicited RSR packet from $peerID - rejecting")
+                return false
+            }
+        }
+
+        if (!skipTimestampCheck) {
+            // Enforce timestamp check for normal packets
+            val packetTime = packet.timestamp.toLong()
+            val skew = abs(currentTime - packetTime)
+            if (skew > MAX_TIMESTAMP_SKEW_MS) {
+                // Allow leeway for ANNOUNCE packets? iOS does, but "less blind" implies strictness.
+                // However, ANNOUNCE is often used to sync time roughly or discover.
+                // For now, strict enforcement as requested.
+                // "enforce the timestamp validation on normal packets... that we currently have disabled"
+                Log.w(TAG, "Packet timestamp skewed by ${skew}ms (max allowed ${MAX_TIMESTAMP_SKEW_MS}ms) from $peerID")
+                return false
+            }
+        }
 
         // Duplicate detection
         val messageID = generateMessageID(packet, peerID)

--- a/app/src/main/java/com/bitchat/android/protocol/BinaryProtocol.kt
+++ b/app/src/main/java/com/bitchat/android/protocol/BinaryProtocol.kt
@@ -60,7 +60,8 @@ data class BitchatPacket(
     val payload: ByteArray,
     var signature: ByteArray? = null,  // Changed from val to var for packet signing
     var ttl: UByte,
-    var route: List<ByteArray>? = null // Optional source route: ordered list of peerIDs (8 bytes each), not including sender and final recipient
+    var route: List<ByteArray>? = null, // Optional source route: ordered list of peerIDs (8 bytes each), not including sender and final recipient
+    val isRSR: Boolean = false // Request-Sync Response flag
 ) : Parcelable {
 
     constructor(
@@ -99,7 +100,8 @@ data class BitchatPacket(
             payload = payload,
             signature = null, // Remove signature for signing
             route = route,
-            ttl = com.bitchat.android.util.AppConstants.SYNC_TTL_HOPS // Use fixed TTL=0 for signing to ensure relay compatibility
+            ttl = com.bitchat.android.util.AppConstants.SYNC_TTL_HOPS, // Use fixed TTL=0 for signing to ensure relay compatibility
+            isRSR = isRSR
         )
         return BinaryProtocol.encode(unsignedPacket)
     }
@@ -156,6 +158,7 @@ data class BitchatPacket(
             val b = other.route?.map { it.toList() } ?: emptyList()
             if (a != b) return false
         }
+        if (isRSR != other.isRSR) return false
 
         return true
     }
@@ -170,6 +173,7 @@ data class BitchatPacket(
         result = 31 * result + (signature?.contentHashCode() ?: 0)
         result = 31 * result + ttl.hashCode()
         result = 31 * result + (route?.fold(1) { acc, bytes -> 31 * acc + bytes.contentHashCode() } ?: 0)
+        result = 31 * result + isRSR.hashCode()
         return result
     }
 }
@@ -189,6 +193,7 @@ object BinaryProtocol {
         const val HAS_SIGNATURE: UByte = 0x02u
         const val IS_COMPRESSED: UByte = 0x04u
         const val HAS_ROUTE: UByte = 0x08u
+        const val IS_RSR: UByte = 0x10u
     }
 
     private fun getHeaderSize(version: UByte): Int {
@@ -247,6 +252,9 @@ object BinaryProtocol {
             // HAS_ROUTE is only supported for v2+ packets
             if (!packet.route.isNullOrEmpty() && packet.version >= 2u.toUByte()) {
                 flags = flags or Flags.HAS_ROUTE
+            }
+            if (packet.isRSR) {
+                flags = flags or Flags.IS_RSR
             }
             buffer.put(flags.toByte())
             
@@ -357,6 +365,7 @@ object BinaryProtocol {
             val isCompressed = (flags and Flags.IS_COMPRESSED) != 0u.toUByte()
             // HAS_ROUTE is only valid for v2+ packets; ignore the flag for v1
             val hasRoute = (version >= 2u.toUByte()) && (flags and Flags.HAS_ROUTE) != 0u.toUByte()
+            val isRSR = (flags and Flags.IS_RSR) != 0u.toUByte()
 
             // Payload length - version-dependent (2 or 4 bytes)
             val payloadLength = if (version >= 2u.toUByte()) {
@@ -464,7 +473,8 @@ object BinaryProtocol {
                 payload = payload,
                 signature = signature,
                 ttl = ttl,
-                route = route
+                route = route,
+                isRSR = isRSR
             )
             
         } catch (e: Exception) {

--- a/app/src/main/java/com/bitchat/android/protocol/BinaryProtocol.kt
+++ b/app/src/main/java/com/bitchat/android/protocol/BinaryProtocol.kt
@@ -101,7 +101,7 @@ data class BitchatPacket(
             signature = null, // Remove signature for signing
             route = route,
             ttl = com.bitchat.android.util.AppConstants.SYNC_TTL_HOPS, // Use fixed TTL=0 for signing to ensure relay compatibility
-            isRSR = isRSR
+            isRSR = false // RSR flag is mutable and not part of the signature
         )
         return BinaryProtocol.encode(unsignedPacket)
     }

--- a/app/src/main/java/com/bitchat/android/sync/RequestSyncManager.kt
+++ b/app/src/main/java/com/bitchat/android/sync/RequestSyncManager.kt
@@ -1,0 +1,68 @@
+package com.bitchat.android.sync
+
+import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Manages outgoing sync requests and validates incoming responses.
+ * 
+ * Allows attributing RSR (Request-Sync Response) packets to specific peers
+ * that we have actively requested sync from.
+ */
+class RequestSyncManager {
+
+    companion object {
+        private const val TAG = "RequestSyncManager"
+        private const val RESPONSE_WINDOW_MS = 30_000L // Allow responses for 30s after request
+    }
+
+    // Tracks the timestamp of the last sync request sent to a peer
+    private val pendingRequests = ConcurrentHashMap<String, Long>()
+
+    /**
+     * Register that we are sending a sync request to a peer.
+     * @param peerID The peer we are requesting sync from
+     */
+    fun registerRequest(peerID: String) {
+        Log.d(TAG, "Registering sync request to $peerID")
+        pendingRequests[peerID] = System.currentTimeMillis()
+    }
+
+    /**
+     * Check if a packet from a peer is a valid response to a sync request.
+     * 
+     * @param peerID The sender of the packet
+     * @param isRSR Whether the packet is marked as a Request-Sync Response
+     * @return true if we have a pending request for this peer and the window is open
+     */
+    fun isValidResponse(peerID: String, isRSR: Boolean): Boolean {
+        if (!isRSR) return false
+
+        val requestTime = pendingRequests[peerID]
+        if (requestTime == null) {
+            Log.w(TAG, "Received unsolicited RSR packet from $peerID")
+            return false
+        }
+
+        val now = System.currentTimeMillis()
+        if (now - requestTime > RESPONSE_WINDOW_MS) {
+            Log.w(TAG, "Received RSR packet from $peerID outside of response window")
+            pendingRequests.remove(peerID) // Cleanup expired
+            return false
+        }
+
+        return true
+    }
+
+    /**
+     * Periodic cleanup of expired requests
+     */
+    fun cleanup() {
+        val now = System.currentTimeMillis()
+        val expired = pendingRequests.filterValues { now - it > RESPONSE_WINDOW_MS }.keys
+        if (expired.isNotEmpty()) {
+            Log.d(TAG, "Cleaning up ${expired.size} expired sync requests")
+            expired.forEach { pendingRequests.remove(it) }
+        }
+    }
+}

--- a/docs/REQUEST_SYNC_MANAGER.md
+++ b/docs/REQUEST_SYNC_MANAGER.md
@@ -1,0 +1,51 @@
+# Request Sync Manager & V2 Packet Updates
+
+This document details the implementation of the Request Sync Manager and updates to the V2 packet structure to improve synchronization security and attribution.
+
+## Overview
+
+The goal of these changes is to make the request sync functionality "less blind". Previously, sync requests were broadcast, and responses were accepted without strict attribution or timestamp validation (to allow syncing old messages). This opened up potential spoofing vectors and prevented us from enforcing timestamp checks on normal traffic.
+
+The new implementation introduces a **RequestSyncManager** to track outgoing sync requests and attributes incoming responses (RSR - Request-Sync Response) to specific peers. This allows us to:
+1.  **Enforce Timestamp Validation**: Normal packets now require timestamps to be within 2 minutes of the local clock.
+2.  **Exempt Solicited Sync Responses**: Packets marked as RSR are exempt from timestamp validation *only if* they correspond to a valid, pending sync request sent to that specific peer.
+3.  **Prevent Unsolicited Sync Floods**: Unsolicited RSR packets are rejected.
+
+## Protocol Changes
+
+### Binary Protocol Updates
+*   **New Flag**: `IS_RSR` (0x10u) added to the packet header flags.
+*   **BitchatPacket**: Updated to include `isRSR: Boolean` field.
+*   **Encoding/Decoding**: Updated `BinaryProtocol` to handle the new flag.
+
+### Request Sync Payload
+The `REQUEST_SYNC` packet payload (TLV encoded) has been updated to include:
+*   **Future Filters (Placeholders)**:
+    *   `typeFilter` (Type 0x05): To request specific packet types.
+    *   `sinceTimestamp` (Type 0x06): To request packets since a certain time.
+    *   `fragmentIdFilter` (Type 0x07): To request specific fragments.
+
+*Note: `requestId` (Type 0x04) was considered but removed as it is not needed for the current sync attribution mechanism.*
+
+## Architecture
+
+### RequestSyncManager
+A new component responsible for:
+*   **Tracking**: Stores `peerID -> timestamp` mappings for pending sync requests.
+*   **Validation**: `isValidResponse(peerID, isRSR)` checks if an incoming RSR packet matches a pending request within the 30-second window.
+*   **Cleanup**: Periodically removes expired requests.
+
+### GossipSyncManager Updates
+*   **Unicast Sync**: Instead of blind broadcasting, the periodic sync task now iterates over connected peers and sends unicast `REQUEST_SYNC` packets.
+*   **Registration**: Before sending, requests are registered with `RequestSyncManager`.
+*   **Response Marking**: When responding to a `REQUEST_SYNC`, generated packets (Announce/Message) are explicitly marked with `isRSR = true`.
+
+### SecurityManager Updates
+*   **Timestamp Enforcement**: Checks `abs(now - packetTimestamp) < 2 minutes` for standard packets.
+*   **Conditional Exemption**: If `packet.isRSR` is true, it queries `RequestSyncManager`.
+    *   **Valid**: If solicited, timestamp check is skipped (allowing historical data sync).
+    *   **Invalid**: If unsolicited or timed out, the packet is rejected.
+
+## Usage
+
+These changes are integrated into `BluetoothMeshService`. No external API changes are required for clients, but all peers must be updated to support the new `IS_RSR` flag and protocol logic to participate in the secure sync process.


### PR DESCRIPTION
## Summary
This PR implements the Request Sync Manager to make sync requests "less blind" and improve security by attributing sync responses to specific peers.

### Key Changes
- **BinaryProtocol**: Added `IS_RSR` flag (0x10u) and `isRSR` field to `BitchatPacket`.
- **RequestSyncPacket**: Updated to include `requestId` (for attribution) and future filter fields.
- **RequestSyncManager**: New component to track pending sync requests and validate incoming RSR packets.
- **GossipSyncManager**: Updated to use unicast sync requests registered with `RequestSyncManager` instead of blind broadcasts.
- **SecurityManager**:
    - Enforces timestamp validation (max 2 min skew) for normal packets.
    - Exempts RSR packets from timestamp validation **only if** they are solicited and validated by `RequestSyncManager`.

### Documentation
- Added `docs/REQUEST_SYNC_MANAGER.md` with implementation details.

Closes https://github.com/permissionlesstech/bitchat-android/issues/622