### PR TITLE
[ticket 640] added nickname to note

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/LocationNotesSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/LocationNotesSheet.kt
@@ -464,7 +464,7 @@ private fun LocationNotesInputSection(
             .background(color = colorScheme.background)
             .padding(horizontal = 12.dp, vertical = 8.dp)
     ) {
-        if (nickname != null) {
+        if (!nickname.isNullOrBlank()) {
             val baseName = nickname.split("#", limit = 2).firstOrNull() ?: nickname
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(

--- a/app/src/main/java/com/bitchat/android/ui/LocationNotesSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/LocationNotesSheet.kt
@@ -202,6 +202,7 @@ fun LocationNotesSheet(
                         onDraftChange = { draft = it },
                         sendButtonEnabled = sendButtonEnabled,
                         accentGreen = accentGreen,
+                        nickname = nickname,
                         onSend = {
                             val content = draft.trim()
                             if (content.isNotEmpty()) {
@@ -451,19 +452,38 @@ private fun LocationNotesInputSection(
     onDraftChange: (String) -> Unit,
     sendButtonEnabled: Boolean,
     accentGreen: Color,
+    nickname: String?,
     onSend: () -> Unit
 ) {
     val isDark = isSystemInDarkTheme()
     val colorScheme = MaterialTheme.colorScheme
-    
-    Row(
+
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .background(color = colorScheme.background)
-            .padding(horizontal = 12.dp, vertical = 8.dp), // Match main chat padding
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp) // Match main chat spacing
+            .padding(horizontal = 12.dp, vertical = 8.dp)
     ) {
+        if (nickname != null) {
+            val baseName = nickname.split("#", limit = 2).firstOrNull() ?: nickname
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "@$baseName",
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
         // Text input with placeholder overlay (matches main chat exactly)
         Box(
             modifier = Modifier.weight(1f)
@@ -531,6 +551,7 @@ private fun LocationNotesInputSection(
                 )
             }
         }
+    }
     }
 }
 


### PR DESCRIPTION
# Description

Shows the user's nickname above the location note input field so they know which identity they're posting with before submitting.

Previously, when composing a location note, there was no indication of which name the note would be attributed to. Now a small @nickname label appears above the text field, using the same monospace style as the note author headers in the list above — so the format feels consistent.

Closes: #640

Checklist
 [x] I have read the contribution guidelines: https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing
[x] I have performed a self-review of my code
 [x]I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
[] If it is a core feature, I have added automated tests
<img width="960" height="2142" alt="Screenshot_20260326_183943" src="https://github.com/user-attachments/assets/728b2505-3071-4381-a1e7-60c7a5ee3fa0" />
