### PR TITLE
Fix BLE scanning stopping permanently when entering performance mode

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothConnectionManager.kt
@@ -81,6 +81,13 @@ class BluetoothConnectionManager(
     
     // Service state
     private var isActive = false
+
+    /**
+     * Duty-cycle state as of the last power mode change, so onPowerModeChanged can tell
+     * whether the behaviour actually changed. PowerManager updates its own currentMode
+     * before invoking the callback, so it cannot be asked what the previous state was.
+     */
+    private var lastKnownDutyCycleState: Boolean = powerManager.shouldUseDutyCycle()
     
     // Delegate for callbacks
     var delegate: BluetoothConnectionManagerDelegate? = null
@@ -456,8 +463,13 @@ class BluetoothConnectionManager(
                 return@launch
             }
 
-            // Avoid rapid scan restarts by checking if we need to change scan behavior
-            val wasUsingDutyCycle = powerManager.shouldUseDutyCycle()
+            // Avoid rapid scan restarts by checking if we need to change scan behavior.
+            //
+            // This must compare against the previous state remembered here. PowerManager
+            // assigns its currentMode before invoking this callback, so querying
+            // shouldUseDutyCycle() twice around the advertising restart returned the same
+            // value every time and the scan was never restarted on a mode change.
+            val wasUsingDutyCycle = lastKnownDutyCycleState
             
             // Update advertising with new power settings if server enabled
             val serverEnabled = isGattServerEnabled()
@@ -469,6 +481,7 @@ class BluetoothConnectionManager(
             
             // Only restart scanning if the duty cycle behavior changed
             val nowUsingDutyCycle = powerManager.shouldUseDutyCycle()
+            lastKnownDutyCycleState = nowUsingDutyCycle
             if (wasUsingDutyCycle != nowUsingDutyCycle) {
                 Log.d(TAG, "Duty cycle behavior changed (${wasUsingDutyCycle} -> ${nowUsingDutyCycle}), restarting scan")
                 val clientEnabled = isGattClientEnabled()

--- a/app/src/main/java/com/bitchat/android/mesh/PowerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/PowerManager.kt
@@ -291,7 +291,13 @@ class PowerManager(private val context: Context) : LifecycleEventObserver {
             if (shouldUseDutyCycle()) {
                 startDutyCycle()
             } else {
+                // Performance mode: no duty cycling, scan continuously.
+                //
+                // stopDutyCycle() only cancels the timer. If the cycle was in its OFF phase
+                // the scanner is left off, and the timer that would have switched it back on
+                // has just been cancelled, so scanning never resumes. Enable it explicitly.
                 stopDutyCycle()
+                delegate?.onScanStateChanged(true)
             }
         }
     }


### PR DESCRIPTION
## Problem

Bringing the app to the foreground can leave the BLE scanner switched off indefinitely. The device keeps advertising, but never discovers anything, until the process is restarted.

Two faults combine.

**1. `stopDutyCycle()` does not re-enable scanning.**

`PowerManager.updatePowerMode()` calls `stopDutyCycle()` when leaving a duty-cycled mode. That only cancels the coroutine. The `delegate?.onScanStateChanged(true)` call that enables continuous scanning lives inside `startDutyCycle()`, which is not reached on this path:

```kotlin
if (shouldUseDutyCycle()) {
    startDutyCycle()      // contains onScanStateChanged(true) for performance mode
} else {
    stopDutyCycle()       // only cancels the job
}
```

So if the cycle happened to be in its OFF phase, the scanner is left off and the timer that would have switched it back on has just been cancelled. In `POWER_SAVER` the cycle is off for 28 of every 30 seconds, so the chance of landing in an OFF phase is roughly 93%.

**2. The scan-restart check compares a value against itself.**

`BluetoothConnectionManager.onPowerModeChanged()` reads `shouldUseDutyCycle()` twice and compares:

```kotlin
val wasUsingDutyCycle = powerManager.shouldUseDutyCycle()
// ... restart advertising ...
val nowUsingDutyCycle = powerManager.shouldUseDutyCycle()
if (wasUsingDutyCycle != nowUsingDutyCycle) { /* restart scan */ }
```

`PowerManager` assigns `currentMode = newMode` *before* invoking the delegate, so both reads observe the new mode. The values are always equal, the branch never runs, and scan settings never update between power modes.

## Reproduction

Observed on a Redmi 23049PCD8I (Android 15). With permissions granted, Bluetooth on, location on and the foreground service running, the device advertised continuously and received nothing at all.

Every power mode transition logged:

```
I/BluetoothConnectionManager: Power mode changed to: PERFORMANCE
D/BluetoothConnectionManager: Duty cycle behavior unchanged, keeping existing scan state
```

and no `BLE scan started successfully` ever appeared.

## After the fix

```
I/PowerManager: Power mode changed: BALANCED -> PERFORMANCE
D/BluetoothConnectionManager: Duty cycle behavior changed (true -> false), restarting scan
I/BluetoothGattClientManager: Switching to continuous scanning mode
D/BluetoothGattClientManager: BLE scan started successfully
```

The device then discovered a peer and both sides validated each other's signed announces:

```
D/PeerManager: New verified peer: samsung (698e839ddb08f8ca)
I/BluetoothPacketBroadcaster: Broadcasting packet v1 type 1 to 1 server + 2 client connections
```

## Changes

- `PowerManager`: enable scanning explicitly when entering performance mode, since `stopDutyCycle()` cannot do it.
- `BluetoothConnectionManager`: remember the previous duty-cycle state so the comparison is meaningful.

This touches radio scheduling only, not the wire protocol, so cross-client compatibility is unaffected. Verified to compile against `main`.

## Note

I found this while working on a fork with a different UI. Happy to adjust the approach if you would prefer the previous mode passed into `onPowerModeChanged()` rather than cached in the connection manager.