### PR TITLE
Add Cashu ecash chips and /pay command

### DIFF
--- a/app/src/main/java/com/bitchat/android/cashu/CashuTokenDecoder.kt
+++ b/app/src/main/java/com/bitchat/android/cashu/CashuTokenDecoder.kt
@@ -1,0 +1,362 @@
+package com.bitchat.android.cashu
+
+import com.google.gson.JsonParser
+import java.net.URI
+import java.util.Base64
+
+/**
+ * Decodes Cashu ecash tokens (V3 `cashuA` = base64url JSON, V4 `cashuB` =
+ * base64url CBOR) just far enough to summarize them for the UI: total
+ * amount, unit, mint host, and memo. The app never contacts a mint — tokens
+ * are bearer strings and redemption is delegated to an external wallet.
+ *
+ * This parses attacker-controlled message content, so every path is
+ * bounds-checked, size-capped, and returns null instead of throwing.
+ *
+ * Port of iOS `CashuTokenDecoder.swift` (bitchat PR #1376).
+ */
+object CashuTokenDecoder {
+
+    data class TokenInfo(
+        /** Token serialization version: "A" (JSON) or "B" (CBOR). */
+        val version: String,
+        /** Sum of all proof amounts; null when no valid amounts were found. */
+        val amount: Long?,
+        /** Currency unit as declared by the token (commonly "sat"), if any. */
+        val unit: String?,
+        /** Host of the (first) mint URL, for display. */
+        val mintHost: String?,
+        /** Optional sender memo, sanitized for display. */
+        val memo: String?
+    ) {
+        /** "500 sat" style summary, defaulting the unit to sats per NUT-00. */
+        val displayAmount: String?
+            get() = amount?.let { "$it ${unit ?: "sat"}" }
+    }
+
+    /** Upper bound on accepted token length in characters. Real tokens are a
+     *  few KB; anything much bigger is abuse we shouldn't spend CPU on. */
+    const val MAX_TOKEN_LENGTH = 60_000
+    private const val MIN_TOKEN_LENGTH = 12
+    /** Per-proof and total amount sanity caps (order of total sats in existence). */
+    private const val MAX_AMOUNT = 2_100_000_000_000_000L
+
+    private val tokenCharset = Regex("^[A-Za-z0-9\\-_+/=.]+$")
+
+    // MARK: - Public API
+
+    /**
+     * Extracts the bare `cashuA…`/`cashuB…` token from raw text that may be
+     * a `cashu:`/`cashu://` URI and/or percent-encoded. Returns null when the
+     * input doesn't look like a Cashu token at all.
+     */
+    fun bareToken(from: String): String? {
+        var token = from.trim()
+        val lower = token.lowercase()
+        token = when {
+            lower.startsWith("cashu://") -> token.substring(8)
+            lower.startsWith("cashu:") -> token.substring(6)
+            else -> token
+        }
+        if (token.contains('%')) {
+            token = percentDecode(token) ?: return null
+        }
+        if (token.length < MIN_TOKEN_LENGTH || token.length > MAX_TOKEN_LENGTH) return null
+        if (!token.startsWith("cashuA") && !token.startsWith("cashuB")) return null
+        if (!tokenCharset.matches(token)) return null
+        return token
+    }
+
+    /**
+     * Decodes a token (raw or `cashu:` URI form) into a display summary.
+     *
+     * In the default (permissive) mode this is for *rendering*: V3 tokens
+     * must parse as JSON, but a V4 token whose CBOR we cannot walk still
+     * returns a generic [TokenInfo] (version "B", no amount) because the
+     * payload may use encodings this minimal reader doesn't support — an
+     * unknown chip is fine for display.
+     *
+     * In `strict` mode (used by the `/pay` SEND path) there is no permissive
+     * fallback: the token must cleanly decode to a known version *and* carry
+     * a positive amount, otherwise this returns null. This stops base64 junk
+     * and truncated V4 tokens from being relayed as if they were valid money.
+     */
+    fun decode(raw: String, strict: Boolean = false): TokenInfo? {
+        val token = bareToken(raw) ?: return null
+        val version = token.substring(5, 6)
+        val payload = base64UrlDecode(token.substring(6))?.takeIf { it.isNotEmpty() } ?: return null
+        val decoded: TokenInfo? = when (version) {
+            "A" -> decodeV3(payload)
+            "B" -> {
+                val walked = decodeV4(payload)
+                when {
+                    walked != null -> walked
+                    strict -> return null // couldn't cleanly walk the CBOR — refuse to send it
+                    else -> TokenInfo(version = "B", amount = null, unit = null, mintHost = null, memo = null)
+                }
+            }
+            else -> return null
+        }
+        val info = decoded ?: return null
+        if (strict) {
+            // A sendable token must resolve to a positive, sane amount.
+            val amount = info.amount ?: return null
+            if (amount <= 0) return null
+        }
+        return info
+    }
+
+    // MARK: - Percent decoding (only %XX; '+' is a valid base64 char and must survive)
+
+    private fun percentDecode(input: String): String? {
+        val bytes = ArrayList<Byte>(input.length)
+        var i = 0
+        while (i < input.length) {
+            val c = input[i]
+            if (c == '%') {
+                if (i + 2 > input.length - 1) return null
+                val h1 = input[i + 1].digitToIntOrNull(16) ?: return null
+                val h2 = input[i + 2].digitToIntOrNull(16) ?: return null
+                bytes.add(((h1 shl 4) or h2).toByte())
+                i += 3
+            } else {
+                bytes.add(c.code.toByte())
+                i += 1
+            }
+        }
+        return String(bytes.toByteArray(), Charsets.UTF_8)
+    }
+
+    // MARK: - Base64url
+
+    private fun base64UrlDecode(input: String): ByteArray? {
+        var s = input.replace('-', '+').replace('_', '/').replace("=", "")
+        val remainder = s.length % 4
+        if (remainder == 1) return null
+        if (remainder > 0) s += "=".repeat(4 - remainder)
+        return try {
+            Base64.getDecoder().decode(s)
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+    }
+
+    // MARK: - V3 (JSON)
+
+    private fun decodeV3(payload: ByteArray): TokenInfo? {
+        val obj = try {
+            JsonParser.parseString(String(payload, Charsets.UTF_8)).asJsonObject
+        } catch (e: Exception) {
+            return null
+        }
+        val entries = try {
+            obj.getAsJsonArray("token")
+        } catch (e: Exception) {
+            null
+        } ?: return null
+        if (entries.size() == 0) return null
+
+        var total = 0L
+        var sawAmount = false
+        var mintHost: String? = null
+        for (entryEl in entries) {
+            val entry = try { entryEl.asJsonObject } catch (e: Exception) { continue }
+            if (mintHost == null) {
+                val mint = entry.get("mint")?.takeIf { it.isJsonPrimitive }?.asString
+                if (mint != null) mintHost = sanitizedHost(mint)
+            }
+            val proofs = try { entry.getAsJsonArray("proofs") } catch (e: Exception) { null } ?: continue
+            for (proofEl in proofs) {
+                val proof = try { proofEl.asJsonObject } catch (e: Exception) { continue }
+                val amountEl = proof.get("amount")?.takeIf { it.isJsonPrimitive } ?: continue
+                val value = try { amountEl.asLong } catch (e: Exception) { continue }
+                if (value <= 0 || value > MAX_AMOUNT) continue
+                total += value
+                if (total > MAX_AMOUNT) return null
+                sawAmount = true
+            }
+        }
+        return TokenInfo(
+            version = "A",
+            amount = if (sawAmount) total else null,
+            unit = sanitizedUnit(obj.get("unit")?.takeIf { it.isJsonPrimitive }?.asString),
+            mintHost = mintHost,
+            memo = sanitizedMemo(obj.get("memo")?.takeIf { it.isJsonPrimitive }?.asString)
+        )
+    }
+
+    // MARK: - V4 (CBOR)
+
+    /**
+     * Minimal walk of the NUT-00 TokenV4 CBOR map:
+     * { "m": mint, "u": unit, "d": memo, "t": [ { "i": bytes, "p": [ { "a": amount, … } ] } ] }
+     */
+    private fun decodeV4(payload: ByteArray): TokenInfo? {
+        val reader = CBORReader(payload)
+        val root = reader.parseValue(0) as? CBORReader.CborMap ?: return null
+        var mintHost: String? = null
+        var unit: String? = null
+        var memo: String? = null
+        var total = 0L
+        var sawAmount = false
+        for ((key, value) in root.pairs) {
+            val name = (key as? CBORReader.CborText)?.s ?: continue
+            when {
+                name == "m" && value is CBORReader.CborText -> mintHost = sanitizedHost(value.s)
+                name == "u" && value is CBORReader.CborText -> unit = sanitizedUnit(value.s)
+                name == "d" && value is CBORReader.CborText -> memo = sanitizedMemo(value.s)
+                name == "t" && value is CBORReader.CborArray -> {
+                    for (group in value.items.filterIsInstance<CBORReader.CborMap>()) {
+                        for ((gKey, gVal) in group.pairs) {
+                            if ((gKey as? CBORReader.CborText)?.s != "p") continue
+                            val proofs = gVal as? CBORReader.CborArray ?: continue
+                            for (proof in proofs.items.filterIsInstance<CBORReader.CborMap>()) {
+                                for ((pKey, pVal) in proof.pairs) {
+                                    if ((pKey as? CBORReader.CborText)?.s != "a") continue
+                                    val amount = (pVal as? CBORReader.CborUnsigned)?.v ?: continue
+                                    if (amount == 0uL || amount > MAX_AMOUNT.toULong()) continue
+                                    total += amount.toLong()
+                                    if (total > MAX_AMOUNT) return null
+                                    sawAmount = true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return TokenInfo(
+            version = "B",
+            amount = if (sawAmount) total else null,
+            unit = unit,
+            mintHost = mintHost,
+            memo = memo
+        )
+    }
+
+    // MARK: - Display sanitization (values are attacker-controlled)
+
+    private fun sanitizedHost(mint: String): String? {
+        if (mint.length > 512) return null
+        val host = try { URI(mint).host } catch (e: Exception) { null } ?: return null
+        if (host.isEmpty()) return null
+        return host.lowercase().take(48)
+    }
+
+    private fun sanitizedUnit(unit: String?): String? {
+        if (unit.isNullOrEmpty() || unit.length > 12) return null
+        if (!unit.all { it.isLetterOrDigit() }) return null
+        return unit
+    }
+
+    private fun sanitizedMemo(memo: String?): String? {
+        if (memo.isNullOrEmpty() || memo.length > 512) return null
+        val cleaned = memo.filter { !it.isISOControl() }.trim()
+        if (cleaned.isEmpty()) return null
+        return cleaned.take(80)
+    }
+
+    // MARK: - Minimal CBOR reader
+
+    /**
+     * Just enough definite-length CBOR to traverse a TokenV4 map. Bounded in
+     * depth, item count, and byte length; indefinite-length items and anything
+     * else exotic make the parse fail (the caller degrades to a generic chip).
+     */
+    private class CBORReader(private val data: ByteArray) {
+        sealed interface CborValue
+        data class CborUnsigned(val v: ULong) : CborValue
+        data class CborText(val s: String) : CborValue
+        data class CborArray(val items: List<CborValue>) : CborValue
+        data class CborMap(val pairs: List<Pair<CborValue, CborValue>>) : CborValue
+        /** Parsed-and-skipped content we don't need (byte strings, negatives, floats…) */
+        object CborOpaque : CborValue
+
+        private var pos = 0
+        private var itemCount = 0
+
+        companion object {
+            private const val MAX_DEPTH = 16
+            private const val MAX_ITEMS = 4_096
+            private const val MAX_CONTAINER_SIZE = 1_024L
+        }
+
+        fun parseValue(depth: Int): CborValue? {
+            if (depth > MAX_DEPTH) return null
+            if (++itemCount > MAX_ITEMS) return null
+            if (pos >= data.size) return null
+            val initial = data[pos++].toInt() and 0xFF
+            val major = initial shr 5
+            val info = initial and 0x1F
+            val arg = readArgument(info) ?: return null // indefinite-length (31) and reserved fail here
+            return when (major) {
+                0 -> CborUnsigned(arg)
+                1 -> CborOpaque // negative int, not needed
+                2 -> if (skipBytes(arg)) CborOpaque else null
+                3 -> readText(arg)
+                4 -> readArray(arg, depth)
+                5 -> readMap(arg, depth)
+                6 -> { // tag: parse the tagged value, then discard it
+                    parseValue(depth + 1) ?: return null
+                    CborOpaque
+                }
+                7 -> CborOpaque // simple/float — argument bytes already consumed by readArgument
+                else -> null
+            }
+        }
+
+        private fun readArgument(info: Int): ULong? {
+            return when {
+                info < 24 -> info.toULong()
+                info == 24 -> readUInt(1)
+                info == 25 -> readUInt(2)
+                info == 26 -> readUInt(4)
+                info == 27 -> readUInt(8)
+                else -> null // 28-30 reserved, 31 indefinite-length
+            }
+        }
+
+        private fun readUInt(n: Int): ULong? {
+            if (pos + n > data.size) return null
+            var v = 0uL
+            repeat(n) {
+                v = (v shl 8) or (data[pos++].toInt() and 0xFF).toULong()
+            }
+            return v
+        }
+
+        private fun skipBytes(n: ULong): Boolean {
+            if (n > (data.size - pos).toULong()) return false
+            pos += n.toInt()
+            return true
+        }
+
+        private fun readText(n: ULong): CborValue? {
+            if (n > (data.size - pos).toULong()) return null
+            val len = n.toInt()
+            val s = String(data, pos, len, Charsets.UTF_8)
+            pos += len
+            return CborText(s)
+        }
+
+        private fun readArray(n: ULong, depth: Int): CborValue? {
+            if (n > MAX_CONTAINER_SIZE.toULong()) return null
+            val items = ArrayList<CborValue>(n.toInt())
+            repeat(n.toInt()) {
+                items.add(parseValue(depth + 1) ?: return null)
+            }
+            return CborArray(items)
+        }
+
+        private fun readMap(n: ULong, depth: Int): CborValue? {
+            if (n > MAX_CONTAINER_SIZE.toULong()) return null
+            val pairs = ArrayList<Pair<CborValue, CborValue>>(n.toInt())
+            repeat(n.toInt()) {
+                val k = parseValue(depth + 1) ?: return null
+                val v = parseValue(depth + 1) ?: return null
+                pairs.add(k to v)
+            }
+            return CborMap(pairs)
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/cashu/CashuTokenDecoder.kt
+++ b/app/src/main/java/com/bitchat/android/cashu/CashuTokenDecoder.kt
@@ -27,7 +27,13 @@ object CashuTokenDecoder {
         /** Host of the (first) mint URL, for display. */
         val mintHost: String?,
         /** Optional sender memo, sanitized for display. */
-        val memo: String?
+        val memo: String?,
+        /**
+         * False when the token is structurally incomplete (V3: missing mint or
+         * proofs lacking secret/signature). Display stays lenient; strict mode
+         * rejects these as unsendable.
+         */
+        val complete: Boolean = true
     ) {
         /** "500 sat" style summary, defaulting the unit to sats per NUT-00. */
         val displayAmount: String?
@@ -99,9 +105,12 @@ object CashuTokenDecoder {
         }
         val info = decoded ?: return null
         if (strict) {
-            // A sendable token must resolve to a positive, sane amount.
+            // A sendable token must resolve to a positive, sane amount and be
+            // structurally complete (mint + full proofs) — an amount alone does
+            // not make an unredeemable payload sendable.
             val amount = info.amount ?: return null
             if (amount <= 0) return null
+            if (!info.complete) return null
         }
         return info
     }
@@ -158,19 +167,24 @@ object CashuTokenDecoder {
 
         var total = 0L
         var sawAmount = false
+        var complete = true
         var mintHost: String? = null
         for (entryEl in entries) {
             val entry = try { entryEl.asJsonObject } catch (e: Exception) { continue }
-            if (mintHost == null) {
-                val mint = entry.get("mint")?.takeIf { it.isJsonPrimitive }?.asString
-                if (mint != null) mintHost = sanitizedHost(mint)
-            }
+            val mint = entry.get("mint")?.takeIf { it.isJsonPrimitive }?.asString
+            if (mint.isNullOrBlank()) complete = false
+            if (mintHost == null && mint != null) mintHost = sanitizedHost(mint)
             val proofs = try { entry.getAsJsonArray("proofs") } catch (e: Exception) { null } ?: continue
             for (proofEl in proofs) {
                 val proof = try { proofEl.asJsonObject } catch (e: Exception) { continue }
                 val amountEl = proof.get("amount")?.takeIf { it.isJsonPrimitive } ?: continue
                 val value = try { amountEl.asLong } catch (e: Exception) { continue }
                 if (value <= 0 || value > MAX_AMOUNT) continue
+                // An amount without keyset id / secret / signature is not redeemable
+                if (proof.get("id")?.takeIf { it.isJsonPrimitive }?.asString.isNullOrBlank() ||
+                    proof.get("secret")?.takeIf { it.isJsonPrimitive }?.asString.isNullOrBlank() ||
+                    proof.get("C")?.takeIf { it.isJsonPrimitive }?.asString.isNullOrBlank()
+                ) complete = false
                 total += value
                 if (total > MAX_AMOUNT) return null
                 sawAmount = true
@@ -181,7 +195,8 @@ object CashuTokenDecoder {
             amount = if (sawAmount) total else null,
             unit = sanitizedUnit(obj.get("unit")?.takeIf { it.isJsonPrimitive }?.asString),
             mintHost = mintHost,
-            memo = sanitizedMemo(obj.get("memo")?.takeIf { it.isJsonPrimitive }?.asString)
+            memo = sanitizedMemo(obj.get("memo")?.takeIf { it.isJsonPrimitive }?.asString),
+            complete = complete
         )
     }
 

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -440,6 +440,15 @@ class CommandProcessor(
             // GeohashViewModel.sendGeohashMessage() adds the local echo with proper metadata
             onSendMessage(token, emptyList(), null)
         } else {
+            val currentChannel = state.getCurrentChannelValue()
+            if (currentChannel != null && channelManager.hasChannelKey(currentChannel)) {
+                // Channel encryption is a no-op stub on main
+                // (ChannelManager.sendEncryptedChannelMessage TODO), and the
+                // command callback broadcasts via mesh.sendMessage in plaintext.
+                // Refuse rather than leak a bearer token outside the channel.
+                systemMessage("payments are disabled in password-protected channels for now — channel encryption is inactive and the token would go out in plaintext")
+                return
+            }
             val message = BitchatMessage(
                 sender = state.getNicknameValue() ?: myPeerID,
                 content = token,

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -2,6 +2,7 @@ package com.bitchat.android.ui
 
 import com.bitchat.android.cashu.CashuTokenDecoder
 import com.bitchat.android.mesh.MeshService
+import com.bitchat.android.services.ContactDirectory
 import com.bitchat.android.model.BitchatMessage
 import java.util.Date
 
@@ -357,13 +358,29 @@ class CommandProcessor(
         onSendMessage: (String, List<String>, String?) -> Unit,
         viewModel: ChatViewModel?
     ) {
+        // /pay feedback (usage errors, public-confirm prompts, bearer warnings)
+        // must land on the timeline the user is looking at — the safety
+        // prompts are useless on a screen they are not watching.
         fun systemMessage(content: String) {
-            messageManager.addMessage(BitchatMessage(
+            val msg = BitchatMessage(
                 sender = "system",
                 content = content,
                 timestamp = Date(),
                 isRelay = false
-            ))
+            )
+            val selectedPeer = state.getSelectedPrivateChatPeerValue()
+            val channel = state.getCurrentChannelValue()
+            val location = state.selectedLocationChannel.value
+            when {
+                selectedPeer != null ->
+                    messageManager.addPrivateMessageNoUnread(
+                        ContactDirectory.canonicalConversationId(selectedPeer), msg)
+                channel != null ->
+                    channelManager.addChannelMessage(channel, msg, null)
+                location is com.bitchat.android.geohash.ChannelID.Location ->
+                    channelManager.addChannelMessage("geo:${location.channel.geohash}", msg, null)
+                else -> messageManager.addMessage(msg)
+            }
         }
 
         val args = parts.drop(1).filter { it.isNotBlank() }.toMutableList()

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -1,5 +1,6 @@
 package com.bitchat.android.ui
 
+import com.bitchat.android.cashu.CashuTokenDecoder
 import com.bitchat.android.mesh.MeshService
 import com.bitchat.android.model.BitchatMessage
 import java.util.Date
@@ -22,6 +23,7 @@ class CommandProcessor(
         CommandSuggestion("/hug", emptyList(), "<nickname>", "send someone a warm hug"),
         CommandSuggestion("/j", listOf("/join"), "<channel>", "join or create a channel"),
         CommandSuggestion("/m", listOf("/msg"), "<nickname> [message]", "send private message"),
+        CommandSuggestion("/pay", emptyList(), "<token>", "send a cashu ecash token"),
         CommandSuggestion("/slap", emptyList(), "<nickname>", "slap someone with a trout"),
         CommandSuggestion("/unblock", emptyList(), "<nickname>", "unblock a peer"),
         CommandSuggestion("/w", emptyList(), null, "see who's online")
@@ -45,6 +47,7 @@ class CommandProcessor(
             "/hug" -> handleActionCommand(parts, "gives", "a warm hug 🫂", meshService, myPeerID, onSendMessage, viewModel)
             "/slap" -> handleActionCommand(parts, "slaps", "around a bit with a large trout 🐟", meshService, myPeerID, onSendMessage, viewModel)
             "/channels" -> handleChannelsCommand()
+            "/pay" -> handlePayCommand(parts, meshService, myPeerID, onSendMessage, viewModel)
             else -> handleUnknownCommand(cmd)
         }
         
@@ -340,6 +343,95 @@ class CommandProcessor(
         }
     }
     
+    /**
+     * `/pay <cashu-token>` — validates the token decodes, then sends it as
+     * the message body in the current chat. Cashu tokens are bearer
+     * instruments (whoever redeems first gets the funds), so posting one to a
+     * public channel requires an explicit `/pay <token> public` confirm.
+     * The app never contacts a mint; it only relays the string.
+     */
+    private fun handlePayCommand(
+        parts: List<String>,
+        meshService: MeshService,
+        myPeerID: String,
+        onSendMessage: (String, List<String>, String?) -> Unit,
+        viewModel: ChatViewModel?
+    ) {
+        fun systemMessage(content: String) {
+            messageManager.addMessage(BitchatMessage(
+                sender = "system",
+                content = content,
+                timestamp = Date(),
+                isRelay = false
+            ))
+        }
+
+        val args = parts.drop(1).filter { it.isNotBlank() }.toMutableList()
+        if (args.isEmpty()) {
+            systemMessage("usage: /pay <token> — paste a cashu token: /pay cashuA…")
+            return
+        }
+        val confirmedPublic = args.last().lowercase() == "public"
+        if (confirmedPublic) args.removeAt(args.size - 1)
+
+        val token = args.singleOrNull()?.let { CashuTokenDecoder.bareToken(it) }
+        if (token == null) {
+            systemMessage("that doesn't look like a cashu token — expected cashuA… or cashuB…")
+            return
+        }
+        val info = CashuTokenDecoder.decode(token, strict = true)
+        if (info == null) {
+            systemMessage("invalid cashu token — it doesn't decode to a known token with an amount, not sending it")
+            return
+        }
+        val summary = info.displayAmount ?: "a cashu token"
+
+        val selectedPeer = state.getSelectedPrivateChatPeerValue()
+        if (selectedPeer != null) {
+            privateChatManager.sendPrivateMessage(
+                token,
+                selectedPeer,
+                getPeerNickname(selectedPeer, meshService),
+                state.getNicknameValue(),
+                myPeerID
+            ) { content, peerIdParam, recipientNicknameParam, messageId ->
+                sendPrivateMessageVia(meshService, content, peerIdParam, recipientNicknameParam, messageId, viewModel)
+            }
+            systemMessage("sent ${summary} — cashu is a bearer token; whoever redeems it first gets the funds")
+            return
+        }
+
+        if (!confirmedPublic) {
+            systemMessage("this is a public channel — anyone reading it can redeem the token. send anyway: /pay <token> public")
+            return
+        }
+
+        // Public send: mirror handleActionCommand's paths (local echo rules included)
+        val isInLocationChannel = state.selectedLocationChannel.value is com.bitchat.android.geohash.ChannelID.Location
+        if (isInLocationChannel) {
+            // GeohashViewModel.sendGeohashMessage() adds the local echo with proper metadata
+            onSendMessage(token, emptyList(), null)
+        } else {
+            val message = BitchatMessage(
+                sender = state.getNicknameValue() ?: myPeerID,
+                content = token,
+                timestamp = Date(),
+                isRelay = false,
+                senderPeerID = myPeerID,
+                channel = state.getCurrentChannelValue()
+            )
+            val channel = state.getCurrentChannelValue()
+            if (channel != null) {
+                channelManager.addChannelMessage(channel, message, myPeerID)
+                onSendMessage(token, emptyList(), channel)
+            } else {
+                messageManager.addMessage(message)
+                onSendMessage(token, emptyList(), null)
+            }
+        }
+        systemMessage("sent ${summary} to the public channel — anyone here can redeem it")
+    }
+
     private fun handleChannelsCommand() {
         val allChannels = channelManager.getJoinedChannelsList()
         val channelList = if (allChannels.isEmpty()) {
@@ -392,6 +484,13 @@ class CommandProcessor(
     }
     
     private fun getAllAvailableCommands(): List<CommandSuggestion> {
+        // /pay sends a bearer instrument; suggesting it in a public geohash
+        // channel invites accidents, so hide it there (it still executes
+        // behind the explicit "public" confirm).
+        val inGeoPublic = state.selectedLocationChannel.value is com.bitchat.android.geohash.ChannelID.Location &&
+                state.getSelectedPrivateChatPeerValue() == null
+        val visibleBase = if (inGeoPublic) baseCommands.filter { it.command != "/pay" } else baseCommands
+
         // Add channel-specific commands if in a channel
         val channelCommands = if (state.getCurrentChannelValue() != null) {
             listOf(
@@ -403,7 +502,7 @@ class CommandProcessor(
             emptyList()
         }
         
-        return baseCommands + channelCommands
+        return visibleBase + channelCommands
     }
     
     private fun filterCommands(commands: List<CommandSuggestion>, input: String): List<CommandSuggestion> {

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -405,6 +405,7 @@ class CommandProcessor(
 
         val selectedPeer = state.getSelectedPrivateChatPeerValue()
         if (selectedPeer != null) {
+            var route: com.bitchat.android.services.MessageRouter.RouteResult? = null
             privateChatManager.sendPrivateMessage(
                 token,
                 selectedPeer,
@@ -412,9 +413,19 @@ class CommandProcessor(
                 state.getNicknameValue(),
                 myPeerID
             ) { content, peerIdParam, recipientNicknameParam, messageId ->
-                sendPrivateMessageVia(meshService, content, peerIdParam, recipientNicknameParam, messageId, viewModel)
+                route = sendPrivateMessageVia(meshService, content, peerIdParam, recipientNicknameParam, messageId, viewModel)
             }
-            systemMessage("sent ${summary} — cashu is a bearer token; whoever redeems it first gets the funds")
+            // MessageRouter only queues to its in-memory outbox when no route is
+            // ready — reporting "sent" here would lie about a bearer token that
+            // may never arrive.
+            when (route) {
+                com.bitchat.android.services.MessageRouter.RouteResult.QUEUED ->
+                    systemMessage("queued ${summary} — no route to the recipient right now; it will send when mesh/Nostr connectivity opens. cashu is a bearer token; whoever redeems it first gets the funds")
+                com.bitchat.android.services.MessageRouter.RouteResult.DROPPED ->
+                    systemMessage("could not send ${summary} — no route to the recipient via mesh or Nostr")
+                else ->
+                    systemMessage("sent ${summary} — cashu is a bearer token; whoever redeems it first gets the funds")
+            }
             return
         }
 
@@ -639,13 +650,14 @@ class CommandProcessor(
         recipientNickname: String,
         messageId: String,
         viewModel: ChatViewModel?
-    ) {
-        if (viewModel != null) {
+    ): com.bitchat.android.services.MessageRouter.RouteResult? {
+        return if (viewModel != null) {
             com.bitchat.android.services.MessageRouter
                 .getInstance(viewModel.getApplication(), meshService)
                 .sendPrivate(content, peerID, recipientNickname, messageId)
         } else {
             meshService.sendPrivateMessage(content, peerID, recipientNickname, messageId)
+            null // fire-and-forget fallback; no route info available
         }
     }
 }

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -199,6 +199,19 @@ fun MessageItem(
         }
         
         // Link previews removed; links are now highlighted inline and clickable within the message text
+
+        // Cashu ecash tokens in the message render as payment chips below the text
+        val cashuTokens = remember(message.content) { MessageSpecialParser.findCashuTokens(message.content) }
+        if (cashuTokens.isNotEmpty()) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(top = 4.dp)
+            ) {
+                cashuTokens.forEach { match ->
+                    CashuPaymentChip(token = match.token)
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageComponents.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -203,8 +204,11 @@ fun MessageItem(
         // Cashu ecash tokens in the message render as payment chips below the text
         val cashuTokens = remember(message.content) { MessageSpecialParser.findCashuTokens(message.content) }
         if (cashuTokens.isNotEmpty()) {
-            Row(
+            // FlowRow so 2-3 chips wrap within the message width instead of
+            // overflowing past the viewport where they can't be tapped
+            FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
                 modifier = Modifier.padding(top = 4.dp)
             ) {
                 cashuTokens.forEach { match ->

--- a/app/src/main/java/com/bitchat/android/ui/MessageSpecialParser.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageSpecialParser.kt
@@ -31,10 +31,20 @@ object MessageSpecialParser {
         val results = mutableListOf<CashuTokenMatch>()
         val seen = mutableSetOf<String>()
         for (m in cashuTokenRegex.findAll(text)) {
-            val token = m.groupValues[1]
+            var token = m.groupValues[1]
+            var endExclusive = m.range.last + 1
+            // '.' is a legacy multipart separator *inside* tokens, but a
+            // trailing run of punctuation is prose glued to the token
+            // ("redeem cashuAxyz.") — strip it so the chip redeems the
+            // real bearer string.
+            while (token.isNotEmpty() && token.last() in ".,;:!?") {
+                token = token.dropLast(1)
+                endExclusive--
+            }
+            if (token.length <= 6) continue // "cashuA"/"cashuB" with no payload
             if (token.length > com.bitchat.android.cashu.CashuTokenDecoder.MAX_TOKEN_LENGTH) continue
             if (!seen.add(token)) continue
-            results.add(CashuTokenMatch(m.range.first + (m.value.length - token.length), m.range.last + 1, token))
+            results.add(CashuTokenMatch(m.range.first, endExclusive, token))
             if (results.size >= max) break
         }
         return results

--- a/app/src/main/java/com/bitchat/android/ui/MessageSpecialParser.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MessageSpecialParser.kt
@@ -13,6 +13,32 @@ object MessageSpecialParser {
 
     data class GeohashMatch(val start: Int, val endExclusive: Int, val geohash: String)
     data class UrlMatch(val start: Int, val endExclusive: Int, val url: String)
+    data class CashuTokenMatch(val start: Int, val endExclusive: Int, val token: String)
+
+    // Cashu bearer tokens (cashuA…/cashuB…). The negative lookbehind keeps the
+    // match off words that merely contain "cashuA" (e.g. "xcashuA…"), and the
+    // token embedded in a cashu:/cashu:// URI matches naturally after the ':'
+    // or '//'. Charset mirrors CashuTokenDecoder.bareToken ('.' appears in
+    // some legacy multi-part tokens).
+    private val cashuTokenRegex = Regex("(?<![A-Za-z0-9])(cashu[AB][A-Za-z0-9\\-_+/=.]{6,})")
+
+    /**
+     * Finds up to [max] distinct Cashu tokens in [text], as the bare bearer
+     * strings. Repeated tokens are one bearer instrument — one chip is enough.
+     */
+    fun findCashuTokens(text: String, max: Int = 3): List<CashuTokenMatch> {
+        if (text.isEmpty()) return emptyList()
+        val results = mutableListOf<CashuTokenMatch>()
+        val seen = mutableSetOf<String>()
+        for (m in cashuTokenRegex.findAll(text)) {
+            val token = m.groupValues[1]
+            if (token.length > com.bitchat.android.cashu.CashuTokenDecoder.MAX_TOKEN_LENGTH) continue
+            if (!seen.add(token)) continue
+            results.add(CashuTokenMatch(m.range.first + (m.value.length - token.length), m.range.last + 1, token))
+            if (results.size >= max) break
+        }
+        return results
+    }
 
     /**
      * Finds standalone geohashes within [text]. A match is returned only when

--- a/app/src/main/java/com/bitchat/android/ui/PaymentChip.kt
+++ b/app/src/main/java/com/bitchat/android/ui/PaymentChip.kt
@@ -1,0 +1,144 @@
+package com.bitchat.android.ui
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.net.toUri
+import com.bitchat.android.cashu.CashuTokenDecoder
+import java.net.URLEncoder
+
+/**
+ * Payment chip for a Cashu ecash bearer token detected in a chat message.
+ *
+ * Renders "🥜 500 sat · mint.example.com" with the memo as a caption when the
+ * token decodes, degrading to a generic "pay via cashu" chip otherwise.
+ * Tap redeems: a wallet app registered for `cashu:` URLs is tried first, with
+ * a browser fallback to redeem.cashu.me. The app never contacts a mint itself.
+ *
+ * Port of iOS `PaymentChipView` (bitchat PR #1376).
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun CashuPaymentChip(token: String, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    val colorScheme = MaterialTheme.colorScheme
+    val isDark = androidx.compose.foundation.isSystemInDarkTheme()
+
+    // Decoded once per token; tokens are size-capped so this is cheap.
+    val info = remember(token) { CashuTokenDecoder.decode(token) }
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    val genericLabel = "pay via cashu"
+    val primaryLabel = remember(info) {
+        if (info == null) return@remember genericLabel
+        val parts = mutableListOf<String>()
+        info.displayAmount?.let { parts.add(it) }
+        info.mintHost?.let { parts.add(it) }
+        if (parts.isEmpty()) genericLabel else parts.joinToString(" · ")
+    }
+
+    val fgColor = colorScheme.primary
+    val bgColor = colorScheme.secondary.copy(alpha = if (isDark) 0.18f else 0.12f)
+    val borderColor = fgColor.copy(alpha = 0.25f)
+
+    fun webRedeemUrl(): String =
+        "https://redeem.cashu.me/?token=" + URLEncoder.encode(token, "UTF-8")
+
+    fun openUrl(url: String): Boolean = try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
+        true
+    } catch (e: ActivityNotFoundException) {
+        false
+    }
+
+    fun redeem() {
+        // Try a wallet registered for cashu: URLs first, then the web page.
+        // The token only reaches the site the user's browser loads.
+        if (!openUrl("cashu:$token")) openUrl(webRedeemUrl())
+    }
+
+    Box(modifier = modifier) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .background(bgColor, RoundedCornerShape(16.dp))
+                .border(1.dp, borderColor, RoundedCornerShape(16.dp))
+                .combinedClickable(
+                    onClick = { redeem() },
+                    onLongClick = { menuExpanded = true }
+                )
+                .padding(horizontal = 12.dp, vertical = 6.dp)
+        ) {
+            Text(text = "🥜", fontSize = 12.sp)
+            Column(modifier = Modifier.padding(start = 6.dp)) {
+                Text(
+                    text = primaryLabel,
+                    color = fgColor,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+                info?.memo?.let { memo ->
+                    Text(
+                        text = memo,
+                        color = fgColor.copy(alpha = 0.7f),
+                        fontSize = 10.sp,
+                        maxLines = 1
+                    )
+                }
+            }
+        }
+
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false }
+        ) {
+            DropdownMenuItem(
+                text = { Text("Copy token") },
+                onClick = {
+                    clipboard.setText(AnnotatedString(token))
+                    menuExpanded = false
+                }
+            )
+            DropdownMenuItem(
+                text = { Text("Redeem in wallet") },
+                onClick = {
+                    openUrl("cashu:$token")
+                    menuExpanded = false
+                }
+            )
+            DropdownMenuItem(
+                text = { Text("Redeem on web") },
+                onClick = {
+                    openUrl(webRedeemUrl())
+                    menuExpanded = false
+                }
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/bitchat/android/cashu/CashuTokenDecoderTest.kt
+++ b/app/src/test/java/com/bitchat/android/cashu/CashuTokenDecoderTest.kt
@@ -213,6 +213,29 @@ class CashuTokenDecoderTest {
     }
 
     @Test
+    fun `strict mode rejects structurally incomplete v3 proofs`() {
+        // amount but no mint, no keyset id, no secret, no signature
+        val json = """{"token":[{"proofs":[{"amount":1}]}]}"""
+        val token = "cashuA" + base64Url(json.toByteArray(Charsets.UTF_8))
+        assertNull(CashuTokenDecoder.decode(token, strict = true))
+        // display mode stays lenient — the amount is still shown
+        assertEquals(1L, CashuTokenDecoder.decode(token)?.amount)
+    }
+
+    @Test
+    fun `strict mode rejects v3 proofs missing secret or signature`() {
+        val json = """{"token":[{"mint":"https://mint.example.com","proofs":[{"amount":1,"id":"009a"}]}]}"""
+        val token = "cashuA" + base64Url(json.toByteArray(Charsets.UTF_8))
+        assertNull(CashuTokenDecoder.decode(token, strict = true))
+    }
+
+    @Test
+    fun `strict mode accepts structurally complete v3`() {
+        assertNotNull(CashuTokenDecoder.decode(
+            makeV3Token(listOf("https://mint.example.com" to listOf(5))), strict = true))
+    }
+
+    @Test
     fun `strict mode rejects token without amount`() {
         // Valid JSON structure but zero proofs -> no amount -> not sendable
         val json = """{"token":[{"mint":"https://mint.example.com","proofs":[]}],"unit":"sat"}"""

--- a/app/src/test/java/com/bitchat/android/cashu/CashuTokenDecoderTest.kt
+++ b/app/src/test/java/com/bitchat/android/cashu/CashuTokenDecoderTest.kt
@@ -1,0 +1,304 @@
+package com.bitchat.android.cashu
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the Cashu token summary decoder: V3 JSON decode, minimal V4
+ * CBOR traversal, URI normalization, detection ranges, and adversarial
+ * (truncated / garbage / huge) input. The decoder renders attacker-controlled
+ * message content, so "never crash" matters as much as "decode correctly".
+ *
+ * Port of iOS `CashuTokenDecoderTests.swift` (bitchat PR #1376).
+ */
+class CashuTokenDecoderTest {
+
+    // MARK: - Token builders
+
+    private fun base64Url(data: ByteArray): String =
+        java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(data)
+
+    private fun makeV3Token(
+        entries: List<Pair<String, List<Int>>>,
+        unit: String? = "sat",
+        memo: String? = null
+    ): String {
+        val entriesJson = entries.joinToString(",") { (mint, amounts) ->
+            val proofs = amounts.joinToString(",") {
+                """{"amount":$it,"id":"009a1f293253e41e","secret":"s","C":"02c"}"""
+            }
+            """{"mint":"$mint","proofs":[$proofs]}"""
+        }
+        var json = """{"token":[$entriesJson]"""
+        if (unit != null) json += ""","unit":"$unit""""
+        if (memo != null) json += ""","memo":"$memo""""
+        json += "}"
+        return "cashuA" + base64Url(json.toByteArray(Charsets.UTF_8))
+    }
+
+    /** Tiny deterministic CBOR encoder (definite lengths only) for building
+     *  V4 test tokens without depending on the decoder under test. */
+    private object CBOREncode {
+        fun head(major: Int, value: Long): ByteArray = when {
+            value <= 23 -> byteArrayOf(((major shl 5) or value.toInt()).toByte())
+            value <= 0xFF -> byteArrayOf(((major shl 5) or 24).toByte(), value.toByte())
+            value <= 0xFFFF -> byteArrayOf(
+                ((major shl 5) or 25).toByte(),
+                (value shr 8).toByte(), value.toByte()
+            )
+            else -> byteArrayOf(
+                ((major shl 5) or 26).toByte(),
+                (value shr 24).toByte(), (value shr 16).toByte(),
+                (value shr 8).toByte(), value.toByte()
+            )
+        }
+        fun uint(v: Long): ByteArray = head(0, v)
+        fun bytes(b: ByteArray): ByteArray = head(2, b.size.toLong()) + b
+        fun text(s: String): ByteArray {
+            val utf8 = s.toByteArray(Charsets.UTF_8)
+            return head(3, utf8.size.toLong()) + utf8
+        }
+        fun array(items: List<ByteArray>): ByteArray =
+            head(4, items.size.toLong()) + items.reduce { acc, b -> acc + b }
+        fun map(pairs: List<Pair<String, ByteArray>>): ByteArray =
+            head(5, pairs.size.toLong()) + pairs.map { text(it.first) + it.second }.reduce { acc, b -> acc + b }
+    }
+
+    private fun makeV4Token(
+        mint: String = "https://mint.example.com",
+        unit: String = "sat",
+        memo: String? = null,
+        amounts: List<Long> = listOf(1, 4)
+    ): String {
+        val pairs = mutableListOf(
+            "m" to CBOREncode.text(mint),
+            "u" to CBOREncode.text(unit)
+        )
+        if (memo != null) pairs.add("d" to CBOREncode.text(memo))
+        val proofs = amounts.map { amount ->
+            CBOREncode.map(listOf(
+                "a" to CBOREncode.uint(amount),
+                "s" to CBOREncode.text("secret"),
+                "c" to CBOREncode.bytes(byteArrayOf(0x02, 0xAB.toByte(), 0xCD.toByte()))
+            ))
+        }
+        pairs.add("t" to CBOREncode.array(listOf(
+            CBOREncode.map(listOf(
+                "i" to CBOREncode.bytes(byteArrayOf(0x00, 0xAD.toByte(), 0x26, 0x8C.toByte())),
+                "p" to CBOREncode.array(proofs)
+            ))
+        )))
+        return "cashuB" + base64Url(CBOREncode.map(pairs))
+    }
+
+    // MARK: - V3 decode
+
+    @Test
+    fun `v3 decode valid token`() {
+        val token = makeV3Token(listOf("https://mint.example.com" to listOf(2, 8)), memo = "thanks!")
+        val info = CashuTokenDecoder.decode(token)
+        assertNotNull(info)
+        assertEquals("A", info!!.version)
+        assertEquals(10L, info.amount)
+        assertEquals("sat", info.unit)
+        assertEquals("mint.example.com", info.mintHost)
+        assertEquals("thanks!", info.memo)
+        assertEquals("10 sat", info.displayAmount)
+    }
+
+    @Test
+    fun `v3 amount sums across entries and proofs`() {
+        val token = makeV3Token(listOf(
+            "https://a.mint.example" to listOf(1, 2, 4),
+            "https://b.mint.example" to listOf(8, 16)
+        ))
+        val info = CashuTokenDecoder.decode(token)
+        assertEquals(31L, info!!.amount)
+        // First mint wins for the display host
+        assertEquals("a.mint.example", info.mintHost)
+    }
+
+    @Test
+    fun `v3 missing unit defaults to sat for display`() {
+        val token = makeV3Token(listOf("https://mint.example.com" to listOf(5)), unit = null)
+        val info = CashuTokenDecoder.decode(token)
+        assertNull(info!!.unit)
+        assertEquals("5 sat", info.displayAmount)
+    }
+
+    @Test
+    fun `v3 rejects nonsense amounts`() {
+        // Negative and absurd amounts must not poison the sum
+        val json = """{"token":[{"mint":"https://mint.example.com","proofs":[""" +
+            """{"amount":-5,"id":"x","secret":"s","C":"c"},""" +
+            """{"amount":3,"id":"x","secret":"s","C":"c"}]}]}"""
+        val token = "cashuA" + base64Url(json.toByteArray())
+        assertEquals(3L, CashuTokenDecoder.decode(token)!!.amount)
+    }
+
+    @Test
+    fun `v3 memo is sanitized for display`() {
+        val token = makeV3Token(
+            listOf("https://mint.example.com" to listOf(1)),
+            memo = "line1line2" + "x".repeat(300)
+        )
+        val memo = CashuTokenDecoder.decode(token)!!.memo
+        assertNotNull(memo)
+        assertTrue(memo!!.length <= 80)
+    }
+
+    // MARK: - V4 decode
+
+    @Test
+    fun `v4 decode valid token`() {
+        val token = makeV4Token(memo = "hi", amounts = listOf(2, 8))
+        val info = CashuTokenDecoder.decode(token)
+        assertNotNull(info)
+        assertEquals("B", info!!.version)
+        assertEquals(10L, info.amount)
+        assertEquals("sat", info.unit)
+        assertEquals("mint.example.com", info.mintHost)
+        assertEquals("hi", info.memo)
+        assertEquals("10 sat", info.displayAmount)
+    }
+
+    @Test
+    fun `v4 large amount`() {
+        val token = makeV4Token(amounts = listOf(2_100_000))
+        assertEquals(2_100_000L, CashuTokenDecoder.decode(token)!!.amount)
+    }
+
+    // MARK: - URI normalization
+
+    @Test
+    fun `bare token strips cashu uri schemes`() {
+        val token = makeV3Token(listOf("https://mint.example.com" to listOf(1)))
+        assertEquals(token, CashuTokenDecoder.bareToken("cashu:$token"))
+        assertEquals(token, CashuTokenDecoder.bareToken("cashu://$token"))
+        assertEquals(token, CashuTokenDecoder.bareToken("  $token  "))
+    }
+
+    @Test
+    fun `decode accepts uri wrapped token`() {
+        val token = makeV3Token(listOf("https://mint.example.com" to listOf(7)))
+        assertEquals(7L, CashuTokenDecoder.decode("cashu://$token")!!.amount)
+    }
+
+    @Test
+    fun `padded base64 is accepted`() {
+        val json = """{"token":[{"mint":"https://mint.example.com","proofs":[{"amount":4,"id":"x","secret":"s","C":"c"}]}],"unit":"sat"}"""
+        val padded = java.util.Base64.getEncoder().encodeToString(json.toByteArray())
+        val token = "cashuA$padded"
+        assertEquals(4L, CashuTokenDecoder.decode(token)!!.amount)
+    }
+
+    // MARK: - Strict mode (the /pay send path)
+
+    @Test
+    fun `strict mode rejects garbage`() {
+        assertNull(CashuTokenDecoder.decode("cashuA" + "a".repeat(100), strict = true))
+        assertNull(CashuTokenDecoder.decode("cashuB" + "a".repeat(100), strict = true))
+        assertNull(CashuTokenDecoder.decode("cashuAnot-base64!!!", strict = true))
+    }
+
+    @Test
+    fun `strict mode accepts valid tokens`() {
+        val v3 = makeV3Token(listOf("https://mint.example.com" to listOf(21)))
+        val v4 = makeV4Token(amounts = listOf(21))
+        assertEquals(21L, CashuTokenDecoder.decode(v3, strict = true)!!.amount)
+        assertEquals(21L, CashuTokenDecoder.decode(v4, strict = true)!!.amount)
+    }
+
+    @Test
+    fun `strict mode rejects token without amount`() {
+        // Valid JSON structure but zero proofs -> no amount -> not sendable
+        val json = """{"token":[{"mint":"https://mint.example.com","proofs":[]}],"unit":"sat"}"""
+        val token = "cashuA" + base64Url(json.toByteArray())
+        assertNull(CashuTokenDecoder.decode(token, strict = true))
+    }
+
+    // MARK: - Adversarial input (must never crash, always fail closed)
+
+    @Test
+    fun `truncated tokens fail closed`() {
+        val v3 = makeV3Token(listOf("https://mint.example.com" to listOf(1)))
+        val v4 = makeV4Token()
+        for (cut in listOf(6, 10, v3.length / 2, v3.length - 1)) {
+            CashuTokenDecoder.decode(v3.take(cut)) // must not throw
+        }
+        for (cut in listOf(6, 10, v4.length / 2, v4.length - 1)) {
+            CashuTokenDecoder.decode(v4.take(cut)) // must not throw
+        }
+        assertNull(CashuTokenDecoder.decode(v3.take(v3.length / 2), strict = true))
+        assertNull(CashuTokenDecoder.decode(v4.take(v4.length - 2), strict = true))
+    }
+
+    @Test
+    fun `garbage payloads fail closed`() {
+        assertNull(CashuTokenDecoder.decode("cashuA"))
+        assertNull(CashuTokenDecoder.decode("cashuB"))
+        assertNull(CashuTokenDecoder.decode("cashuCaaaaaa"))
+        assertNull(CashuTokenDecoder.bareToken("notcashu"))
+        assertNull(CashuTokenDecoder.decode("cashuA!!!invalid!!!"))
+        // Random base64 that decodes to non-JSON / non-CBOR bytes
+        CashuTokenDecoder.decode("cashuA" + base64Url(byteArrayOf(1, 2, 3, 4)))
+        CashuTokenDecoder.decode("cashuB" + base64Url(byteArrayOf(1, 2, 3, 4)))
+    }
+
+    @Test
+    fun `oversized token is rejected before decoding`() {
+        val huge = "cashuA" + "a".repeat(CashuTokenDecoder.MAX_TOKEN_LENGTH)
+        assertNull(CashuTokenDecoder.bareToken(huge))
+        assertNull(CashuTokenDecoder.decode(huge))
+    }
+
+    @Test
+    fun `indefinite length cbor degrades gracefully`() {
+        // 0xBF = indefinite-length map start; the bounded reader must refuse it.
+        // Permissive mode: generic chip with no amount. Strict: null.
+        // (payload padded so the token clears the 12-char minimum length)
+        val payload = byteArrayOf(0xBF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte())
+        val token = "cashuB" + base64Url(payload)
+        val permissive = CashuTokenDecoder.decode(token)
+        assertNotNull(permissive)
+        assertEquals("B", permissive!!.version)
+        assertNull(permissive.amount)
+        assertNull(CashuTokenDecoder.decode(token, strict = true))
+    }
+
+    @Test
+    fun `deeply nested cbor is bounded`() {
+        // 100 nested arrays exceeds the depth cap; must fail, not stack-overflow
+        var payload = CBOREncode.uint(0)
+        repeat(100) { payload = CBOREncode.array(listOf(payload)) }
+        val token = "cashuB" + base64Url(payload)
+        CashuTokenDecoder.decode(token) // must not throw
+        assertNull(CashuTokenDecoder.decode(token, strict = true))
+    }
+
+    @Test
+    fun `overflow adjacent amounts are capped`() {
+        // Two proofs at the sanity cap -> sum exceeds it -> whole decode fails
+        val json = """{"token":[{"mint":"https://mint.example.com","proofs":[""" +
+            """{"amount":2100000000000000,"id":"x","secret":"s","C":"c"},""" +
+            """{"amount":2100000000000000,"id":"x","secret":"s","C":"c"}]}]}"""
+        val token = "cashuA" + base64Url(json.toByteArray())
+        assertNull(CashuTokenDecoder.decode(token))
+    }
+
+    @Test
+    fun `control characters in memo are stripped`() {
+        val json = """{"token":[{"mint":"https://mint.example.com","proofs":[{"amount":1,"id":"x","secret":"s","C":"c"}]}],"memo":"hi\nthere"}"""
+        val token = "cashuA" + base64Url(json.toByteArray())
+        val memo = CashuTokenDecoder.decode(token)!!.memo
+        assertEquals("hithere", memo)
+    }
+
+    @Test
+    fun `display amount is null without amount`() {
+        assertNull(CashuTokenDecoder.TokenInfo("B", null, null, null, null).displayAmount)
+    }
+}

--- a/app/src/test/java/com/bitchat/android/cashu/CashuTokenDetectionTest.kt
+++ b/app/src/test/java/com/bitchat/android/cashu/CashuTokenDetectionTest.kt
@@ -1,0 +1,62 @@
+package com.bitchat.android.cashu
+
+import com.bitchat.android.ui.MessageSpecialParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Detection parity tests for [MessageSpecialParser.findCashuTokens]:
+ * bare + URI forms, dedup, max count, and word-boundary behavior.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CashuTokenDetectionTest {
+
+    private val tokenA = "cashuA" + "eyJ0b2tlbiI6W119" + "abc"
+    private val tokenB = "cashuB" + "o2FhAWFz" + "xyz"
+
+    @Test
+    fun `detects bare tokens in message text`() {
+        val matches = MessageSpecialParser.findCashuTokens("here you go $tokenA thanks")
+        assertEquals(1, matches.size)
+        assertEquals(tokenA, matches[0].token)
+    }
+
+    @Test
+    fun `detects token embedded in cashu uri`() {
+        for (uri in listOf("cashu:$tokenA", "cashu://$tokenA")) {
+            val matches = MessageSpecialParser.findCashuTokens(uri)
+            assertEquals(1, matches.size)
+            assertEquals(tokenA, matches[0].token)
+        }
+    }
+
+    @Test
+    fun `detects both v3 and v4 tokens`() {
+        val matches = MessageSpecialParser.findCashuTokens("$tokenA and $tokenB")
+        assertEquals(listOf(tokenA, tokenB), matches.map { it.token })
+    }
+
+    @Test
+    fun `deduplicates repeated tokens`() {
+        val matches = MessageSpecialParser.findCashuTokens("$tokenA $tokenA $tokenA")
+        assertEquals(1, matches.size)
+    }
+
+    @Test
+    fun `caps at max tokens`() {
+        val text = (1..6).joinToString(" ") { "cashuA" + "abcdef$it" + "x".repeat(6) }
+        val matches = MessageSpecialParser.findCashuTokens(text, max = 3)
+        assertEquals(3, matches.size)
+    }
+
+    @Test
+    fun `does not match words containing cashu prefix`() {
+        assertTrue(MessageSpecialParser.findCashuTokens("xcashuAabcdefgh").isEmpty())
+        assertTrue(MessageSpecialParser.findCashuTokens("cashuCabcdefgh").isEmpty())
+        assertTrue(MessageSpecialParser.findCashuTokens("cashuA").isEmpty())
+        assertTrue(MessageSpecialParser.findCashuTokens("no tokens here").isEmpty())
+    }
+}

--- a/app/src/test/java/com/bitchat/android/cashu/CashuTokenDetectionTest.kt
+++ b/app/src/test/java/com/bitchat/android/cashu/CashuTokenDetectionTest.kt
@@ -53,6 +53,22 @@ class CashuTokenDetectionTest {
     }
 
     @Test
+    fun `trims trailing prose punctuation from token`() {
+        for (punct in listOf(".", "!", "?", ",", ";", ":")) {
+            val matches = MessageSpecialParser.findCashuTokens("redeem $tokenA$punct")
+            assertEquals(1, matches.size)
+            assertEquals(tokenA, matches[0].token)
+        }
+    }
+
+    @Test
+    fun `keeps internal multipart dots`() {
+        val multipart = "cashuA" + "abcdef.ghijkl"
+        val matches = MessageSpecialParser.findCashuTokens(multipart)
+        assertEquals(listOf(multipart), matches.map { it.token })
+    }
+
+    @Test
     fun `does not match words containing cashu prefix`() {
         assertTrue(MessageSpecialParser.findCashuTokens("xcashuAabcdefgh").isEmpty())
         assertTrue(MessageSpecialParser.findCashuTokens("cashuCabcdefgh").isEmpty())


### PR DESCRIPTION
## Summary

Port of iOS PR permissionlesstech/bitchat#1376 to Android. Detects Cashu ecash tokens in chat messages, renders them as payment chips, and adds a  command. Content-level only — no wire-protocol changes.

- **** (new  package): decodes V3 ( = base64url JSON via Gson) and V4 ( = base64url CBOR) tokens into a display summary (amount, unit, mint host, memo). V4 uses a minimal bounded CBOR reader — definite lengths only, depth ≤ 16, item/byte budgets; exotic encodings degrade to a generic chip. All input treated as attacker-controlled: 60k char cap, 2.1e15 amount caps with overflow-guarded sum, memo/unit/host sanitization.  mode for the send path requires a clean decode with a positive amount.
- **Detection**:  — word-boundary regex matching bare tokens and / URI forms, deduped, max 3 per message.
- **** (new composable, rendered under message text in ): amount · mint host + memo caption, degrades to generic label. Tap redeems via  wallet intent with browser fallback to redeem.cashu.me; long-press menu: copy / redeem in wallet / redeem on web.
- ****: validates via strict decode, sends as message body in the current chat (DM via , public via existing mesh/geohash routing). Cashu is a bearer instrument, so public sends require  and every send states the bearer warning. Suggestion hidden in geohash public channels.

The app never contacts a mint and holds no keys/wallet state.

Fixes #756

## Test plan

- > Task :app:preBuild UP-TO-DATE
> Task :app:preDebugBuild UP-TO-DATE
> Task :app:generateDebugResources UP-TO-DATE
> Task :app:packageDebugResources UP-TO-DATE
> Task :app:processDebugNavigationResources UP-TO-DATE
> Task :app:parseDebugLocalResources UP-TO-DATE
> Task :app:generateDebugRFile UP-TO-DATE
> Task :app:compileDebugKotlin UP-TO-DATE
> Task :app:javaPreCompileDebug UP-TO-DATE
> Task :app:compileDebugJavaWithJavac UP-TO-DATE
> Task :app:checkDebugAarMetadata UP-TO-DATE
> Task :app:mapDebugSourceSetPaths UP-TO-DATE
> Task :app:compileDebugNavigationResources UP-TO-DATE
> Task :app:mergeDebugResources UP-TO-DATE
> Task :app:createDebugCompatibleScreenManifests
> Task :app:extractDeepLinksDebug UP-TO-DATE
> Task :app:processDebugMainManifest UP-TO-DATE
> Task :app:processDebugManifest
> Task :app:preDebugUnitTestBuild UP-TO-DATE
> Task :app:javaPreCompileDebugUnitTest UP-TO-DATE
> Task :app:processDebugJavaRes UP-TO-DATE
> Task :app:processDebugManifestForPackage
> Task :app:processDebugResources
> Task :app:bundleDebugClassesToRuntimeJar UP-TO-DATE
> Task :app:bundleDebugClassesToCompileJar UP-TO-DATE
> Task :app:compileDebugUnitTestKotlin UP-TO-DATE
> Task :app:compileDebugUnitTestJavaWithJavac NO-SOURCE
> Task :app:processDebugUnitTestJavaRes UP-TO-DATE
> Task :app:testDebugUnitTest UP-TO-DATE

BUILD SUCCESSFUL in 797ms
25 actionable tasks: 4 executed, 21 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.6.1/userguide/configuration_cache_enabling.html — 257 tests pass, incl. new  (V3/V4 decode, URI normalization, padding variants, strict mode, adversarial: truncated/garbage/oversized/deep-nested/indefinite-length CBOR, overflow sums, memo sanitization) and  (detection parity, dedup, max 3, word boundaries)
- > Task :app:preBuild UP-TO-DATE
> Task :app:preDebugBuild UP-TO-DATE
> Task :app:mergeDebugNativeDebugMetadata NO-SOURCE
> Task :app:generateDebugResources UP-TO-DATE
> Task :app:packageDebugResources UP-TO-DATE
> Task :app:processDebugNavigationResources UP-TO-DATE
> Task :app:parseDebugLocalResources UP-TO-DATE
> Task :app:generateDebugRFile UP-TO-DATE
> Task :app:compileDebugKotlin UP-TO-DATE
> Task :app:javaPreCompileDebug UP-TO-DATE
> Task :app:compileDebugJavaWithJavac UP-TO-DATE
> Task :app:generateDebugAssets UP-TO-DATE
> Task :app:mergeDebugAssets UP-TO-DATE
> Task :app:compressDebugAssets UP-TO-DATE
> Task :app:generateDebugGlobalSynthetics UP-TO-DATE
> Task :app:processDebugJavaRes UP-TO-DATE
> Task :app:mergeDebugJavaResource UP-TO-DATE
> Task :app:checkDebugDuplicateClasses UP-TO-DATE
> Task :app:desugarDebugFileDependencies UP-TO-DATE
> Task :app:mergeExtDexDebug UP-TO-DATE
> Task :app:mergeLibDexDebug UP-TO-DATE
> Task :app:checkDebugAarMetadata UP-TO-DATE
> Task :app:mapDebugSourceSetPaths UP-TO-DATE
> Task :app:compileDebugNavigationResources UP-TO-DATE
> Task :app:mergeDebugResources UP-TO-DATE
> Task :app:createDebugCompatibleScreenManifests
> Task :app:extractDeepLinksDebug UP-TO-DATE
> Task :app:processDebugMainManifest UP-TO-DATE
> Task :app:processDebugManifest
> Task :app:mergeDebugJniLibFolders UP-TO-DATE
> Task :app:mergeDebugNativeLibs UP-TO-DATE
> Task :app:stripDebugDebugSymbols UP-TO-DATE
> Task :app:validateSigningDebug UP-TO-DATE
> Task :app:writeDebugAppMetadata UP-TO-DATE
> Task :app:writeDebugSigningConfigVersions UP-TO-DATE
> Task :app:preDebugAndroidTestBuild SKIPPED
> Task :app:extractProguardFiles UP-TO-DATE
> Task :app:generateDebugLintReportModel UP-TO-DATE
> Task :app:preDebugUnitTestBuild UP-TO-DATE
> Task :app:lintAnalyzeDebug UP-TO-DATE
> Task :app:processDebugManifestForPackage
> Task :app:processDebugResources
> Task :app:dexBuilderDebug UP-TO-DATE
> Task :app:mergeProjectDexDebug UP-TO-DATE
> Task :app:packageDebug UP-TO-DATE
> Task :app:createDebugApkListingFileRedirect UP-TO-DATE
> Task :app:assembleDebug UP-TO-DATE
> Task :app:bundleDebugClassesToCompileJar UP-TO-DATE
> Task :app:generateDebugAndroidTestLintModel UP-TO-DATE
> Task :app:generateDebugUnitTestLintModel UP-TO-DATE
> Task :app:lintAnalyzeDebugAndroidTest UP-TO-DATE
> Task :app:lintAnalyzeDebugUnitTest UP-TO-DATE
> Task :app:lintReportDebug UP-TO-DATE
> Task :app:lintDebug

BUILD SUCCESSFUL in 1s
47 actionable tasks: 5 executed, 42 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.6.1/userguide/configuration_cache_enabling.html — green, no new lint findings in changed files
- Manual: paste a / token in a chat → chip renders with amount/mint; tap → wallet/web redeem;  in DM sends;  in public refuses without  confirm