### PR TITLE
Fix hashtags incorrectly detected inside URLs

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIUtils.kt
@@ -398,10 +398,10 @@ private fun appendIOSFormattedContent(
         val iterator = allMatches.listIterator()
         while (iterator.hasNext()) {
             val (range, type) = iterator.next()
-            // Remove generic hashtags that overlap with geohashes, and geohashes that overlap with URLs
+            // Remove generic hashtags that overlap with geohashes or URLs, and geohashes that overlap with URLs
             val overlapsGeo = geoRanges.any { rangesOverlap(range, it) }
             val overlapsUrl = urlRanges.any { rangesOverlap(range, it) }
-            if ((type == "hashtag" && overlapsGeo) || (type == "geohash" && overlapsUrl)) iterator.remove()
+            if ((type == "hashtag" && (overlapsGeo || overlapsUrl)) || (type == "geohash" && overlapsUrl)) iterator.remove()
         }
     }
     


### PR DESCRIPTION
# Description

When a URL contains a # fragment (e.g. https://example.com/page#section), the hashtag regex matches the fragment as a hashtag. The overlap removal logic already removes hashtags overlapping geohashes, and geohashes overlapping URLs, but did not remove hashtags overlapping URLs. Add the missing overlapsUrl check to the hashtag condition.

## Fix                                                                                                                                              
  Add `|| overlapsUrl` to the hashtag condition in `ChatUIUtils.kt` so hashtags inside URLs are filtered out.

## How to reproduce                                                                                                                                 
Send a message containing a URL with a fragment, e.g. `https://example.com/page#section`. The word "section" incorrectly appears as a hashtag. 

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
