### PR TITLE
fix: geohash online count accuracy and channel switch latency

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
@@ -332,6 +332,7 @@ class GeohashViewModel(
             is com.bitchat.android.geohash.ChannelID.Location -> {
                 Log.d(TAG, "📍 Switching to geohash channel: ${channel.channel.geohash}")
                 repo.setCurrentGeohash(channel.channel.geohash)
+                repo.refreshGeohashPeople()
                 notificationManager.setCurrentGeohash(channel.channel.geohash)
                 notificationManager.clearNotificationsForGeohash(channel.channel.geohash)
                 try { messageManager.clearChannelUnreadCount("geo:${channel.channel.geohash}") } catch (_: Exception) { }


### PR DESCRIPTION
## Summary

- **Stale timestamp overwrite**: relays deliver events newest-first (NIP-01), so a user's older heartbeats were overwriting their fresher `lastSeen`, pushing them past the 5-minute cutoff and dropping them from the count. Fix: only update `lastSeen` when the incoming timestamp is strictly newer.
- **Silent ConcurrentModificationException**: event processing ran on `Dispatchers.Default` (thread pool), causing concurrent coroutines to hit the same `HashMap` with `iterator()` + `put()` simultaneously. The resulting `ConcurrentModificationException` was swallowed by the catch block, so heartbeat updates were silently dropped — only less-frequent chat messages updated the count reliably. Fix: process events on `viewModelScope`'s default dispatcher (Main), which is single-threaded.
- **Channel switch latency**: switching to a new geohash channel set `currentGeohash` but never called `refreshGeohashPeople()`, so the header count waited for a relay round-trip even though sampling subscriptions had already populated participant data for that channel. Fix: call `refreshGeohashPeople()` immediately after `setCurrentGeohash()`.

## Test plan

- [ ] Open a geohash channel — online count matches iOS (~50) and stays stable
- [ ] Leave app open for 5+ minutes — count does not drop to 0 between heartbeat cycles
- [ ] Switch between geohash channels — count updates immediately without waiting for relay response
- [ ] Send a chat message — count does not increment by exactly 1 (presence drives the count, not messages)