### PR TITLE
fix(wifiaware): validate ACCESS_FINE_LOCATION permission before start

### DIFF
--- a/app/src/main/java/com/bitchat/android/wifi-aware/WifiAwareController.kt
+++ b/app/src/main/java/com/bitchat/android/wifi-aware/WifiAwareController.kt
@@ -145,6 +145,19 @@ object WifiAwareController {
             return
         }
 
+        // Require ACCESS_FINE_LOCATION runtime permission
+        val locationPermissionGranted = androidx.core.content.ContextCompat.checkSelfPermission(
+            ctx,
+            android.Manifest.permission.ACCESS_FINE_LOCATION
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+
+        if (!locationPermissionGranted) {
+            Log.w(TAG, "Missing ACCESS_FINE_LOCATION permission; not starting Wi‑Fi Aware")
+            addBlockedDebugMessage("missing-fine-location", "Grant Location permission to start Wi-Fi Aware")
+            synchronized(lifecycleLock) { starting = false }
+            return
+        }
+
         // Android 13+: require NEARBY_WIFI_DEVICES runtime permission
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val granted = androidx.core.content.ContextCompat.checkSelfPermission(ctx, android.Manifest.permission.NEARBY_WIFI_DEVICES) == android.content.pm.PackageManager.PERMISSION_GRANTED

--- a/app/src/main/java/com/bitchat/android/wifi-aware/WifiAwareMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/wifi-aware/WifiAwareMeshService.kt
@@ -330,6 +330,30 @@ class WifiAwareMeshService(private val context: Context) : MeshService, Transpor
             Log.i(TAG, "Wi-Fi Aware transport disabled by debug settings; not starting")
             return
         }
+
+        // Require ACCESS_FINE_LOCATION runtime permission
+        val fineLocationGranted = androidx.core.content.ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+
+        if (!fineLocationGranted) {
+            Log.w(TAG, "Missing ACCESS_FINE_LOCATION permission; aborting startServices")
+            return
+        }
+
+        // Android 13+: require NEARBY_WIFI_DEVICES runtime permission
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val nearbyGranted = androidx.core.content.ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.NEARBY_WIFI_DEVICES
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+            if (!nearbyGranted) {
+                Log.w(TAG, "Missing NEARBY_WIFI_DEVICES permission; aborting startServices")
+                return
+            }
+        }
+
         val supportStatus = com.bitchat.android.wifiaware.WifiAwareSupport.evaluate(context)
         if (!supportStatus.supported) {
             Log.i(TAG, "Wi-Fi Aware unsupported on this device; not starting (${supportStatus.reason})")


### PR DESCRIPTION
This PR fixes a SecurityException crash occurring when Wi-Fi Aware starts on devices or environments where location permissions are missing or revoked.