### PR TITLE
Harden GeohashPickerActivity WebView security by blocking mixed conte…

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/GeohashPickerActivity.kt
+++ b/app/src/main/java/com/bitchat/android/ui/GeohashPickerActivity.kt
@@ -10,6 +10,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
+import android.webkit.WebResourceRequest
 import android.webkit.WebViewClient
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
@@ -104,10 +105,16 @@ class GeohashPickerActivity : OrientationAwareActivity() {
                                     settings.javaScriptEnabled = true
                                     settings.domStorageEnabled = true
                                     settings.cacheMode = WebSettings.LOAD_DEFAULT
+                                    settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
                                     settings.allowFileAccess = true
                                     settings.allowContentAccess = true
                                     webChromeClient = WebChromeClient()
                                     webViewClient = object : WebViewClient() {
+                                        override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                                            val url = request?.url?.toString() ?: return true
+                                            // Block navigation away from the local geohash picker asset
+                                            return !url.startsWith("file:///android_asset/geohash_picker.html")
+                                        }
                                         override fun onPageFinished(view: WebView?, url: String?) {
                                             super.onPageFinished(view, url)
                                             // Initialize to last/initial geohash if provided, otherwise center


### PR DESCRIPTION
…nt and restricting navigation to local asset only on experimental security branch.

# Description

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [ ] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [ ] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests
