### PR TITLE
chore(deps): upgrade to AGP 9.3.1, Gradle 9.6.1, Kotlin 2.4.10, SDK 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlin.compose)
 }
@@ -65,11 +66,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     buildFeatures {
         compose = true
@@ -83,6 +81,12 @@ android {
         baseline = file("lint-baseline.xml")
         abortOnError = false
         checkReleaseBuilds = false
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }
 
@@ -143,7 +147,7 @@ dependencies {
     implementation(libs.androidx.security.crypto)
     
     // EXIF orientation handling for images
-    implementation("androidx.exifinterface:exifinterface:1.3.7")
+    implementation(libs.androidx.exifinterface)
     
     // Testing
     testImplementation(libs.bundles.testing)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,8 +31,9 @@
       Android 17 (API 37) makes local network protection mandatory for apps targeting it.
       The Wi‑Fi Aware transport reaches peers over link-local IPv6 TCP sockets
       (WifiAwareMeshService.connectAwareClientSocket), so declare this defensively.
-      It belongs to the NEARBY_DEVICES group, but is granted independently of
-      NEARBY_WIFI_DEVICES, so it must be requested explicitly (see PermissionManager).
+      It is granted independently of NEARBY_WIFI_DEVICES so must be requested explicitly
+      (see PermissionManager), but shares the NEARBY_DEVICES group with it, so the two
+      are requested together in a single "Nearby devices" prompt.
     -->
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <!-- Signature permission for internal UI shutdown broadcasts -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,14 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <!-- Android 13+ runtime permission for Wi‑Fi operations (including Aware) -->
     <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
+    <!--
+      Android 17 (API 37) makes local network protection mandatory for apps targeting it.
+      The Wi‑Fi Aware transport reaches peers over link-local IPv6 TCP sockets
+      (WifiAwareMeshService.connectAwareClientSocket), so declare this defensively.
+      It belongs to the NEARBY_DEVICES group, so it does not add a prompt for users
+      who have already granted NEARBY_WIFI_DEVICES.
+    -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <!-- Signature permission for internal UI shutdown broadcasts -->
     <uses-permission android:name="com.bitchat.android.permission.FORCE_FINISH" />
     <!-- Foreground service and boot permissions for long-running background mesh -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,8 +31,8 @@
       Android 17 (API 37) makes local network protection mandatory for apps targeting it.
       The Wi‑Fi Aware transport reaches peers over link-local IPv6 TCP sockets
       (WifiAwareMeshService.connectAwareClientSocket), so declare this defensively.
-      It belongs to the NEARBY_DEVICES group, so it does not add a prompt for users
-      who have already granted NEARBY_WIFI_DEVICES.
+      It belongs to the NEARBY_DEVICES group, but is granted independently of
+      NEARBY_WIFI_DEVICES, so it must be requested explicitly (see PermissionManager).
     -->
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <!-- Signature permission for internal UI shutdown broadcasts -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,14 +27,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <!-- Android 13+ runtime permission for Wi‑Fi operations (including Aware) -->
     <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
-    <!--
-      Android 17 (API 37) makes local network protection mandatory for apps targeting it.
-      The Wi‑Fi Aware transport reaches peers over link-local IPv6 TCP sockets
-      (WifiAwareMeshService.connectAwareClientSocket), so declare this defensively.
-      It is granted independently of NEARBY_WIFI_DEVICES so must be requested explicitly
-      (see PermissionManager), but shares the NEARBY_DEVICES group with it, so the two
-      are requested together in a single "Nearby devices" prompt.
-    -->
+    <!-- Android 17+ gates local network access; Wi‑Fi Aware peers over link-local IPv6 -->
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <!-- Signature permission for internal UI shutdown broadcasts -->
     <uses-permission android:name="com.bitchat.android.permission.FORCE_FINISH" />

--- a/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
@@ -40,6 +40,24 @@ class PermissionManager(private val context: Context) {
     }
 
     /**
+     * Runtime permissions needed for the Wi‑Fi Aware transport.
+     *
+     * Android 17 (API 37) makes local network protection mandatory for apps that target it.
+     * WifiAwareMeshService reaches peers over link-local IPv6 TCP sockets
+     * (connectAwareClientSocket), so ACCESS_LOCAL_NETWORK is requested defensively there.
+     * It shares the NEARBY_DEVICES group with NEARBY_WIFI_DEVICES, so granting it does not
+     * cost the user an extra prompt.
+     */
+    private fun wifiAwarePermissions(): List<String> {
+        val permissions = mutableListOf(Manifest.permission.NEARBY_WIFI_DEVICES)
+        // API 37 == Android 17; no named VERSION_CODES constant is available yet.
+        if (Build.VERSION.SDK_INT >= 37) {
+            permissions.add(Manifest.permission.ACCESS_LOCAL_NETWORK)
+        }
+        return permissions
+    }
+
+    /**
      * Check if this is the first time the user is launching the app
      */
     fun isFirstTimeLaunch(): Boolean {
@@ -87,7 +105,7 @@ class PermissionManager(private val context: Context) {
 
         // Wi‑Fi Aware: Android 13+ requires NEARBY_WIFI_DEVICES runtime permission
         if (shouldRequireWifiAwarePermission()) {
-            permissions.add(Manifest.permission.NEARBY_WIFI_DEVICES)
+            permissions.addAll(wifiAwarePermissions())
         }
 
         // Notification permission intentionally excluded to keep it optional
@@ -232,7 +250,7 @@ class PermissionManager(private val context: Context) {
 
         // Wi‑Fi Aware category (Android 13+)
         if (shouldRequireWifiAwarePermission()) {
-            val wifiAwarePermissions = listOf(Manifest.permission.NEARBY_WIFI_DEVICES)
+            val wifiAwarePermissions = wifiAwarePermissions()
             categories.add(
                 PermissionCategory(
                     type = PermissionType.WIFI_AWARE,

--- a/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
@@ -40,22 +40,18 @@ class PermissionManager(private val context: Context) {
     }
 
     /**
-     * Runtime permissions needed for the Wi‑Fi Aware transport.
+     * Runtime permissions for the Wi‑Fi Aware transport, version-gated because neither exists
+     * at minSdk 26 — requesting an unknown permission comes back permanently denied.
      *
-     * Android 17 (API 37) makes local network protection mandatory for apps that target it.
-     * WifiAwareMeshService reaches peers over link-local IPv6 TCP sockets
-     * (connectAwareClientSocket), so ACCESS_LOCAL_NETWORK is requested defensively there.
-     *
-     * Both were verified on an Android 17 device, and the two levels behave differently:
-     *
-     *  - Grants are tracked independently. Granting NEARBY_WIFI_DEVICES alone leaves
-     *    ACCESS_LOCAL_NETWORK denied, so it has to be requested explicitly — hence this list.
-     *  - The dialog is shared. Because both belong to the NEARBY_DEVICES group, requesting
-     *    them together surfaces a single "Nearby devices" prompt rather than two, so adding
-     *    ACCESS_LOCAL_NETWORK costs the user nothing.
+     * ACCESS_LOCAL_NETWORK is defensive: Android 17 gates local network access, and the
+     * transport reaches peers over link-local IPv6 sockets. It is granted separately from
+     * NEARBY_WIFI_DEVICES but shares its permission group, so the two prompt only once.
      */
     fun wifiAwarePermissions(): List<String> {
-        val permissions = mutableListOf(Manifest.permission.NEARBY_WIFI_DEVICES)
+        val permissions = mutableListOf<String>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            permissions.add(Manifest.permission.NEARBY_WIFI_DEVICES)
+        }
         // API 37 == Android 17; no named VERSION_CODES constant is available yet.
         if (Build.VERSION.SDK_INT >= 37) {
             permissions.add(Manifest.permission.ACCESS_LOCAL_NETWORK)

--- a/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
@@ -46,14 +46,15 @@ class PermissionManager(private val context: Context) {
      * WifiAwareMeshService reaches peers over link-local IPv6 TCP sockets
      * (connectAwareClientSocket), so ACCESS_LOCAL_NETWORK is requested defensively there.
      *
-     * Note that although ACCESS_LOCAL_NETWORK shares the NEARBY_DEVICES group with
-     * NEARBY_WIFI_DEVICES, the two are tracked and granted independently: granting
-     * NEARBY_WIFI_DEVICES alone leaves ACCESS_LOCAL_NETWORK denied (verified on an
-     * Android 17 device). It must therefore be requested explicitly, which is what this
-     * list is for. Whether the runtime dialog bundles the two into a single prompt has
-     * not been verified.
+     * Both were verified on an Android 17 device, and the two levels behave differently:
+     *
+     *  - Grants are tracked independently. Granting NEARBY_WIFI_DEVICES alone leaves
+     *    ACCESS_LOCAL_NETWORK denied, so it has to be requested explicitly — hence this list.
+     *  - The dialog is shared. Because both belong to the NEARBY_DEVICES group, requesting
+     *    them together surfaces a single "Nearby devices" prompt rather than two, so adding
+     *    ACCESS_LOCAL_NETWORK costs the user nothing.
      */
-    private fun wifiAwarePermissions(): List<String> {
+    fun wifiAwarePermissions(): List<String> {
         val permissions = mutableListOf(Manifest.permission.NEARBY_WIFI_DEVICES)
         // API 37 == Android 17; no named VERSION_CODES constant is available yet.
         if (Build.VERSION.SDK_INT >= 37) {

--- a/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/PermissionManager.kt
@@ -45,8 +45,13 @@ class PermissionManager(private val context: Context) {
      * Android 17 (API 37) makes local network protection mandatory for apps that target it.
      * WifiAwareMeshService reaches peers over link-local IPv6 TCP sockets
      * (connectAwareClientSocket), so ACCESS_LOCAL_NETWORK is requested defensively there.
-     * It shares the NEARBY_DEVICES group with NEARBY_WIFI_DEVICES, so granting it does not
-     * cost the user an extra prompt.
+     *
+     * Note that although ACCESS_LOCAL_NETWORK shares the NEARBY_DEVICES group with
+     * NEARBY_WIFI_DEVICES, the two are tracked and granted independently: granting
+     * NEARBY_WIFI_DEVICES alone leaves ACCESS_LOCAL_NETWORK denied (verified on an
+     * Android 17 device). It must therefore be requested explicitly, which is what this
+     * list is for. Whether the runtime dialog bundles the two into a single prompt has
+     * not been verified.
      */
     private fun wifiAwarePermissions(): List<String> {
         val permissions = mutableListOf(Manifest.permission.NEARBY_WIFI_DEVICES)

--- a/app/src/main/java/com/bitchat/android/ui/debug/DebugSettingsSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/debug/DebugSettingsSheet.kt
@@ -134,17 +134,18 @@ fun DebugSettingsSheet(
     val wifiAwareEnabled by manager.wifiAwareEnabled.collectAsState()
     val wifiAwareVerbose by manager.wifiAwareVerbose.collectAsState()
 
-    // Onboarding only asks for the Wi‑Fi Aware permissions when the feature is already
-    // enabled, and the toggle defaults to off — so enabling it from here has to request
-    // them itself. Without this, WifiAwareController just logs
-    // "Missing NEARBY_WIFI_DEVICES permission" on a 5s retry loop and never starts.
+    // Onboarding only asks for these when the toggle is already on, and it defaults to off,
+    // so enabling from here has to request them or the controller never starts.
     val wifiAwarePermissions = remember { PermissionManager(context).wifiAwarePermissions() }
     val wifiAwarePermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
-    ) { results ->
-        // NEARBY_WIFI_DEVICES is the hard requirement; ACCESS_LOCAL_NETWORK is defensive,
-        // so don't block enabling on it.
-        val nearbyGranted = results[android.Manifest.permission.NEARBY_WIFI_DEVICES] ?: true
+    ) { _ ->
+        // Check live state, not the result map — already-held permissions are filtered out
+        // before launching. Only NEARBY_WIFI_DEVICES blocks startup; the other is defensive.
+        val nearbyPermission = android.Manifest.permission.NEARBY_WIFI_DEVICES
+        val nearbyGranted = nearbyPermission !in wifiAwarePermissions ||
+            ContextCompat.checkSelfPermission(context, nearbyPermission) ==
+                PackageManager.PERMISSION_GRANTED
         if (nearbyGranted) {
             manager.setWifiAwareEnabled(true)
         } else {

--- a/app/src/main/java/com/bitchat/android/ui/debug/DebugSettingsSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/debug/DebugSettingsSheet.kt
@@ -37,6 +37,11 @@ import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.res.stringResource
 import com.bitchat.android.R
 import androidx.compose.ui.platform.LocalContext
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import com.bitchat.android.onboarding.PermissionManager
 import com.bitchat.android.core.ui.component.sheet.BitchatBottomSheet
 import com.bitchat.android.core.ui.component.sheet.BitchatSheetTopBar
 import com.bitchat.android.core.ui.component.sheet.BitchatSheetTitle
@@ -128,6 +133,36 @@ fun DebugSettingsSheet(
     val bleEnabled by manager.bleEnabled.collectAsState()
     val wifiAwareEnabled by manager.wifiAwareEnabled.collectAsState()
     val wifiAwareVerbose by manager.wifiAwareVerbose.collectAsState()
+
+    // Onboarding only asks for the Wi‑Fi Aware permissions when the feature is already
+    // enabled, and the toggle defaults to off — so enabling it from here has to request
+    // them itself. Without this, WifiAwareController just logs
+    // "Missing NEARBY_WIFI_DEVICES permission" on a 5s retry loop and never starts.
+    val wifiAwarePermissions = remember { PermissionManager(context).wifiAwarePermissions() }
+    val wifiAwarePermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { results ->
+        // NEARBY_WIFI_DEVICES is the hard requirement; ACCESS_LOCAL_NETWORK is defensive,
+        // so don't block enabling on it.
+        val nearbyGranted = results[android.Manifest.permission.NEARBY_WIFI_DEVICES] ?: true
+        if (nearbyGranted) {
+            manager.setWifiAwareEnabled(true)
+        } else {
+            manager.addDebugMessage(
+                DebugMessage.SystemMessage("Wi‑Fi Aware needs the Nearby devices permission")
+            )
+        }
+    }
+    val enableWifiAware: () -> Unit = {
+        val missing = wifiAwarePermissions.filter {
+            ContextCompat.checkSelfPermission(context, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (missing.isEmpty()) {
+            manager.setWifiAwareEnabled(true)
+        } else {
+            wifiAwarePermissionLauncher.launch(missing.toTypedArray())
+        }
+    }
     val wifiAwareDiscovered by manager.wifiAwareDiscovered.collectAsState()
     val wifiAwareConnected by manager.wifiAwareConnected.collectAsState()
     val wifiAwareSupported by com.bitchat.android.wifiaware.WifiAwareController.supported.collectAsState()
@@ -345,7 +380,9 @@ fun DebugSettingsSheet(
                             Switch(
                                 checked = wifiAwareEnabled && wifiAwareSupported,
                                 enabled = wifiSwitchEnabled,
-                                onCheckedChange = { manager.setWifiAwareEnabled(it) }
+                                onCheckedChange = { on ->
+                                    if (on) enableWifiAware() else manager.setWifiAwareEnabled(false)
+                                }
                             )
                         }
                         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -643,7 +680,7 @@ fun DebugSettingsSheet(
                         }
                         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                             AssistChip(
-                                onClick = { manager.setWifiAwareEnabled(true) },
+                                onClick = enableWifiAware,
                                 enabled = wifiAwareSupported,
                                 label = { Text("Start") }
                             )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.compose) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,6 @@
 # Specifies the JVM arguments used for the daemon process.
 android.useAndroidX=true
 
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
-
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,72 +1,72 @@
 [versions]
 # Android and Kotlin
-agp = "8.10.1"
-kotlin = "2.2.0"
-compileSdk = "35"
+agp = "9.3.1"
+kotlin = "2.4.10"
+compileSdk = "37"
 minSdk = "26" # API 26 for proper BLE support
-targetSdk = "35"
+targetSdk = "37"
 
 # AndroidX Core
-core-ktx = "1.16.0"
-lifecycle-runtime = "2.9.1"
-activity-compose = "1.10.1"
+core-ktx = "1.19.0"
+lifecycle-runtime = "2.11.0"
+activity-compose = "1.13.0"
 appcompat = "1.7.1"
 
 # Compose
-compose-bom = "2025.06.01"
+compose-bom = "2026.06.01"
 
 # Navigation
-navigation-compose = "2.9.1"
+navigation-compose = "2.9.8"
 
 # Accompanist
 accompanist-permissions = "0.37.3"
 
 # Cryptography
-bouncycastle = "1.70"
-tink-android = "1.10.0"
+bouncycastle = "1.85"
+tink-android = "1.23.0"
 
 # JSON
-gson = "2.13.1"
+gson = "2.14.0"
 
 # Coroutines
-kotlinx-coroutines = "1.10.2"
+kotlinx-coroutines = "1.11.0"
 
 # Bluetooth
-nordic-ble = "2.6.1"
+nordic-ble = "2.11.0"
 
 # WebSocket
-okhttp = "4.12.0"
+okhttp = "5.4.0"
 tor-android-binary = "0.4.4.6"
 
 
 # Google Play Services
-gms-location = "21.3.0"
+gms-location = "21.4.0"
 
 # Security
-security-crypto = "1.1.0-beta01"
+security-crypto = "1.1.0"
 
 # QR
 zxing-core = "3.5.4"
 
+# EXIF
+exifinterface = "1.4.2"
+
 # CameraX / ML Kit
-camerax = "1.5.2"
+camerax = "1.6.1"
 mlkit-barcode = "17.3.0"
 
 # Testing
 junit = "4.13.2"
-androidx-test-ext = "1.2.1"
-espresso = "3.6.1"
-mockito-kotlin = "4.1.0"
-mockito-inline = "4.1.0"
-roboelectric = "4.15"
-kotlinx-coroutines-test = "1.6"
-
-lifecycle-process = "2.8.7"
+androidx-test-ext = "1.3.0"
+espresso = "3.7.0"
+mockito-kotlin = "6.3.0"
+mockito-core = "5.23.0"
+roboelectric = "4.15" # 4.16+ drops the AndroidKeyStore shim; breaks EncryptionServiceTest
 
 [libraries]
 # AndroidX Core
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
-androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle-process" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle-runtime" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle-runtime" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
@@ -90,7 +90,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist-permissions" }
 
 # Cryptography
-bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncycastle" }
+bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 google-tink-android = { module = "com.google.crypto.tink:tink-android", version.ref = "tink-android" }
 
 # JSON
@@ -117,6 +117,9 @@ androidx-security-crypto = { module = "androidx.security:security-crypto", versi
 # QR
 zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
 
+# EXIF
+androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exifinterface" }
+
 # CameraX / ML Kit
 androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
 androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
@@ -130,14 +133,13 @@ androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core",
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
-mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito-inline" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
 roboelectric = { module = "org.robolectric:robolectric", version.ref = "roboelectric"}
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test"}
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "kotlin-parcelize" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
@@ -165,7 +167,7 @@ testing = [
     "androidx-test-ext-junit",
     "androidx-test-espresso-core",
     "mockito-kotlin",
-    "mockito-inline",
+    "mockito-core",
     "roboelectric",
     "kotlinx-coroutines-test"
 ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Brings the toolchain and every dependency to latest stable.

## Toolchain

| | From | To |
|---|---|---|
| AGP | 8.10.1 | 9.3.1 |
| Gradle | 8.13 | 9.6.1 |
| Kotlin | 2.2.0 | 2.4.10 |
| compileSdk / targetSdk | 35 | 37 |
| Java | 8 | 11 |

API 37 (Android 17) is stable, not preview.

## AGP 9 migration

- Dropped `org.jetbrains.kotlin.android` — AGP 9 provides built-in Kotlin and the plugin is incompatible with the new DSL
- `kotlinOptions.jvmTarget` → `kotlin.compilerOptions` (the String setter is a hard error in Kotlin 2.4)
- Dropped `android.enableJetifier` (deprecated, removed in AGP 10, no support-library deps remain)

`kotlin-parcelize` and the Compose plugin needed no changes. KGP resolves to 2.4.10 transitively, so no `buildscript` pin. No legacy variant API, no custom `BuildConfig` fields, and none of the removed AGP 9 properties were in use.

## Libraries

Compose BOM `2025.06.01` → `2026.06.01` · okhttp `4.12.0` → `5.4.0` · Tink `1.10.0` → `1.23.0` · CameraX `1.5.2` → `1.6.1` · coroutines `1.10.2` → `1.11.0` · core-ktx `1.16.0` → `1.19.0` · lifecycle `2.9.1` → `2.11.0` · activity-compose `1.10.1` → `1.13.0` · navigation-compose `2.9.1` → `2.9.8` · gson `2.13.1` → `2.14.0` · gms-location `21.3.0` → `21.4.0` · security-crypto `1.1.0-beta01` → `1.1.0`

Notable, beyond version numbers:

- **BouncyCastle `1.70` → `1.85`**, switching `bcprov-jdk15on` → `bcprov-jdk18on`. The `jdk15on` line is abandoned; same packages, so no source changes.
- **`mockito-inline` → `mockito-core 5.23.0`.** The former is deprecated — the inline mock-maker has been the default since Mockito 5.
- **`coroutines-test` was pinned at `1.6`** while the runtime was `1.10.2`. Now shares the `kotlinx-coroutines` ref so it can't drift again.
- **`exifinterface`** moved from a hardcoded `1.3.7` into the version catalog at `1.4.2`.

## Wi-Fi Aware permissions

Automated review flagged that `targetSdk 37` brings mandatory local network protection, while `WifiAwareMeshService` reaches peers over link-local IPv6 sockets. `ACCESS_LOCAL_NETWORK` is now declared and requested.

Two related bugs surfaced while verifying this on hardware:

- **Enabling Wi-Fi Aware from Debug Settings never requested its permissions.** The permission flow is gated behind the toggle already being on, and it defaults to off — so onboarding never asked and the toggle didn't either. The controller logged `Missing NEARBY_WIFI_DEVICES permission` on a 5s retry loop forever. Reproduced on two devices; both needed `adb shell pm grant` before the transport would start at all. The toggle and Start chip now request the permissions first.
- **Both permissions needed version gating.** `NEARBY_WIFI_DEVICES` only exists from API 33 and `ACCESS_LOCAL_NETWORK` from API 37, against minSdk 26.

Measured on Android 17: the two are granted independently (`pm grant` of one does not cascade), but share the `NEARBY_DEVICES` group, so requesting them together produces a single prompt. A denied `ACCESS_LOCAL_NETWORK` does not block enabling — the transport starts fine without it and its necessity for link-local sockets is still unproven.

## Verification

- `compileDebugKotlin` — clean, zero warnings
- `testDebugUnitTest` — 124 tests, 0 failures
- `bundleRelease` — builds with R8 and resource shrinking
- `gradlew help`, `build --dry-run` — pass

The 6 R8 `error occurred when parsing kotlin metadata` warnings present under AGP 8.13.2 are gone under 9.3.1.

## Device testing

Pixel 9a on **Android 17 (API 37)** running this branch, so the target behaviours were genuinely exercised:

- Bluetooth mesh — discovery and connection ✅
- Nostr relay chat — end-to-end, also covers okhttp 4 → 5 ✅
- Wi-Fi Aware — permission flow and discovery ✅ (single prompt, both granted)

**Wi-Fi Aware data path does not establish** between the Pixel (Android 17) and a Samsung SM-A366E (Android 16). `ConnectivityManager.requestNetwork` returns `onUnavailable` on both client and server roles, including after role reversal. This happens *before* `connectAwareClientSocket` runs, so no link-local socket is attempted and no `SecurityException` or `EPERM` appears on either device — it is not permission-related. Whether it predates this branch is unconfirmed. Wi-Fi Aware is debug-gated and off by default.

Not yet exercised: Tor via Arti, background voice-note playback, foreground-service survival.

## targetSdk 36/37 behaviour audit

Checked against the source: edge-to-edge and predictive back are already handled correctly; no `BluetoothSocket`/RFCOMM; no `scheduleAtFixedRate`; Safer Intents is opt-in; the reflection in `ChatViewModel` touches instance rather than `static final` fields. On large screens (sw≥600dp) orientation constraints are now ignored — no `screenOrientation` locks exist, so nothing breaks.

## Known hold-back

Robolectric stays at **4.15**. 4.16+ breaks `EncryptionServiceTest` with `AndroidKeyStore not found` — bisected away from `security-crypto`, and not SDK-level related (`@Config(sdk=[35])` with 4.16.1 still fails). Robolectric has never genuinely supported `AndroidKeyStore` ([robolectric#1517](https://github.com/robolectric/robolectric/issues/1517), open since 2015), so the 4.15 pass is incidental. Unpinning needs a storage seam in `EncryptionService`, deferred rather than weakening a test that guards panic-mode key rotation.

## Follow-ups (not in this PR)

- `nordic-ble` is unused — no imports, no ProGuard references — yet resolves onto the release runtime classpath.
- Stale `tor-android-binary` catalog entry, unreferenced and unresolvable. Unrelated to how Tor actually works here (a self-compiled Arti build in `app/src/main/jniLibs/` with the JNI bridge vendored in-tree). Nearby comments in `app/build.gradle.kts` are also stale.
- `AndroidManifest.xml` declares `.service.NotificationPermissionChangedReceiver`, but no such class exists anywhere in the source.
- `lint-baseline.xml` was generated `by="lint 8.2.0"`, four AGP majors ago.
