### PR TITLE
feat: disable Wi‑Fi Aware by default

### DIFF
--- a/app/src/main/java/com/bitchat/android/BitchatApplication.kt
+++ b/app/src/main/java/com/bitchat/android/BitchatApplication.kt
@@ -43,7 +43,7 @@ class BitchatApplication : Application() {
 
         // Initialize Wi‑Fi Aware controller with persisted default
         try {
-            val enabled = com.bitchat.android.ui.debug.DebugPreferenceManager.getWifiAwareEnabled(true)
+            val enabled = com.bitchat.android.ui.debug.DebugPreferenceManager.getWifiAwareEnabled(false)
             com.bitchat.android.wifiaware.WifiAwareController.initialize(this, enabled)
         } catch (_: Exception) { }
 

--- a/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
@@ -26,9 +26,9 @@ class PermissionManager(private val context: Context) {
     private fun shouldRequireWifiAwarePermission(): Boolean {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
         val enabled = try {
-            com.bitchat.android.ui.debug.DebugPreferenceManager.getWifiAwareEnabled(true)
+            com.bitchat.android.ui.debug.DebugPreferenceManager.getWifiAwareEnabled(false)
         } catch (_: Exception) {
-            true
+            false
         }
         if (!enabled) return false
 

--- a/app/src/main/java/com/bitchat/android/ui/debug/DebugPreferenceManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/debug/DebugPreferenceManager.kt
@@ -113,7 +113,7 @@ object DebugPreferenceManager {
         if (ready()) prefs.edit().putBoolean(KEY_BLE_ENABLED, value).apply()
     }
 
-    fun getWifiAwareEnabled(default: Boolean = true): Boolean =
+    fun getWifiAwareEnabled(default: Boolean = false): Boolean =
         if (ready()) prefs.getBoolean(KEY_WIFI_AWARE_ENABLED, default) else default
 
     fun setWifiAwareEnabled(value: Boolean) {

--- a/app/src/main/java/com/bitchat/android/ui/debug/DebugSettingsManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/debug/DebugSettingsManager.kt
@@ -44,7 +44,7 @@ class DebugSettingsManager private constructor() {
     private val _bleEnabled = MutableStateFlow(true)
     val bleEnabled: StateFlow<Boolean> = _bleEnabled.asStateFlow()
 
-    private val _wifiAwareEnabled = MutableStateFlow(true)
+    private val _wifiAwareEnabled = MutableStateFlow(false)
     val wifiAwareEnabled: StateFlow<Boolean> = _wifiAwareEnabled.asStateFlow()
 
     // Master transport toggles
@@ -76,7 +76,7 @@ class DebugSettingsManager private constructor() {
             _maxClientConnections.value = DebugPreferenceManager.getMaxConnectionsClient(8)
             // Transport toggles
             _bleEnabled.value = DebugPreferenceManager.getBleEnabled(true)
-            _wifiAwareEnabled.value = DebugPreferenceManager.getWifiAwareEnabled(true)
+            _wifiAwareEnabled.value = DebugPreferenceManager.getWifiAwareEnabled(false)
             _wifiAwareVerbose.value = DebugPreferenceManager.getWifiAwareVerbose(false)
         } catch (_: Exception) {
             // Preferences not ready yet; keep defaults. They will be applied on first change.


### PR DESCRIPTION
Sets the Wi‑Fi Aware master toggle to default to "off" so new installs do not attempt to start the transport or request the NEARBY_WIFI_DEVICES runtime permission unless the user explicitly enables it in the debug settings.

Changed files:
- DebugPreferenceManager: default preference value for KEY_WIFI_AWARE_ENABLED.
- DebugSettingsManager: in-memory default and persisted loader default.
- BitchatApplication: startup default passed to WifiAwareController.initialize().
- PermissionManager: treat missing preference as disabled when deciding whether to request NEARBY_WIFI_DEVICES.

Existing installs that already have Wi‑Fi Aware enabled in SharedPreferences are not affected.