### PR TITLE
Fix/traffic issue optimizations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ android {
         jvmTarget = "1.8"
     }
     buildFeatures {
+        buildConfig = true
         compose = true
     }
     packaging {

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.Lifecycle
 import com.bitchat.android.mesh.BluetoothMeshService
+import com.bitchat.android.nostr.NostrRelayManager
 import com.bitchat.android.onboarding.BluetoothCheckScreen
 import com.bitchat.android.onboarding.BluetoothStatus
 import com.bitchat.android.onboarding.BluetoothStatusManager
@@ -76,7 +77,7 @@ class MainActivity : OrientationAwareActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
+        NostrRelayManager.shared.setDiagnosticLogging(BuildConfig.DEBUG)
         // Register receiver for force finish signal from shutdown coordinator
         val filter = android.content.IntentFilter(com.bitchat.android.util.AppConstants.UI.ACTION_FORCE_FINISH)
         if (android.os.Build.VERSION.SDK_INT >= 33) {

--- a/app/src/main/java/com/bitchat/android/nostr/LocationNotesInitializer.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/LocationNotesInitializer.kt
@@ -29,14 +29,15 @@ object LocationNotesInitializer {
                     }
                     
                     Log.d(TAG, "📍 Location Notes subscribing to geohash: $geohashFromFilter")
-                    
+
+                    val optimalRelays = NostrRelayManager.optimalRelayCount(geohashFromFilter)
                     NostrRelayManager.getInstance(context).subscribeForGeohash(
                         geohash = geohashFromFilter,
                         filter = filter,
                         id = id,
                         handler = handler,
                         includeDefaults = true,
-                        nRelays = 5
+                        nRelays = optimalRelays
                     )
                 },
                 unsubscribe = { id ->

--- a/app/src/main/java/com/bitchat/android/nostr/NostrDiagnosticsReporter.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrDiagnosticsReporter.kt
@@ -1,0 +1,290 @@
+package com.bitchat.android.nostr
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Handles diagnostics reporting and health checks for Nostr relays
+ * Separates diagnostics logic from relay management
+ */
+class NostrDiagnosticsReporter(
+    private val metricsCollector: NostrMetricsCollector,
+    private val scope: CoroutineScope,
+    private val getActiveSubscriptions: () -> Map<String, NostrRelayManager.SubscriptionInfo>,
+    private val getConnections: () -> Map<String, *>,
+    private val getSubscriptions: () -> Map<String, Set<String>>
+) {
+
+    companion object {
+        private const val TAG = "NostrDiagnostics"
+        private const val HEALTH_CHECK_INTERVAL = 300000L // 5 minutes
+        private const val SUBSCRIPTION_VALIDATION_INTERVAL = 30000L // 30 seconds
+    }
+
+    private var healthCheckJob: Job? = null
+    private var subscriptionValidationJob: Job? = null
+    var diagnosticLoggingEnabled = false
+
+    /**
+     * Start periodic health check logging
+     */
+    fun startHealthCheck() {
+        stopHealthCheck()
+
+        healthCheckJob = scope.launch {
+            while (isActive) {
+                delay(HEALTH_CHECK_INTERVAL)
+
+                try {
+                    val metrics = metricsCollector.getMetrics()
+                    val activeSubscriptions = getActiveSubscriptions()
+                    val now = System.currentTimeMillis()
+
+                    // Find old subscriptions
+                    val oldSubs = activeSubscriptions.filter { (_, info) ->
+                        (now - info.createdAt) > 21600000 // > 6 hours
+                    }
+
+                    val mbReceived = metrics.totalBytesReceived / 1048576.0
+                    val ratePerHour = if (metrics.uptimeHours > 0) mbReceived / metrics.uptimeHours else 0.0
+
+                    Log.i(TAG, """
+                        ═══ HEALTH CHECK ═══
+                        📊 Subscriptions: ${activeSubscriptions.size} active, ${oldSubs.size} old (>6h)
+                        📡 Relays: ${getConnections().size} connected, ${metrics.reconnectionCount} reconnections
+                        📈 Data: ${formatBytes(metrics.totalBytesReceived)} received (${String.format("%.1f", ratePerHour)} MB/h)
+                        📥 Events: ${metrics.totalEventsReceived} (avg ${formatBytes(metrics.averageEventSize)})
+                        ${if (oldSubs.size > 5) "⚠️  WARNING: ${oldSubs.size} old subscriptions (possible leaks)" else ""}
+                        ${if (ratePerHour > 100) "⚠️  WARNING: High bandwidth (${String.format("%.1f", ratePerHour)} MB/h)" else ""}
+                    """.trimIndent())
+
+                    if (oldSubs.size > 10 || ratePerHour > 500) {
+                        Log.w(TAG, "🚨 CRITICAL ISSUE DETECTED - Full diagnostics:")
+                        Log.w(TAG, generateDiagnosticsReport())
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error during health check: ${e.message}")
+                }
+            }
+        }
+
+        Log.d(TAG, "🔄 Started periodic health check (${HEALTH_CHECK_INTERVAL / 1000}s interval)")
+    }
+
+    /**
+     * Stop health check logging
+     */
+    fun stopHealthCheck() {
+        healthCheckJob?.cancel()
+        healthCheckJob = null
+    }
+
+    /**
+     * Generate comprehensive diagnostics report
+     */
+    fun generateDiagnosticsReport(): String {
+        val metrics = metricsCollector.getMetrics()
+        val activeSubscriptions = getActiveSubscriptions()
+        val connections = getConnections()
+        val now = System.currentTimeMillis()
+
+        // Group subscriptions by age
+        val subsByAge = activeSubscriptions.entries.groupBy { (_, info) ->
+            val ageHours = (now - info.createdAt) / 3600000
+            when {
+                ageHours < 1 -> "0-1h"
+                ageHours < 6 -> "1-6h"
+                ageHours < 24 -> "6-24h"
+                else -> "24h+"
+            }
+        }
+
+        // Find old subscriptions (likely leaks)
+        val oldSubs = activeSubscriptions.filter { (_, info) ->
+            (now - info.createdAt) > 21600000 // > 6 hours
+        }
+
+        // Find top event-receiving subscriptions
+        val topSubs = metrics.eventsReceivedPerSubscription.entries
+            .sortedByDescending { it.value }
+            .take(10)
+
+        // Calculate per-relay bandwidth
+        val relayBandwidth = metrics.bytesReceivedPerRelay.entries
+            .sortedByDescending { it.value }
+            .take(10)
+
+        return """
+════════════════════════════════════════════════════════════════
+                NOSTR DATA USAGE DIAGNOSTICS REPORT
+════════════════════════════════════════════════════════════════
+
+📊 OVERVIEW
+────────────────────────────────────────────────────────────────
+Active Subscriptions: ${activeSubscriptions.size}
+Connected Relays: ${connections.size}
+Reconnections: ${metrics.reconnectionCount}
+Uptime: ${String.format("%.1f", metrics.uptimeHours)} hours
+
+🔍 DATA TRANSFER
+────────────────────────────────────────────────────────────────
+Total Sent: ${formatBytes(metrics.totalBytesSent)}
+Total Received: ${formatBytes(metrics.totalBytesReceived)}
+Total: ${formatBytes(metrics.totalBytesSent + metrics.totalBytesReceived)}
+
+Events Received: ${metrics.totalEventsReceived}
+Average Event Size: ${formatBytes(metrics.averageEventSize)}
+${if (metrics.averageEventSize > 5000) "⚠️  WARNING: Large average event size!" else ""}
+
+Rate: ${String.format("%.1f", metrics.bandwidthPerHour)} MB/hour
+Projected Weekly: ${String.format("%.1f", metrics.bandwidthPerHour * 168)} MB
+
+⚠️  LEAK DETECTION
+────────────────────────────────────────────────────────────────
+Subscriptions by Age:
+  0-1 hour:   ${subsByAge["0-1h"]?.size ?: 0} subs
+  1-6 hours:  ${subsByAge["1-6h"]?.size ?: 0} subs
+  6-24 hours: ${subsByAge["6-24h"]?.size ?: 0} subs
+  24+ hours:  ${subsByAge["24h+"]?.size ?: 0} subs
+
+Old Subscriptions (>6h): ${oldSubs.size}
+${if (oldSubs.size > 5) "⚠️  WARNING: Likely subscription leaks detected!" else ""}
+${if (oldSubs.size > 20) "🚨 CRITICAL: Severe subscription leak! ${oldSubs.size} old subscriptions!" else ""}
+
+📈 TOP EVENT-RECEIVING SUBSCRIPTIONS
+────────────────────────────────────────────────────────────────
+${topSubs.joinToString("\n") { (subId, count) ->
+            val info = activeSubscriptions[subId]
+            val ageMin = if (info != null) (now - info.createdAt) / 60000 else 0
+            val geo = info?.originGeohash ?: "unknown"
+            "  $subId: $count events (age: ${ageMin}min, geo: $geo)"
+        }}
+${if (topSubs.isEmpty()) "  No events received yet" else ""}
+
+📡 TOP BANDWIDTH-CONSUMING RELAYS
+────────────────────────────────────────────────────────────────
+${relayBandwidth.joinToString("\n") { (relay, bytes) ->
+            "  ${relay.substringAfter("wss://")}: ${formatBytes(bytes)}"
+        }}
+
+🔧 SUBSCRIPTION DETAILS (first 20)
+────────────────────────────────────────────────────────────────
+${activeSubscriptions.entries.take(20).joinToString("\n") { (id, info) ->
+            val ageMin = (now - info.createdAt) / 60000
+            val eventCount = metrics.eventsReceivedPerSubscription[id] ?: 0
+            val targets = info.targetRelayUrls?.size ?: connections.size
+            val geo = info.originGeohash?.take(6) ?: "global"
+            "  $id: age=${ageMin}min, events=$eventCount, relays=$targets, geo=$geo"
+        }}
+${if (activeSubscriptions.size > 20) "  ... and ${activeSubscriptions.size - 20} more subscriptions" else ""}
+
+🩺 HEALTH STATUS
+────────────────────────────────────────────────────────────────
+${when {
+            activeSubscriptions.size > 100 -> "🚨 CRITICAL: Too many active subscriptions (${activeSubscriptions.size})"
+            activeSubscriptions.size > 50 -> "⚠️  WARNING: High subscription count (${activeSubscriptions.size})"
+            oldSubs.size > 20 -> "🚨 CRITICAL: Severe subscription leaks (${oldSubs.size} old subs)"
+            oldSubs.size > 5 -> "⚠️  WARNING: Possible subscription leaks (${oldSubs.size} old subs)"
+            metrics.reconnectionCount > 50 -> "⚠️  WARNING: High reconnection rate (${metrics.reconnectionCount})"
+            metrics.averageEventSize > 10000 -> "⚠️  WARNING: Very large events (${formatBytes(metrics.averageEventSize)} avg)"
+            metrics.bandwidthPerHour > 100 -> "⚠️  WARNING: High bandwidth usage (${String.format("%.1f", metrics.bandwidthPerHour)} MB/hour)"
+            else -> "✅ All metrics look healthy"
+        }}
+
+📋 RECOMMENDATIONS
+────────────────────────────────────────────────────────────────
+${generateRecommendations(oldSubs.size, metrics.averageEventSize, metrics.reconnectionCount.toInt(), metrics.bandwidthPerHour)}
+
+════════════════════════════════════════════════════════════════
+Generated: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date(now))}
+════════════════════════════════════════════════════════════════
+        """.trimIndent()
+    }
+
+    /**
+     * Validate subscription consistency between client and relays
+     */
+    fun validateSubscriptionConsistency(): SubscriptionConsistencyReport {
+        val expectedSubs = getActiveSubscriptions().keys
+        val actualSubsByRelay = getSubscriptions().toMap()
+        val inconsistencies = mutableListOf<String>()
+
+        val connections = getConnections()
+        for ((relayUrl, _) in connections) {
+            val actualSubs = actualSubsByRelay[relayUrl] ?: emptySet()
+            val expectedSubsForRelay = getActiveSubscriptions().filter { (_, info) ->
+                info.targetRelayUrls == null || info.targetRelayUrls.contains(relayUrl)
+            }.keys
+
+            val missing = expectedSubsForRelay - actualSubs
+            val extra = actualSubs - expectedSubs
+
+            if (missing.isNotEmpty()) {
+                inconsistencies.add("Relay $relayUrl missing subscriptions: $missing")
+            }
+            if (extra.isNotEmpty()) {
+                inconsistencies.add("Relay $relayUrl has extra subscriptions: $extra")
+            }
+        }
+
+        return SubscriptionConsistencyReport(
+            isConsistent = inconsistencies.isEmpty(),
+            inconsistencies = inconsistencies,
+            connectedRelayCount = connections.size
+        )
+    }
+
+    private fun formatBytes(bytes: Long): String {
+        return when {
+            bytes < 1024 -> "$bytes B"
+            bytes < 1048576 -> String.format("%.1f KB", bytes / 1024.0)
+            bytes < 1073741824 -> String.format("%.1f MB", bytes / 1048576.0)
+            else -> String.format("%.2f GB", bytes / 1073741824.0)
+        }
+    }
+
+    private fun generateRecommendations(oldSubCount: Int, avgEventSize: Long, reconnections: Int, bandwidthPerHour: Double): String {
+        val recommendations = mutableListOf<String>()
+
+        if (oldSubCount > 20) {
+            recommendations.add("🚨 URGENT: Clear all subscriptions with panicReset() and restart")
+        } else if (oldSubCount > 5) {
+            recommendations.add("⚠️  Call clearAllSubscriptions() to remove leaked subscriptions")
+        }
+
+        if (avgEventSize > 10000) {
+            recommendations.add("⚠️  Events are very large - investigate event content")
+        }
+
+        if (reconnections > 50) {
+            recommendations.add("⚠️  Network unstable - check WiFi/Tor connection")
+        }
+
+        if (bandwidthPerHour > 100) {
+            recommendations.add("⚠️  High bandwidth - consider reducing relay count from 5 to 2")
+        }
+
+        return if (recommendations.isEmpty()) {
+            "✅ No issues detected"
+        } else {
+            recommendations.joinToString("\n")
+        }
+    }
+}
+
+/**
+ * Report of subscription consistency check
+ */
+data class SubscriptionConsistencyReport(
+    val isConsistent: Boolean,
+    val inconsistencies: List<String>,
+    val connectedRelayCount: Int
+)

--- a/app/src/main/java/com/bitchat/android/nostr/NostrFilter.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrFilter.kt
@@ -42,7 +42,31 @@ data class NostrFilter(
                 limit = limit
             )
         }
-        
+
+        /**
+         * Create filter for geohash chat messages only (kind 20000)
+         */
+        fun geohashMessages(geohash: String, since: Long? = null, limit: Int = 200): NostrFilter {
+            return NostrFilter(
+                kinds = listOf(NostrKind.EPHEMERAL_EVENT),
+                since = since?.let { (it / 1000).toInt() },
+                tagFilters = mapOf("g" to listOf(geohash)),
+                limit = limit
+            )
+        }
+
+        /**
+         * Create filter for geohash presence heartbeats only (kind 20001)
+         */
+        fun geohashPresence(geohash: String, since: Long? = null, limit: Int = 100): NostrFilter {
+            return NostrFilter(
+                kinds = listOf(NostrKind.GEOHASH_PRESENCE),
+                since = since?.let { (it / 1000).toInt() },
+                tagFilters = mapOf("g" to listOf(geohash)),
+                limit = limit
+            )
+        }
+
         /**
          * Create filter for text notes from specific authors
          */

--- a/app/src/main/java/com/bitchat/android/nostr/NostrMetricsCollector.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrMetricsCollector.kt
@@ -1,0 +1,139 @@
+package com.bitchat.android.nostr
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Collects and tracks Nostr relay metrics
+ * Separates metric collection from relay management logic
+ */
+class NostrMetricsCollector {
+
+    // Atomic counters for thread-safe updates
+    private val totalBytesReceived = AtomicLong(0)
+    private val totalBytesSent = AtomicLong(0)
+    private val totalEventsReceived = AtomicLong(0)
+    private val reconnectionCount = AtomicLong(0)
+
+    // Per-relay and per-subscription tracking
+    private val bytesReceivedPerRelay = ConcurrentHashMap<String, Long>()
+    private val bytesSentPerRelay = ConcurrentHashMap<String, Long>()
+    private val eventsReceivedPerSubscription = ConcurrentHashMap<String, Long>()
+
+    // Relay message counters
+    private val relayMessagesSent = ConcurrentHashMap<String, Int>()
+    private val relayMessagesReceived = ConcurrentHashMap<String, Int>()
+
+    // Track start time for uptime calculation
+    private val startTime = System.currentTimeMillis()
+
+    /**
+     * Record bytes received from a relay
+     */
+    fun recordBytesReceived(relayUrl: String, bytes: Long) {
+        totalBytesReceived.addAndGet(bytes)
+        bytesReceivedPerRelay.merge(relayUrl, bytes) { old, new -> old + new }
+    }
+
+    /**
+     * Record bytes sent to a relay
+     */
+    fun recordBytesSent(relayUrl: String, bytes: Long) {
+        totalBytesSent.addAndGet(bytes)
+        bytesSentPerRelay.merge(relayUrl, bytes) { old, new -> old + new }
+    }
+
+    /**
+     * Record an event received for a subscription
+     */
+    fun recordEventReceived(subscriptionId: String, eventSize: Long) {
+        totalEventsReceived.incrementAndGet()
+        eventsReceivedPerSubscription.merge(subscriptionId, 1) { old, _ -> old + 1 }
+    }
+
+    /**
+     * Record a relay reconnection
+     */
+    fun recordReconnection() {
+        reconnectionCount.incrementAndGet()
+    }
+
+    /**
+     * Record a message sent to a relay
+     */
+    fun recordMessageSent(relayUrl: String) {
+        relayMessagesSent.merge(relayUrl, 1) { old, _ -> old + 1 }
+    }
+
+    /**
+     * Record a message received from a relay
+     */
+    fun recordMessageReceived(relayUrl: String) {
+        relayMessagesReceived.merge(relayUrl, 1) { old, _ -> old + 1 }
+    }
+
+    /**
+     * Remove subscription tracking when unsubscribed
+     */
+    fun removeSubscription(subscriptionId: String) {
+        eventsReceivedPerSubscription.remove(subscriptionId)
+    }
+
+    /**
+     * Get current metrics snapshot
+     */
+    fun getMetrics(): NostrMetrics {
+        return NostrMetrics(
+            totalBytesReceived = totalBytesReceived.get(),
+            totalBytesSent = totalBytesSent.get(),
+            totalEventsReceived = totalEventsReceived.get(),
+            reconnectionCount = reconnectionCount.get(),
+            bytesReceivedPerRelay = bytesReceivedPerRelay.toMap(),
+            bytesSentPerRelay = bytesSentPerRelay.toMap(),
+            eventsReceivedPerSubscription = eventsReceivedPerSubscription.toMap(),
+            relayMessagesSent = relayMessagesSent.toMap(),
+            relayMessagesReceived = relayMessagesReceived.toMap(),
+            uptimeMillis = System.currentTimeMillis() - startTime
+        )
+    }
+
+    /**
+     * Reset all metrics (for testing or panic reset)
+     */
+    fun reset() {
+        totalBytesReceived.set(0)
+        totalBytesSent.set(0)
+        totalEventsReceived.set(0)
+        reconnectionCount.set(0)
+        bytesReceivedPerRelay.clear()
+        bytesSentPerRelay.clear()
+        eventsReceivedPerSubscription.clear()
+        relayMessagesSent.clear()
+        relayMessagesReceived.clear()
+    }
+}
+
+/**
+ * Immutable snapshot of Nostr metrics
+ */
+data class NostrMetrics(
+    val totalBytesReceived: Long,
+    val totalBytesSent: Long,
+    val totalEventsReceived: Long,
+    val reconnectionCount: Long,
+    val bytesReceivedPerRelay: Map<String, Long>,
+    val bytesSentPerRelay: Map<String, Long>,
+    val eventsReceivedPerSubscription: Map<String, Long>,
+    val relayMessagesSent: Map<String, Int>,
+    val relayMessagesReceived: Map<String, Int>,
+    val uptimeMillis: Long
+) {
+    val uptimeHours: Double
+        get() = uptimeMillis / 3600000.0
+
+    val averageEventSize: Long
+        get() = if (totalEventsReceived > 0) totalBytesReceived / totalEventsReceived else 0
+
+    val bandwidthPerHour: Double
+        get() = if (uptimeHours > 0) (totalBytesReceived / 1048576.0) / uptimeHours else 0.0
+}

--- a/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
@@ -46,19 +46,8 @@ class NostrRelayManager private constructor() {
         private const val MAX_BACKOFF_INTERVAL = com.bitchat.android.util.AppConstants.Nostr.MAX_BACKOFF_INTERVAL_MS    // 5 minutes
         private const val BACKOFF_MULTIPLIER = com.bitchat.android.util.AppConstants.Nostr.BACKOFF_MULTIPLIER
         private const val MAX_RECONNECT_ATTEMPTS = com.bitchat.android.util.AppConstants.Nostr.MAX_RECONNECT_ATTEMPTS
-        
-        /**
-         * Calculate optimal relay count based on geohash precision
-         * Broad geohashes (1-2 chars) have high activity → need fewer relays
-         * Narrow geohashes (5+ chars) have low activity → need more relays for coverage
-         */
-        fun optimalRelayCount(geohash: String): Int {
-            return when (geohash.length) {
-                1, 2 -> 2  // Broad: continent/country (e.g., "u", "u0", "sy") - high activity
-                3, 4 -> 3  // Medium: province/state - moderate activity
-                else -> 5  // Narrow: city/neighborhood (5+ chars) - low activity, need coverage
-            }
-        }
+
+        fun optimalRelayCount(geohash: String): Int = 3
 
         // Track gift-wraps we initiated for logging
         private val pendingGiftWrapIDs = ConcurrentHashMap.newKeySet<String>()

--- a/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
@@ -168,7 +168,7 @@ class NostrRelayManager private constructor() {
         id: String = generateSubscriptionId(),
         handler: (NostrEvent) -> Unit,
         includeDefaults: Boolean = false,
-    nRelays: Int = 5
+        nRelays: Int = 5
     ): String {
         ensureGeohashRelaysConnected(geohash, nRelays, includeDefaults)
         val relayUrls = getRelaysForGeohash(geohash)

--- a/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
@@ -47,6 +47,19 @@ class NostrRelayManager private constructor() {
         private const val BACKOFF_MULTIPLIER = com.bitchat.android.util.AppConstants.Nostr.BACKOFF_MULTIPLIER
         private const val MAX_RECONNECT_ATTEMPTS = com.bitchat.android.util.AppConstants.Nostr.MAX_RECONNECT_ATTEMPTS
         
+        /**
+         * Calculate optimal relay count based on geohash precision
+         * Broad geohashes (1-2 chars) have high activity → need fewer relays
+         * Narrow geohashes (5+ chars) have low activity → need more relays for coverage
+         */
+        fun optimalRelayCount(geohash: String): Int {
+            return when (geohash.length) {
+                1, 2 -> 2  // Broad: continent/country (e.g., "u", "u0", "sy") - high activity
+                3, 4 -> 3  // Medium: province/state - moderate activity
+                else -> 5  // Narrow: city/neighborhood (5+ chars) - low activity, need coverage
+            }
+        }
+
         // Track gift-wraps we initiated for logging
         private val pendingGiftWrapIDs = ConcurrentHashMap.newKeySet<String>()
         
@@ -123,6 +136,10 @@ class NostrRelayManager private constructor() {
     // Per-geohash relay selection
     private val geohashToRelays = ConcurrentHashMap<String, Set<String>>() // geohash -> relay URLs
 
+    // Metrics and diagnostics - delegated to specialized classes
+    internal val metricsCollector = NostrMetricsCollector()
+    private lateinit var diagnosticsReporter: NostrDiagnosticsReporter
+
     // --- Public API for geohash-specific operation ---
 
     /**
@@ -162,7 +179,7 @@ class NostrRelayManager private constructor() {
         id: String = generateSubscriptionId(),
         handler: (NostrEvent) -> Unit,
         includeDefaults: Boolean = false,
-        nRelays: Int = 5
+    nRelays: Int = 5
     ): String {
         ensureGeohashRelaysConnected(geohash, nRelays, includeDefaults)
         val relayUrls = getRelaysForGeohash(geohash)
@@ -229,6 +246,16 @@ class NostrRelayManager private constructor() {
             relaysList.addAll(defaultRelayUrls.map { Relay(it) })
             _relays.value = relaysList.toList()
             updateConnectionStatus()
+
+            // Initialize diagnostics reporter
+            diagnosticsReporter = NostrDiagnosticsReporter(
+                metricsCollector = metricsCollector,
+                scope = scope,
+                getActiveSubscriptions = { activeSubscriptions.toMap() },
+                getConnections = { connections.toMap() },
+                getSubscriptions = { subscriptions.toMap() }
+            )
+
             Log.d(TAG, "✅ NostrRelayManager initialized with ${relaysList.size} default relays")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize NostrRelayManager: ${e.message}", e)
@@ -318,8 +345,27 @@ class NostrRelayManager private constructor() {
         
         activeSubscriptions[id] = subscriptionInfo
         messageHandlers[id] = handler
-        
-        Log.d(TAG, "📡 Subscribing to Nostr filter id=$id ${filter.getDebugDescription()}")
+
+        // Diagnostic logging with stack trace to identify subscription source
+        if (diagnosticsReporter.diagnosticLoggingEnabled) {
+            val stackTrace = Thread.currentThread().stackTrace
+                .take(8)
+                .drop(2) // Skip Thread.getStackTrace() and this method
+                .joinToString("\n") { "    at $it" }
+            Log.d(
+                TAG, """
+                ➕ SUBSCRIPTION CREATED
+                   ID: $id
+                   Filter: ${filter.getDebugDescription()}
+                   Targets: ${targetRelayUrls?.size ?: "all"} relays
+                   Total active: ${activeSubscriptions.size}
+                   Stack trace:
+                $stackTrace
+            """.trimIndent()
+            )
+        } else {
+            Log.d(TAG, "📡 Subscribing to Nostr filter id=$id ${filter.getDebugDescription()}")
+        }
         
         // Send subscription to appropriate relays
         sendSubscriptionToRelays(subscriptionInfo)
@@ -344,12 +390,16 @@ class NostrRelayManager private constructor() {
                 val webSocket = connections[relayUrl]
                 if (webSocket != null) {
                     try {
+                        // Track bytes sent
+                        val messageSize = message.length.toLong()
+                        metricsCollector.recordBytesSent(relayUrl, messageSize)
+
                         val success = webSocket.send(message)
                         if (success) {
                             // Track subscription for this relay
                             val currentSubs = subscriptions[relayUrl] ?: emptySet()
                             subscriptions[relayUrl] = currentSubs + subscriptionInfo.id
-                            
+
                             Log.v(TAG, "✅ Subscription '${subscriptionInfo.id}' sent to relay: $relayUrl")
                         } else {
                             Log.w(TAG, "❌ Failed to send subscription to $relayUrl: WebSocket send failed")
@@ -380,8 +430,29 @@ class NostrRelayManager private constructor() {
             Log.w(TAG, "⚠️ Attempted to unsubscribe from unknown subscription: $id")
             return
         }
-        
-        Log.d(TAG, "🚫 Unsubscribing from subscription: $id")
+
+        // Diagnostic logging
+        val subscriptionAge = System.currentTimeMillis() - subscriptionInfo.createdAt
+        val eventCount = metricsCollector.getMetrics().eventsReceivedPerSubscription[id] ?: 0
+        metricsCollector.removeSubscription(id)
+
+        if (diagnosticsReporter.diagnosticLoggingEnabled) {
+            val stackTrace = Thread.currentThread().stackTrace
+                .take(8)
+                .drop(2)
+                .joinToString("\n") { "    at $it" }
+            Log.d(TAG, """
+                ➖ SUBSCRIPTION CLOSED
+                   ID: $id
+                   Age: ${subscriptionAge / 60000} minutes
+                   Events received: $eventCount
+                   Total active: ${activeSubscriptions.size - 1}
+                   Stack trace:
+                $stackTrace
+            """.trimIndent())
+        } else {
+            Log.d(TAG, "🚫 Unsubscribing from subscription: $id (age: ${subscriptionAge / 60000}min, events: $eventCount)")
+        }
         
         val request = NostrRequest.Close(id)
         val message = gson.toJson(request, NostrRequest::class.java)
@@ -391,6 +462,10 @@ class NostrRelayManager private constructor() {
                 val currentSubs = subscriptions[relayUrl]
                 if (currentSubs?.contains(id) == true) {
                     try {
+                        // Track bytes sent
+                        val messageSize = message.length.toLong()
+                        metricsCollector.recordBytesSent(relayUrl, messageSize)
+
                         webSocket.send(message)
                         subscriptions[relayUrl] = currentSubs - id
                         Log.v(TAG, "Unsubscribed '$id' from relay: $relayUrl")
@@ -514,48 +589,35 @@ class NostrRelayManager private constructor() {
     fun getActiveSubscriptions(): Map<String, SubscriptionInfo> {
         return activeSubscriptions.toMap()
     }
+
+    /**
+     * Enable or disable diagnostic logging
+     */
+    fun setDiagnosticLogging(enabled: Boolean) {
+        diagnosticsReporter.diagnosticLoggingEnabled = enabled
+        if (enabled) {
+            Log.i(TAG, "🔍 Diagnostic logging ENABLED - detailed logs will be generated")
+            diagnosticsReporter.startHealthCheck()
+        } else {
+            Log.i(TAG, "🔍 Diagnostic logging DISABLED")
+            diagnosticsReporter.stopHealthCheck()
+        }
+    }
+
+    /**
+     * Generate comprehensive diagnostics report for data usage debugging
+     */
+    fun generateDiagnosticsReport(): String {
+        return diagnosticsReporter.generateDiagnosticsReport()
+    }
     
     /**
      * Validate subscription consistency across all relays
      * Returns a report of any inconsistencies found
      */
     fun validateSubscriptionConsistency(): SubscriptionConsistencyReport {
-        val expectedSubs = activeSubscriptions.keys
-        val actualSubsByRelay = subscriptions.toMap()
-        val inconsistencies = mutableListOf<String>()
-        
-        connections.keys.forEach { relayUrl ->
-            val actualSubs = actualSubsByRelay[relayUrl] ?: emptySet()
-            val expectedForRelay = expectedSubs.filter { subId ->
-                val subInfo = activeSubscriptions[subId]
-                subInfo?.targetRelayUrls == null || subInfo.targetRelayUrls.contains(relayUrl)
-            }.toSet()
-            
-            val missing = expectedForRelay - actualSubs
-            val extra = actualSubs - expectedForRelay
-            
-            if (missing.isNotEmpty()) {
-                inconsistencies.add("Relay $relayUrl missing subscriptions: $missing")
-            }
-            if (extra.isNotEmpty()) {
-                inconsistencies.add("Relay $relayUrl has extra subscriptions: $extra")
-            }
-        }
-        
-        return SubscriptionConsistencyReport(
-            isConsistent = inconsistencies.isEmpty(),
-            inconsistencies = inconsistencies,
-            totalActiveSubscriptions = activeSubscriptions.size,
-            connectedRelayCount = connections.size
-        )
+        return diagnosticsReporter.validateSubscriptionConsistency()
     }
-    
-    data class SubscriptionConsistencyReport(
-        val isConsistent: Boolean,
-        val inconsistencies: List<String>,
-        val totalActiveSubscriptions: Int,
-        val connectedRelayCount: Int
-    )
     
     /**
      * Start periodic subscription validation to ensure robustness
@@ -573,17 +635,36 @@ class NostrRelayManager private constructor() {
                         Log.w(TAG, "⚠️ Subscription inconsistencies detected: ${report.inconsistencies}")
                         
                         // Auto-repair: re-establish subscriptions for relays with missing ones
+                        // AND clean up extra subscriptions that shouldn't be there
                         connections.forEach { (relayUrl, webSocket) ->
                             val currentSubs = subscriptions[relayUrl] ?: emptySet()
                             val expectedSubs = activeSubscriptions.keys.filter { subId ->
                                 val subInfo = activeSubscriptions[subId]
                                 subInfo?.targetRelayUrls == null || subInfo.targetRelayUrls.contains(relayUrl)
                             }.toSet()
-                            
+
+                            // Fix missing subscriptions
                             val missingSubs = expectedSubs - currentSubs
                             if (missingSubs.isNotEmpty()) {
                                 Log.i(TAG, "🔧 Auto-repairing ${missingSubs.size} missing subscriptions for $relayUrl")
                                 restoreSubscriptionsForRelay(relayUrl, webSocket)
+                            }
+
+                            // Clean up extra subscriptions (leaked/orphaned)
+                            val extraSubs = currentSubs - expectedSubs
+                            if (extraSubs.isNotEmpty()) {
+                                Log.i(TAG, "🧹 Auto-cleaning ${extraSubs.size} extra subscriptions from $relayUrl: $extraSubs")
+                                extraSubs.forEach { subId ->
+                                    try {
+                                        val closeRequest = NostrRequest.Close(subId)
+                                        val closeMessage = gson.toJson(closeRequest, NostrRequest::class.java)
+                                        webSocket.send(closeMessage)
+                                        subscriptions[relayUrl] = subscriptions[relayUrl]?.minus(subId) ?: emptySet()
+                                        Log.v(TAG, "Cleaned up orphaned subscription '$subId' from $relayUrl")
+                                    } catch (e: Exception) {
+                                        Log.w(TAG, "Failed to clean up subscription $subId from $relayUrl: ${e.message}")
+                                    }
+                                }
                             }
                         }
                     }
@@ -604,6 +685,7 @@ class NostrRelayManager private constructor() {
         subscriptionValidationJob = null
         Log.v(TAG, "⏹️ Stopped subscription validation")
     }
+
     
     // MARK: - Private Methods
     
@@ -633,9 +715,13 @@ class NostrRelayManager private constructor() {
         try {
             val request = NostrRequest.Event(event)
             val message = gson.toJson(request, NostrRequest::class.java)
-            
+
+            // Track bytes sent
+            val messageSize = message.length.toLong()
+            metricsCollector.recordBytesSent(relayUrl, messageSize)
+
             Log.v(TAG, "📤 Sending Nostr event (kind: ${event.kind}) to relay: $relayUrl")
-            
+
             val success = webSocket.send(message)
             if (success) {
                 // Update relay stats
@@ -651,17 +737,24 @@ class NostrRelayManager private constructor() {
     }
     
     private fun handleMessage(message: String, relayUrl: String) {
+        // Track data received
+        val messageSize = message.length.toLong()
+        metricsCollector.recordBytesReceived(relayUrl, messageSize)
+
         try {
             val jsonElement = JsonParser.parseString(message)
             if (!jsonElement.isJsonArray) {
                 Log.w(TAG, "Received non-array message from $relayUrl")
                 return
             }
-            
+
             val response = NostrResponse.fromJsonArray(jsonElement.asJsonArray)
             
             when (response) {
                 is NostrResponse.Event -> {
+                    // Track event statistics
+                    metricsCollector.recordEventReceived(response.subscriptionId, messageSize)
+
                     // Update relay stats
                     val relay = relaysList.find { it.url == relayUrl }
                     relay?.messagesReceived = (relay?.messagesReceived ?: 0) + 1
@@ -736,7 +829,14 @@ class NostrRelayManager private constructor() {
         connections.remove(relayUrl)
         // NOTE: Don't remove subscriptions here - keep them for restoration on reconnection
         // subscriptions.remove(relayUrl)  // REMOVED - this was causing subscription loss
-        
+
+        metricsCollector.recordReconnection()
+
+        if (diagnosticsReporter.diagnosticLoggingEnabled) {
+            val metrics = metricsCollector.getMetrics()
+            Log.d(TAG, "🔌 DISCONNECTION #${metrics.reconnectionCount} from $relayUrl: ${error.message}")
+        }
+
         updateRelayStatus(relayUrl, false, error)
         
         // Check if this is a DNS error
@@ -830,13 +930,17 @@ class NostrRelayManager private constructor() {
             try {
                 val request = NostrRequest.Subscribe(subscriptionInfo.id, listOf(subscriptionInfo.filter))
                 val message = gson.toJson(request, NostrRequest::class.java)
-                
+
+                // Track bytes sent
+                val messageSize = message.length.toLong()
+                metricsCollector.recordBytesSent(relayUrl, messageSize)
+
                 val success = webSocket.send(message)
                 if (success) {
                     // Track subscription for this relay
                     val currentSubs = subscriptions[relayUrl] ?: emptySet()
                     subscriptions[relayUrl] = currentSubs + subscriptionInfo.id
-                    
+
                     Log.v(TAG, "✅ Restored subscription '${subscriptionInfo.id}' to relay: $relayUrl")
                 } else {
                     Log.w(TAG, "❌ Failed to restore subscription '${subscriptionInfo.id}' to $relayUrl: WebSocket send failed")

--- a/app/src/main/java/com/bitchat/android/nostr/NostrSubscriptionManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrSubscriptionManager.kt
@@ -30,7 +30,9 @@ class NostrSubscriptionManager(
     fun subscribeGeohash(geohash: String, sinceMs: Long, limit: Int, id: String, handler: (NostrEvent) -> Unit) {
         scope.launch {
             val filter = NostrFilter.geohashEphemeral(geohash, sinceMs, limit)
-            relayManager.subscribeForGeohash(geohash, filter, id, handler, includeDefaults = false, nRelays = 5)
+            val optimalRelays = NostrRelayManager.optimalRelayCount(geohash)
+            Log.d(TAG, "📡 Subscribing to $geohash with $optimalRelays relays (precision: ${geohash.length} chars)")
+            relayManager.subscribeForGeohash(geohash, filter, id, handler, includeDefaults = false, nRelays = optimalRelays)
         }
     }
 

--- a/app/src/main/java/com/bitchat/android/nostr/NostrSubscriptionManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrSubscriptionManager.kt
@@ -36,5 +36,23 @@ class NostrSubscriptionManager(
         }
     }
 
+    fun subscribeGeohashMessages(geohash: String, sinceMs: Long, limit: Int, id: String, handler: (NostrEvent) -> Unit) {
+        scope.launch {
+            val filter = NostrFilter.geohashMessages(geohash, sinceMs, limit)
+            val optimalRelays = NostrRelayManager.optimalRelayCount(geohash)
+            Log.d(TAG, "📡 Subscribing to $geohash MESSAGES with $optimalRelays relays")
+            relayManager.subscribeForGeohash(geohash, filter, id, handler, includeDefaults = false, nRelays = optimalRelays)
+        }
+    }
+
+    fun subscribeGeohashPresence(geohash: String, sinceMs: Long, limit: Int, id: String, handler: (NostrEvent) -> Unit) {
+        scope.launch {
+            val filter = NostrFilter.geohashPresence(geohash, sinceMs, limit)
+            val optimalRelays = NostrRelayManager.optimalRelayCount(geohash)
+            Log.d(TAG, "📡 Subscribing to $geohash PRESENCE with $optimalRelays relays")
+            relayManager.subscribeForGeohash(geohash, filter, id, handler, includeDefaults = false, nRelays = optimalRelays)
+        }
+    }
+
     fun unsubscribe(id: String) { scope.launch { runCatching { relayManager.unsubscribe(id) } } }
 }

--- a/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
@@ -173,8 +173,9 @@ class GeohashViewModel(
             val identity = NostrIdentityBridge.deriveIdentity(geohash, getApplication())
             val event = NostrProtocol.createGeohashPresenceEvent(geohash, identity)
             val relayManager = NostrRelayManager.getInstance(getApplication())
-            // Presence is lightweight, send to geohash relays
-            relayManager.sendEventToGeohash(event, geohash, includeDefaults = false, nRelays = 5)
+            // Presence is lightweight, send to geohash relays with optimal relay count
+            val optimalRelays = NostrRelayManager.optimalRelayCount(geohash)
+            relayManager.sendEventToGeohash(event, geohash, includeDefaults = false, nRelays = optimalRelays)
             Log.v(TAG, "💓 Sent presence heartbeat for $geohash")
         } catch (e: Exception) {
             Log.w(TAG, "Failed to send presence for $geohash: ${e.message}")
@@ -206,7 +207,8 @@ class GeohashViewModel(
                     val teleported = state.isTeleported.value
                     val event = NostrProtocol.createEphemeralGeohashEvent(content, channel.geohash, identity, nickname, teleported)
                     val relayManager = NostrRelayManager.getInstance(getApplication())
-                    relayManager.sendEventToGeohash(event, channel.geohash, includeDefaults = false, nRelays = 5)
+                    val optimalRelays = NostrRelayManager.optimalRelayCount(channel.geohash)
+                    relayManager.sendEventToGeohash(event, channel.geohash, includeDefaults = false, nRelays = optimalRelays)
                 } finally {
                     // Ensure we stop the per-message mining animation regardless of success/failure
                     if (startedMining) {

--- a/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
@@ -333,6 +333,7 @@ class GeohashViewModel(
         currentGeohashSubId?.let { subscriptionManager.unsubscribe(it); currentGeohashSubId = null }
         currentPresenceSubId?.let { subscriptionManager.unsubscribe(it); currentPresenceSubId = null }
         currentDmSubId?.let { subscriptionManager.unsubscribe(it); currentDmSubId = null }
+        currentActiveGeohash = null
 
         when (channel) {
             is com.bitchat.android.geohash.ChannelID.Mesh -> {

--- a/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
@@ -423,7 +423,7 @@ class GeohashViewModel(
     }
 
     override fun onStart(owner: LifecycleOwner) {
-        Log.d(TAG, "🌍 App foregrounded: Resuming sampling, presence heartbeat, and presence subscription")
+        Log.d(TAG, "🌍 App foregrounded: Resuming sampling and presence subscription")
         activeSamplingGeohashes.forEach { performSubscribeSampling(it) }
         startGlobalPresenceHeartbeat()
         // Reopen presence subscription for active channel
@@ -441,10 +441,8 @@ class GeohashViewModel(
     }
 
     override fun onStop(owner: LifecycleOwner) {
-        Log.d(TAG, "🌍 App backgrounded: Pausing sampling, presence heartbeat, and presence subscription")
+        Log.d(TAG, "🌍 App backgrounded: Pausing sampling and presence subscription")
         activeSamplingGeohashes.forEach { subscriptionManager.unsubscribe("sampling-$it") }
-        globalPresenceJob?.cancel()
-        globalPresenceJob = null
         currentPresenceSubId?.let { subscriptionManager.unsubscribe(it); currentPresenceSubId = null }
     }
 

--- a/app/src/main/java/com/bitchat/android/ui/LocationChannelsSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/LocationChannelsSheet.kt
@@ -534,13 +534,9 @@ fun LocationChannelsSheet(
     }
 
     // Sampling management: update sampling when channels/bookmarks change
-    LaunchedEffect(isPresented, availableChannels, bookmarks) {
-        if (isPresented) {
-            val geohashes = (availableChannels.map { it.geohash } + bookmarks).toSet().toList()
-            viewModel.beginGeohashSampling(geohashes)
-        } else {
-            viewModel.endGeohashSampling()
-        }
+    LaunchedEffect(availableChannels, bookmarks) {
+        val geohashes = (availableChannels.map { it.geohash } + bookmarks).toSet().toList()
+        viewModel.beginGeohashSampling(geohashes)
     }
 
     // Ensure cleanup when the composable is destroyed (e.g. removed from parent composition)


### PR DESCRIPTION
## Nostr Traffic Optimization

### Changes

1. **Use 3 relays for all geohash subscriptions** — balances reliability (survives 1 relay down) with bandwidth (limits duplicate event downloads)

2. **Pause presence heartbeat when backgrounded** — `globalPresenceJob` was running 24/7 broadcasting to all channels even when the app was not visible. Now cancelled on background, restarted on foreground.

3. **Split message/presence subscriptions** — Active channel subscription split into kind 20000 (messages, stays open always) and kind 20001 (presence heartbeats, closed on background). Presence events are high-frequency but have no value when the app is not visible.

4. **Subscription lifecycle cleanup** — Presence sub properly cleaned up on channel switch, `currentActiveGeohash` cleared when leaving a location channel, `panicReset` clears relay manager subscriptions to prevent ghost subs on reconnect.

## Checklist
- [ ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added automated tests