### PR TITLE
i18n: declare android:localeConfig with all 33 supported locales

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.BitchatAndroid"
         tools:targetApi="31">

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="ar"/>
+    <locale android:name="bn"/>
+    <locale android:name="de"/>
+    <locale android:name="es"/>
+    <locale android:name="fa"/>
+    <locale android:name="fil"/>
+    <locale android:name="fr"/>
+    <locale android:name="he"/>
+    <locale android:name="hi"/>
+    <locale android:name="id"/>
+    <locale android:name="it"/>
+    <locale android:name="ja"/>
+    <locale android:name="ka"/>
+    <locale android:name="ko"/>
+    <locale android:name="mg"/>
+    <locale android:name="ms"/>
+    <locale android:name="ne"/>
+    <locale android:name="nl"/>
+    <locale android:name="pa-PK"/>
+    <locale android:name="pl"/>
+    <locale android:name="pt"/>
+    <locale android:name="pt-BR"/>
+    <locale android:name="ru"/>
+    <locale android:name="sv"/>
+    <locale android:name="ta"/>
+    <locale android:name="th"/>
+    <locale android:name="tr"/>
+    <locale android:name="uk"/>
+    <locale android:name="ur"/>
+    <locale android:name="vi"/>
+    <locale android:name="zh"/>
+    <locale android:name="zh-CN"/>
+    <locale android:name="zh-TW"/>
+</locale-config>


### PR DESCRIPTION
# Description

## Checklist
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>) — uses "Relates to #737" since this addresses only the language-picker piece of that issue, not the translation-completeness or Weblate-pipeline parts
- [ ] If it is a core feature, I have added automated tests — not applicable; this is a manifest/resource declaration with no runtime logic to unit test, verified via build/lint/APK-assembly checks below instead

## Summary
Relates to #737.

Android 13+ (API 33) ships a built-in per-app language picker (Settings → Apps → bitchat → Language). Without an `android:localeConfig` declaration, this picker has no way to know which languages bitchat actually supports, so it falls back to listing every system language instead of just the ones bitchat ships translations for — a much noisier, less useful list for users trying to switch bitchat's language independently of their device's overall language.

## Changes
- Added `app/src/main/res/xml/locales_config.xml`, listing the 33 languages that currently have a `values-<locale>/strings.xml` folder, plus `en` for the default/fallback `values/strings.xml`.
- Referenced it via `android:localeConfig="@xml/locales_config"` on the `<application>` tag in `AndroidManifest.xml`.
- Locale names use BCP-47 tags where they differ from Android's resource-folder naming convention: `pa-rPK` → `pa-PK`, `zh-rCN` → `zh-CN`, `zh-rTW` → `zh-TW`.

No behavior change below API 33 — `minSdk` is 26, and the attribute is simply inert/ignored on older devices, which continue to follow the whole device's system language exactly as before this change.

## Test plan
- [x] `locales_config.xml` parses as well-formed XML
- [x] `./gradlew :app:processDebugResources` — clean resource/manifest merge
- [x] Confirmed `android:localeConfig="@xml/locales_config"` survives manifest merging by inspecting the packaged manifest output
- [x] `./gradlew :app:assembleDebug` — full debug APK builds successfully with the new resource packaged
- [x] `./gradlew lintDebug` — the only lint signal attributable to this change is an expected, non-fatal `UnusedAttribute` info-level note that `localeConfig` has no effect below API 33 (by design, since `minSdk` 26 is below 33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
