### PR TITLE
fix(geohash): cleanup sampling subscriptions when closing location sheet

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -1046,7 +1046,7 @@ class ChatViewModel(
      * End geohash sampling
      */
     fun endGeohashSampling() {
-        // No-op in refactored architecture; sampling subscriptions are short-lived
+        geohashViewModel.endGeohashSampling()
     }
 
     /**

--- a/app/src/main/java/com/bitchat/android/ui/LocationChannelsSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/LocationChannelsSheet.kt
@@ -542,6 +542,13 @@ fun LocationChannelsSheet(
             viewModel.endGeohashSampling()
         }
     }
+
+    // Ensure cleanup when the composable is destroyed (e.g. removed from parent composition)
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.endGeohashSampling()
+        }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Summary
Fixes a bug where subscriptions for geohash heartbeats (kind: 20001) were not being cleaned up when closing the `LocationChannelsSheet`.

## Changes
- **`LocationChannelsSheet.kt`**: Added a `DisposableEffect` to ensure `viewModel.endGeohashSampling()` is called when the composable is removed from the composition. Previously, the `LaunchedEffect` was cancelled before it could run its cleanup block.
- **`ChatViewModel.kt`**: Updated `endGeohashSampling()` to actually delegate the call to `geohashViewModel.endGeohashSampling()`. It was previously a no-op, preventing any cleanup from happening even if called.

## Impact
- Prevents accumulation of stale subscriptions when opening/closing the locations sheet multiple times.
- Ensures the app only listens to the current geohash channel + DM context when the sheet is closed, reducing data usage and processing overhead.