### PR TITLE
Add vouched peer verification

### DIFF
--- a/app/src/main/java/com/bitchat/android/identity/SecureIdentityStateManager.kt
+++ b/app/src/main/java/com/bitchat/android/identity/SecureIdentityStateManager.kt
@@ -10,6 +10,7 @@ import android.util.Base64
 import android.util.Log
 import com.bitchat.android.model.AuthenticatedPeerState
 import com.bitchat.android.model.PeerCapabilities
+import com.bitchat.android.model.VouchAttestation
 import com.bitchat.android.util.hexEncodedString
 import androidx.core.content.edit
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -43,21 +44,22 @@ class SecureIdentityStateManager {
         private const val KEY_VOUCH_BATCH_SENT_AT = "vouch_batch_sent_at_v1"
         private const val KEY_VERIFIED_AT = "verified_at_v1"
         const val MAX_VOUCHERS_PER_VOUCHEE = 8
-        private const val VOUCH_RECORD_FIELD_COUNT = 3
+        private const val VOUCH_RECORD_FIELD_COUNT = 4
         private const val RECORD_SEPARATOR = ':'
         private const val RECORD_SEPARATOR_LENGTH = 1
         private const val VOUCHEE_FIELD_INDEX = 0
         private const val VOUCHER_FIELD_INDEX = 1
+        private const val VOUCHEE_SIGNING_KEY_FIELD_INDEX = 2
         private const val INDEX_NOT_FOUND = -1
         private const val IDENTITY_EVENT_BUFFER_CAPACITY = 1
+        private const val EXPIRY_TRANSITION_OFFSET_MS = 1L
 
         // BLE, Wi-Fi Aware, and Noise services each hold their own manager
         // instance over the same encrypted preferences. Serialize pin updates
         // process-wide so concurrent promotions cannot lose one another or
         // race a panic wipe.
-        private val privateMediaPinsLock = Any()
-        private val vouchStateLock = Any()
-        private var privateMediaPinsEpoch = 0L
+        private val identityPersistenceLock = Any()
+        private var identityPersistenceEpoch = 0L
         private val identityChanges =
             MutableSharedFlow<Unit>(extraBufferCapacity = IDENTITY_EVENT_BUFFER_CAPACITY)
         val changes = identityChanges.asSharedFlow()
@@ -65,11 +67,11 @@ class SecureIdentityStateManager {
     
     private val prefs: SharedPreferences
     private val lock = Any()
-    private var privateMediaPinsEpochAtCreation: Long
+    private var identityPersistenceEpochAtCreation: Long
 
     constructor(context: Context) {
-        privateMediaPinsEpochAtCreation = synchronized(privateMediaPinsLock) {
-            privateMediaPinsEpoch
+        identityPersistenceEpochAtCreation = synchronized(identityPersistenceLock) {
+            identityPersistenceEpoch
         }
         // Create master key for encryption
         val masterKey = MasterKey.Builder(context, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
@@ -89,8 +91,8 @@ class SecureIdentityStateManager {
     /** Test-only storage injection; production always uses encrypted prefs. */
     internal constructor(prefs: SharedPreferences, testOnly: Boolean) {
         require(testOnly) { "Plain SharedPreferences are test-only" }
-        privateMediaPinsEpochAtCreation = synchronized(privateMediaPinsLock) {
-            privateMediaPinsEpoch
+        identityPersistenceEpochAtCreation = synchronized(identityPersistenceLock) {
+            identityPersistenceEpoch
         }
         this.prefs = prefs
     }
@@ -240,10 +242,12 @@ class SecureIdentityStateManager {
         return getVerifiedFingerprints().contains(fingerprint)
     }
 
+    @SuppressLint("UseKtx")
     fun setVerifiedFingerprint(fingerprint: String, verified: Boolean) {
         if (!isValidFingerprint(fingerprint)) return
         val normalizedFingerprint = fingerprint.lowercase()
-        synchronized(vouchStateLock) {
+        synchronized(identityPersistenceLock) {
+            if (identityPersistenceEpochAtCreation != identityPersistenceEpoch) return
             val current = prefs.getStringSet(KEY_VERIFIED_FINGERPRINTS, emptySet())
                 ?.mapTo(mutableSetOf()) { it.lowercase() } ?: mutableSetOf()
             if (verified) {
@@ -254,49 +258,62 @@ class SecureIdentityStateManager {
             val verifiedAt = readTimestampMap(KEY_VERIFIED_AT).toMutableMap()
             if (verified) verifiedAt[normalizedFingerprint] = System.currentTimeMillis()
             else verifiedAt.remove(normalizedFingerprint)
-            prefs.edit {
-                putStringSet(KEY_VERIFIED_FINGERPRINTS, current)
-                putStringSet(KEY_VERIFIED_AT, encodeTimestampMap(verifiedAt))
-            }
+            val committed = prefs.edit()
+                .putStringSet(KEY_VERIFIED_FINGERPRINTS, current)
+                .putStringSet(KEY_VERIFIED_AT, encodeTimestampMap(verifiedAt))
+                .commit()
+            if (!committed) return
             identityChanges.tryEmit(Unit)
         }
     }
 
-    data class VouchRecord(val voucherFingerprint: String, val timestampMs: Long)
+    data class VouchRecord(
+        val voucherFingerprint: String,
+        val voucheeSigningKeyHex: String,
+        val timestampMs: Long
+    )
 
+    @SuppressLint("UseKtx")
     fun recordVouch(
         voucheeFingerprint: String,
         voucherFingerprint: String,
+        voucheeSigningKey: ByteArray,
         timestampMs: Long,
         nowMs: Long = System.currentTimeMillis()
     ): Boolean {
         val vouchee = voucheeFingerprint.lowercase()
         val voucher = voucherFingerprint.lowercase()
-        if (!isValidFingerprint(vouchee) || !isValidFingerprint(voucher)) return false
-        synchronized(vouchStateLock) {
+        if (!isValidFingerprint(vouchee) || !isValidFingerprint(voucher) ||
+            voucheeSigningKey.size != VouchAttestation.SIGNING_KEY_SIZE
+        ) return false
+        synchronized(identityPersistenceLock) {
+            if (identityPersistenceEpochAtCreation != identityPersistenceEpoch) return false
             val verified = getVerifiedFingerprints().mapTo(mutableSetOf()) { it.lowercase() }
             val age = nowMs - timestampMs
             if (vouchee == voucher || voucher !in verified || vouchee in verified ||
-                age > com.bitchat.android.model.VouchAttestation.MAX_AGE_MS ||
-                age < -com.bitchat.android.model.VouchAttestation.MAX_CLOCK_SKEW_MS
+                age > VouchAttestation.MAX_AGE_MS ||
+                age < -VouchAttestation.MAX_CLOCK_SKEW_MS
             ) return false
 
             val all = readVouchRecords().toMutableMap()
             val records = all[vouchee].orEmpty().toMutableList()
             val existing = records.indexOfFirst { it.voucherFingerprint == voucher }
-            val record = VouchRecord(
-                voucher,
-                if (existing > INDEX_NOT_FOUND) {
-                    maxOf(records[existing].timestampMs, timestampMs)
-                } else {
-                    timestampMs
-                }
+            val proposed = VouchRecord(
+                voucherFingerprint = voucher,
+                voucheeSigningKeyHex = voucheeSigningKey.hexEncodedString(),
+                timestampMs = timestampMs
             )
+            val record = records.getOrNull(existing)
+                ?.takeIf { it.timestampMs >= timestampMs }
+                ?: proposed
             if (existing > INDEX_NOT_FOUND) records[existing] = record else records += record
             val capped = records.sortedByDescending { it.timestampMs }.take(MAX_VOUCHERS_PER_VOUCHEE)
             if (capped.none { it.voucherFingerprint == voucher }) return false
             all[vouchee] = capped
-            prefs.edit { putStringSet(KEY_VOUCH_RECORDS, encodeVouchRecords(all)) }
+            val committed = prefs.edit()
+                .putStringSet(KEY_VOUCH_RECORDS, encodeVouchRecords(all))
+                .commit()
+            if (!committed) return false
             identityChanges.tryEmit(Unit)
             return true
         }
@@ -308,13 +325,17 @@ class SecureIdentityStateManager {
     ): List<VouchRecord> {
         val normalized = fingerprint.lowercase()
         if (!isValidFingerprint(normalized)) return emptyList()
-        synchronized(vouchStateLock) {
+        synchronized(identityPersistenceLock) {
+            if (identityPersistenceEpochAtCreation != identityPersistenceEpoch) return emptyList()
             val verified = getVerifiedFingerprints().mapTo(mutableSetOf()) { it.lowercase() }
+            val authenticatedSigningKeyHex = getAuthenticatedSigningKey(normalized)
+                ?.hexEncodedString() ?: return emptyList()
             return readVouchRecords()[normalized].orEmpty().filter {
                 it.voucherFingerprint != normalized &&
                     it.voucherFingerprint in verified &&
-                    nowMs - it.timestampMs <= com.bitchat.android.model.VouchAttestation.MAX_AGE_MS &&
-                    nowMs - it.timestampMs >= -com.bitchat.android.model.VouchAttestation.MAX_CLOCK_SKEW_MS
+                    it.voucheeSigningKeyHex == authenticatedSigningKeyHex &&
+                    nowMs - it.timestampMs <= VouchAttestation.MAX_AGE_MS &&
+                    nowMs - it.timestampMs >= -VouchAttestation.MAX_CLOCK_SKEW_MS
             }
         }
     }
@@ -328,12 +349,23 @@ class SecureIdentityStateManager {
     }
 
     fun getVouchedFingerprints(nowMs: Long = System.currentTimeMillis()): Set<String> =
-        synchronized(vouchStateLock) {
+        synchronized(identityPersistenceLock) {
             readVouchRecords().keys.filterTo(mutableSetOf()) { isVouched(it, nowMs) }
         }
 
+    fun nextVouchExpiryMs(nowMs: Long = System.currentTimeMillis()): Long? =
+        synchronized(identityPersistenceLock) {
+            readVouchRecords().keys
+                .flatMap { validVouchers(it, nowMs) }
+                .minOfOrNull {
+                    it.timestampMs +
+                        VouchAttestation.MAX_AGE_MS +
+                        EXPIRY_TRANSITION_OFFSET_MS
+                }
+        }
+
     fun mostRecentlyVerifiedFingerprints(limit: Int, excluding: String): List<String> {
-        return synchronized(vouchStateLock) {
+        return synchronized(identityPersistenceLock) {
             val verifiedAt = readTimestampMap(KEY_VERIFIED_AT)
             getVerifiedFingerprints()
                 .map { it.lowercase() }
@@ -344,15 +376,22 @@ class SecureIdentityStateManager {
     }
 
     fun lastVouchBatchSent(fingerprint: String): Long? =
-        synchronized(vouchStateLock) {
+        synchronized(identityPersistenceLock) {
             readTimestampMap(KEY_VOUCH_BATCH_SENT_AT)[fingerprint.lowercase()]
         }
 
+    @SuppressLint("UseKtx")
     fun markVouchBatchSent(fingerprint: String, timestampMs: Long) {
-        synchronized(vouchStateLock) {
+        synchronized(identityPersistenceLock) {
+            if (identityPersistenceEpochAtCreation != identityPersistenceEpoch) return
             val sent = readTimestampMap(KEY_VOUCH_BATCH_SENT_AT).toMutableMap()
             sent[fingerprint.lowercase()] = timestampMs
-            prefs.edit { putStringSet(KEY_VOUCH_BATCH_SENT_AT, encodeTimestampMap(sent)) }
+            if (!prefs.edit()
+                    .putStringSet(KEY_VOUCH_BATCH_SENT_AT, encodeTimestampMap(sent))
+                    .commit()
+            ) {
+                Log.e(TAG, "Vouch batch timestamp could not be committed")
+            }
         }
     }
 
@@ -377,14 +416,20 @@ class SecureIdentityStateManager {
         prefs.getStringSet(KEY_VOUCH_RECORDS, emptySet()).orEmpty().mapNotNull { entry ->
             val fields = entry.split(RECORD_SEPARATOR)
             if (fields.size != VOUCH_RECORD_FIELD_COUNT) null else fields.last().toLongOrNull()?.let {
-                fields[VOUCHEE_FIELD_INDEX] to VouchRecord(fields[VOUCHER_FIELD_INDEX], it)
+                fields[VOUCHEE_FIELD_INDEX] to VouchRecord(
+                    voucherFingerprint = fields[VOUCHER_FIELD_INDEX],
+                    voucheeSigningKeyHex = fields[VOUCHEE_SIGNING_KEY_FIELD_INDEX],
+                    timestampMs = it
+                )
             }
         }.groupBy({ it.first }, { it.second })
 
     private fun encodeVouchRecords(values: Map<String, List<VouchRecord>>): Set<String> =
         values.flatMapTo(mutableSetOf()) { (vouchee, records) ->
             records.map {
-                "$vouchee$RECORD_SEPARATOR${it.voucherFingerprint}$RECORD_SEPARATOR${it.timestampMs}"
+                "$vouchee$RECORD_SEPARATOR${it.voucherFingerprint}" +
+                    "$RECORD_SEPARATOR${it.voucheeSigningKeyHex}" +
+                    "$RECORD_SEPARATOR${it.timestampMs}"
             }
         }
 
@@ -475,8 +520,8 @@ class SecureIdentityStateManager {
 
     fun isPrivateMediaCapable(fingerprint: String): Boolean {
         if (!isValidFingerprint(fingerprint)) return false
-        return synchronized(privateMediaPinsLock) {
-            if (privateMediaPinsEpochAtCreation != privateMediaPinsEpoch) {
+        return synchronized(identityPersistenceLock) {
+            if (identityPersistenceEpochAtCreation != identityPersistenceEpoch) {
                 return@synchronized false
             }
             prefs.getStringSet(KEY_PRIVATE_MEDIA_CAPABILITY_PINS, emptySet())
@@ -491,11 +536,13 @@ class SecureIdentityStateManager {
         state: AuthenticatedPeerState,
         onCommitted: () -> Unit = {}
     ): Boolean {
-        if (!isValidFingerprint(fingerprint) || state.signingPublicKey.size != 32) return false
+        if (!isValidFingerprint(fingerprint) ||
+            state.signingPublicKey.size != VouchAttestation.SIGNING_KEY_SIZE
+        ) return false
         val normalizedFingerprint = fingerprint.lowercase()
-        return synchronized(privateMediaPinsLock) {
+        return synchronized(identityPersistenceLock) {
             // A controller that survived panic must not republish pre-wipe proof state.
-            if (privateMediaPinsEpochAtCreation != privateMediaPinsEpoch) return@synchronized false
+            if (identityPersistenceEpochAtCreation != identityPersistenceEpoch) return@synchronized false
             val records = prefs.getStringSet(KEY_AUTHENTICATED_PEER_STATES, emptySet())
                 ?.toMutableSet() ?: mutableSetOf()
             records.removeAll { it.startsWith("$normalizedFingerprint:") }
@@ -514,15 +561,18 @@ class SecureIdentityStateManager {
             // This result is a security boundary: do not publish the Ed key in memory unless the
             // encrypted identity record and its HSTS pin were durably committed together.
             editor.commit().also { committed ->
-                if (committed) onCommitted()
+                if (committed) {
+                    identityChanges.tryEmit(Unit)
+                    onCommitted()
+                }
             }
         }
     }
 
     fun getAuthenticatedPeerState(fingerprint: String): AuthenticatedPeerState? {
         if (!isValidFingerprint(fingerprint)) return null
-        return synchronized(privateMediaPinsLock) {
-            if (privateMediaPinsEpochAtCreation != privateMediaPinsEpoch) return@synchronized null
+        return synchronized(identityPersistenceLock) {
+            if (identityPersistenceEpochAtCreation != identityPersistenceEpoch) return@synchronized null
             val prefix = "${fingerprint.lowercase()}:"
             val record = prefs.getStringSet(KEY_AUTHENTICATED_PEER_STATES, emptySet())
                 ?.firstOrNull { it.startsWith(prefix) } ?: return@synchronized null
@@ -620,9 +670,9 @@ class SecureIdentityStateManager {
     @SuppressLint("UseKtx")
     fun clearIdentityData() {
         try {
-            synchronized(privateMediaPinsLock) {
-                privateMediaPinsEpoch += 1
-                privateMediaPinsEpochAtCreation = privateMediaPinsEpoch
+            synchronized(identityPersistenceLock) {
+                identityPersistenceEpoch += 1
+                identityPersistenceEpochAtCreation = identityPersistenceEpoch
                 if (!prefs.edit().clear().commit()) {
                     Log.e(TAG, "Identity preference wipe could not be committed")
                 }

--- a/app/src/main/java/com/bitchat/android/identity/SecureIdentityStateManager.kt
+++ b/app/src/main/java/com/bitchat/android/identity/SecureIdentityStateManager.kt
@@ -12,6 +12,8 @@ import com.bitchat.android.model.AuthenticatedPeerState
 import com.bitchat.android.model.PeerCapabilities
 import com.bitchat.android.util.hexEncodedString
 import androidx.core.content.edit
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
 /**
  * Manages persistent identity storage and peer ID rotation - 100% compatible with iOS implementation
@@ -37,13 +39,28 @@ class SecureIdentityStateManager {
         private const val KEY_CACHED_FINGERPRINT_NICKNAMES = "cached_fingerprint_nicknames"
         private const val KEY_PRIVATE_MEDIA_CAPABILITY_PINS = "private_media_capability_pins_v1"
         private const val KEY_AUTHENTICATED_PEER_STATES = "authenticated_peer_states_v1"
+        private const val KEY_VOUCH_RECORDS = "vouch_records_v1"
+        private const val KEY_VOUCH_BATCH_SENT_AT = "vouch_batch_sent_at_v1"
+        private const val KEY_VERIFIED_AT = "verified_at_v1"
+        const val MAX_VOUCHERS_PER_VOUCHEE = 8
+        private const val VOUCH_RECORD_FIELD_COUNT = 3
+        private const val RECORD_SEPARATOR = ':'
+        private const val RECORD_SEPARATOR_LENGTH = 1
+        private const val VOUCHEE_FIELD_INDEX = 0
+        private const val VOUCHER_FIELD_INDEX = 1
+        private const val INDEX_NOT_FOUND = -1
+        private const val IDENTITY_EVENT_BUFFER_CAPACITY = 1
 
         // BLE, Wi-Fi Aware, and Noise services each hold their own manager
         // instance over the same encrypted preferences. Serialize pin updates
         // process-wide so concurrent promotions cannot lose one another or
         // race a panic wipe.
         private val privateMediaPinsLock = Any()
+        private val vouchStateLock = Any()
         private var privateMediaPinsEpoch = 0L
+        private val identityChanges =
+            MutableSharedFlow<Unit>(extraBufferCapacity = IDENTITY_EVENT_BUFFER_CAPACITY)
+        val changes = identityChanges.asSharedFlow()
     }
     
     private val prefs: SharedPreferences
@@ -225,16 +242,151 @@ class SecureIdentityStateManager {
 
     fun setVerifiedFingerprint(fingerprint: String, verified: Boolean) {
         if (!isValidFingerprint(fingerprint)) return
-        synchronized(lock) {
-            val current = prefs.getStringSet(KEY_VERIFIED_FINGERPRINTS, emptySet())?.toMutableSet() ?: mutableSetOf()
+        val normalizedFingerprint = fingerprint.lowercase()
+        synchronized(vouchStateLock) {
+            val current = prefs.getStringSet(KEY_VERIFIED_FINGERPRINTS, emptySet())
+                ?.mapTo(mutableSetOf()) { it.lowercase() } ?: mutableSetOf()
             if (verified) {
-                current.add(fingerprint)
+                current.add(normalizedFingerprint)
             } else {
-                current.remove(fingerprint)
+                current.remove(normalizedFingerprint)
             }
-            prefs.edit { putStringSet(KEY_VERIFIED_FINGERPRINTS, current) }
+            val verifiedAt = readTimestampMap(KEY_VERIFIED_AT).toMutableMap()
+            if (verified) verifiedAt[normalizedFingerprint] = System.currentTimeMillis()
+            else verifiedAt.remove(normalizedFingerprint)
+            prefs.edit {
+                putStringSet(KEY_VERIFIED_FINGERPRINTS, current)
+                putStringSet(KEY_VERIFIED_AT, encodeTimestampMap(verifiedAt))
+            }
+            identityChanges.tryEmit(Unit)
         }
     }
+
+    data class VouchRecord(val voucherFingerprint: String, val timestampMs: Long)
+
+    fun recordVouch(
+        voucheeFingerprint: String,
+        voucherFingerprint: String,
+        timestampMs: Long,
+        nowMs: Long = System.currentTimeMillis()
+    ): Boolean {
+        val vouchee = voucheeFingerprint.lowercase()
+        val voucher = voucherFingerprint.lowercase()
+        if (!isValidFingerprint(vouchee) || !isValidFingerprint(voucher)) return false
+        synchronized(vouchStateLock) {
+            val verified = getVerifiedFingerprints().mapTo(mutableSetOf()) { it.lowercase() }
+            val age = nowMs - timestampMs
+            if (vouchee == voucher || voucher !in verified || vouchee in verified ||
+                age > com.bitchat.android.model.VouchAttestation.MAX_AGE_MS ||
+                age < -com.bitchat.android.model.VouchAttestation.MAX_CLOCK_SKEW_MS
+            ) return false
+
+            val all = readVouchRecords().toMutableMap()
+            val records = all[vouchee].orEmpty().toMutableList()
+            val existing = records.indexOfFirst { it.voucherFingerprint == voucher }
+            val record = VouchRecord(
+                voucher,
+                if (existing > INDEX_NOT_FOUND) {
+                    maxOf(records[existing].timestampMs, timestampMs)
+                } else {
+                    timestampMs
+                }
+            )
+            if (existing > INDEX_NOT_FOUND) records[existing] = record else records += record
+            val capped = records.sortedByDescending { it.timestampMs }.take(MAX_VOUCHERS_PER_VOUCHEE)
+            if (capped.none { it.voucherFingerprint == voucher }) return false
+            all[vouchee] = capped
+            prefs.edit { putStringSet(KEY_VOUCH_RECORDS, encodeVouchRecords(all)) }
+            identityChanges.tryEmit(Unit)
+            return true
+        }
+    }
+
+    fun validVouchers(
+        fingerprint: String,
+        nowMs: Long = System.currentTimeMillis()
+    ): List<VouchRecord> {
+        val normalized = fingerprint.lowercase()
+        if (!isValidFingerprint(normalized)) return emptyList()
+        synchronized(vouchStateLock) {
+            val verified = getVerifiedFingerprints().mapTo(mutableSetOf()) { it.lowercase() }
+            return readVouchRecords()[normalized].orEmpty().filter {
+                it.voucherFingerprint != normalized &&
+                    it.voucherFingerprint in verified &&
+                    nowMs - it.timestampMs <= com.bitchat.android.model.VouchAttestation.MAX_AGE_MS &&
+                    nowMs - it.timestampMs >= -com.bitchat.android.model.VouchAttestation.MAX_CLOCK_SKEW_MS
+            }
+        }
+    }
+
+    fun isVouched(fingerprint: String, nowMs: Long = System.currentTimeMillis()): Boolean {
+        val normalized = fingerprint.lowercase()
+        val isExplicitlyVerified = getVerifiedFingerprints().any {
+            it.equals(normalized, ignoreCase = true)
+        }
+        return !isExplicitlyVerified && validVouchers(normalized, nowMs).isNotEmpty()
+    }
+
+    fun getVouchedFingerprints(nowMs: Long = System.currentTimeMillis()): Set<String> =
+        synchronized(vouchStateLock) {
+            readVouchRecords().keys.filterTo(mutableSetOf()) { isVouched(it, nowMs) }
+        }
+
+    fun mostRecentlyVerifiedFingerprints(limit: Int, excluding: String): List<String> {
+        return synchronized(vouchStateLock) {
+            val verifiedAt = readTimestampMap(KEY_VERIFIED_AT)
+            getVerifiedFingerprints()
+                .map { it.lowercase() }
+                .filterNot { it == excluding.lowercase() }
+                .sortedWith(compareByDescending<String> { verifiedAt[it] ?: Long.MIN_VALUE }.thenByDescending { it })
+                .take(limit)
+        }
+    }
+
+    fun lastVouchBatchSent(fingerprint: String): Long? =
+        synchronized(vouchStateLock) {
+            readTimestampMap(KEY_VOUCH_BATCH_SENT_AT)[fingerprint.lowercase()]
+        }
+
+    fun markVouchBatchSent(fingerprint: String, timestampMs: Long) {
+        synchronized(vouchStateLock) {
+            val sent = readTimestampMap(KEY_VOUCH_BATCH_SENT_AT).toMutableMap()
+            sent[fingerprint.lowercase()] = timestampMs
+            prefs.edit { putStringSet(KEY_VOUCH_BATCH_SENT_AT, encodeTimestampMap(sent)) }
+        }
+    }
+
+    private fun readTimestampMap(key: String): Map<String, Long> =
+        prefs.getStringSet(key, emptySet()).orEmpty().mapNotNull { entry ->
+            val split = entry.lastIndexOf(RECORD_SEPARATOR)
+            if (split <= VOUCHEE_FIELD_INDEX) {
+                null
+            } else {
+                entry.substring(split + RECORD_SEPARATOR_LENGTH).toLongOrNull()?.let {
+                    entry.substring(VOUCHEE_FIELD_INDEX, split) to it
+                }
+            }
+        }.toMap()
+
+    private fun encodeTimestampMap(values: Map<String, Long>): Set<String> =
+        values.mapTo(mutableSetOf()) { (fingerprint, timestamp) ->
+            "$fingerprint$RECORD_SEPARATOR$timestamp"
+        }
+
+    private fun readVouchRecords(): Map<String, List<VouchRecord>> =
+        prefs.getStringSet(KEY_VOUCH_RECORDS, emptySet()).orEmpty().mapNotNull { entry ->
+            val fields = entry.split(RECORD_SEPARATOR)
+            if (fields.size != VOUCH_RECORD_FIELD_COUNT) null else fields.last().toLongOrNull()?.let {
+                fields[VOUCHEE_FIELD_INDEX] to VouchRecord(fields[VOUCHER_FIELD_INDEX], it)
+            }
+        }.groupBy({ it.first }, { it.second })
+
+    private fun encodeVouchRecords(values: Map<String, List<VouchRecord>>): Set<String> =
+        values.flatMapTo(mutableSetOf()) { (vouchee, records) ->
+            records.map {
+                "$vouchee$RECORD_SEPARATOR${it.voucherFingerprint}$RECORD_SEPARATOR${it.timestampMs}"
+            }
+        }
 
     fun getCachedPeerFingerprint(peerID: String): String? {
         val pid = peerID.lowercase()
@@ -474,6 +626,7 @@ class SecureIdentityStateManager {
                 if (!prefs.edit().clear().commit()) {
                     Log.e(TAG, "Identity preference wipe could not be committed")
                 }
+                identityChanges.tryEmit(Unit)
             }
             Log.w(TAG, "All identity data cleared")
         } catch (e: Exception) {

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -19,6 +19,7 @@ import com.bitchat.android.sync.GossipSyncManager
 import com.bitchat.android.util.toHexString
 import com.bitchat.android.services.VerificationService
 import com.bitchat.android.service.TransportBridgeService
+import com.bitchat.android.identity.SecureIdentityStateManager
 import kotlinx.coroutines.*
 import java.util.*
 import kotlin.math.sign
@@ -52,6 +53,7 @@ class BluetoothMeshService(private val context: Context) : TransportBridgeServic
     // My peer identification - derived from persisted Noise identity fingerprint (first 16 hex chars)
     val myPeerID: String = encryptionService.getIdentityFingerprint().take(16)
     private val peerManager = PeerManager()
+    private val identityState = SecureIdentityStateManager(context.applicationContext)
     private val fragmentManager = FragmentManager()
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val readReceiptRetrySender = RetryingControlPacketSender(serviceScope)
@@ -127,6 +129,20 @@ class BluetoothMeshService(private val context: Context) : TransportBridgeServic
     // Coroutines
     // Tracks whether this instance has been terminated via stopServices()
     private var terminated = false
+    private val vouchCoordinator by lazy {
+        VouchCoordinator(
+            scope = serviceScope,
+            identity = identityState,
+            connectedPeerIDs = peerManager::getActivePeerIDs,
+            fingerprintForPeer = peerManager::getFingerprintForPeer,
+            peerInfo = peerManager::getPeerInfo,
+            signingKeyForFingerprint = ::signingKeyForFingerprint,
+            hasEstablishedSession = encryptionService::hasEstablishedSession,
+            sign = encryptionService::signData,
+            verify = encryptionService::verifyEd25519Signature,
+            send = ::sendVouchPayload
+        )
+    }
     
     init {
         Log.i(TAG, "Initializing BluetoothMeshService for peer=$myPeerID")
@@ -253,6 +269,7 @@ class BluetoothMeshService(private val context: Context) : TransportBridgeServic
             override fun onPeerListUpdated(peerIDs: List<String>) {
                 // Update process-wide state first
                 try { com.bitchat.android.services.AppStateStore.setTransportPeers("BLE", peerIDs) } catch (_: Exception) { }
+                vouchCoordinator.peersUpdated(peerIDs)
                 // Then notify UI delegate if attached
                 delegate?.didUpdatePeerList(peerIDs)
             }
@@ -284,6 +301,10 @@ class BluetoothMeshService(private val context: Context) : TransportBridgeServic
                     peerID,
                     authenticatedRemoteStaticKey,
                     authenticatedSessionToken
+                )
+                vouchCoordinator.peerAuthenticated(
+                    peerID,
+                    identityState.generateFingerprint(authenticatedRemoteStaticKey)
                 )
                 // Send announcement and cached messages after key exchange
                 serviceScope.launch {
@@ -535,6 +556,10 @@ class BluetoothMeshService(private val context: Context) : TransportBridgeServic
 
             override fun onVerifyResponseReceived(peerID: String, payload: ByteArray, timestampMs: Long) {
                 delegate?.didReceiveVerifyResponse(peerID, payload, timestampMs)
+            }
+
+            override fun onVouchPayloadReceived(peerID: String, payload: ByteArray) {
+                vouchCoordinator.handlePayload(peerID, payload)
             }
         }
         
@@ -895,6 +920,31 @@ class BluetoothMeshService(private val context: Context) : TransportBridgeServic
         val signed = signPacketBeforeBroadcast(packet)
         if (signed.signature?.size != 64) return false
         broadcastRoutedPacket(RoutedPacket(signed))
+        return true
+    }
+
+    private fun signingKeyForFingerprint(fingerprint: String): ByteArray? {
+        identityState.getAuthenticatedSigningKey(fingerprint)?.let { return it }
+        return peerManager.getActivePeerIDs().firstNotNullOfOrNull { peerID ->
+            val peerFingerprint = peerManager.getFingerprintForPeer(peerID)
+            peerManager.getPeerInfo(peerID)?.signingPublicKey
+                ?.takeIf { peerFingerprint.equals(fingerprint, ignoreCase = true) }
+        }
+    }
+
+    private fun sendVouchPayload(peerID: String, payload: ByteArray): Boolean {
+        val plaintext = NoisePayload(NoisePayloadType.VOUCH, payload).encode()
+        val encrypted = securityManager.encryptForPeer(plaintext, peerID) ?: return false
+        val packet = BitchatPacket(
+            version = VouchCoordinator.NOISE_PACKET_VERSION,
+            type = MessageType.NOISE_ENCRYPTED.value,
+            senderID = hexStringToByteArray(myPeerID),
+            recipientID = hexStringToByteArray(peerID),
+            timestamp = System.currentTimeMillis().toULong(),
+            payload = encrypted,
+            ttl = MAX_TTL
+        )
+        broadcastRoutedPacket(RoutedPacket(signPacketBeforeBroadcast(packet)))
         return true
     }
 

--- a/app/src/main/java/com/bitchat/android/mesh/MeshCore.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/MeshCore.kt
@@ -16,6 +16,7 @@ import com.bitchat.android.model.RoutedPacket
 import com.bitchat.android.protocol.BitchatPacket
 import com.bitchat.android.protocol.MessageType
 import com.bitchat.android.protocol.SpecialRecipients
+import com.bitchat.android.identity.SecureIdentityStateManager
 import com.bitchat.android.service.TransportBridgeService
 import com.bitchat.android.sync.GossipSyncManager
 import com.bitchat.android.util.toHexString
@@ -54,6 +55,7 @@ class MeshCore(
     )
 
     private val peerManager = PeerManager()
+    private val identityState = SecureIdentityStateManager(context.applicationContext)
     val fragmentManager = FragmentManager()
     private val readReceiptRetrySender = RetryingControlPacketSender(scope)
     private val authenticatedPeerStateStore = SecureAuthenticatedPeerStateStore(context)
@@ -112,6 +114,20 @@ class MeshCore(
     private val messageHandler = MessageHandler(myPeerID, context.applicationContext)
     private val packetProcessor = PacketProcessor(myPeerID)
     private val directPeers = ConcurrentHashMap.newKeySet<String>()
+    private val vouchCoordinator by lazy {
+        VouchCoordinator(
+            scope = scope,
+            identity = identityState,
+            connectedPeerIDs = peerManager::getActivePeerIDs,
+            fingerprintForPeer = peerManager::getFingerprintForPeer,
+            peerInfo = peerManager::getPeerInfo,
+            signingKeyForFingerprint = ::signingKeyForFingerprint,
+            hasEstablishedSession = encryptionService::hasEstablishedSession,
+            sign = encryptionService::signData,
+            verify = encryptionService::verifyEd25519Signature,
+            send = ::sendVouchPayload
+        )
+    }
 
     val gossipSyncManager: GossipSyncManager =
         sharedGossipManager ?: GossipSyncManager(myPeerID = myPeerID, scope = scope, configProvider = gossipConfigProvider)
@@ -211,6 +227,7 @@ class MeshCore(
         peerManager.delegate = object : PeerManagerDelegate {
             override fun onPeerListUpdated(peerIDs: List<String>) {
                 try { com.bitchat.android.services.AppStateStore.setTransportPeers(transport.id, peerIDs) } catch (_: Exception) { }
+                vouchCoordinator.peersUpdated(peerIDs)
                 delegate?.didUpdatePeerList(peerIDs)
             }
 
@@ -235,6 +252,10 @@ class MeshCore(
                     peerID,
                     authenticatedRemoteStaticKey,
                     authenticatedSessionToken
+                )
+                vouchCoordinator.peerAuthenticated(
+                    peerID,
+                    identityState.generateFingerprint(authenticatedRemoteStaticKey)
                 )
                 scope.launch {
                     delay(100)
@@ -431,6 +452,10 @@ class MeshCore(
             override fun onVerifyResponseReceived(peerID: String, payload: ByteArray, timestampMs: Long) {
                 delegate?.didReceiveVerifyResponse(peerID, payload, timestampMs)
             }
+
+            override fun onVouchPayloadReceived(peerID: String, payload: ByteArray) {
+                vouchCoordinator.handlePayload(peerID, payload)
+            }
         }
 
         packetProcessor.delegate = object : PacketProcessorDelegate {
@@ -563,6 +588,31 @@ class MeshCore(
         val signed = signPacketBeforeBroadcast(packet)
         if (signed.signature?.size != 64) return false
         dispatchGlobal(RoutedPacket(signed))
+        return true
+    }
+
+    private fun signingKeyForFingerprint(fingerprint: String): ByteArray? {
+        identityState.getAuthenticatedSigningKey(fingerprint)?.let { return it }
+        return peerManager.getActivePeerIDs().firstNotNullOfOrNull { peerID ->
+            val peerFingerprint = peerManager.getFingerprintForPeer(peerID)
+            peerManager.getPeerInfo(peerID)?.signingPublicKey
+                ?.takeIf { peerFingerprint.equals(fingerprint, ignoreCase = true) }
+        }
+    }
+
+    private fun sendVouchPayload(peerID: String, payload: ByteArray): Boolean {
+        val plaintext = NoisePayload(NoisePayloadType.VOUCH, payload).encode()
+        val encrypted = securityManager.encryptForPeer(plaintext, peerID) ?: return false
+        val packet = BitchatPacket(
+            version = VouchCoordinator.NOISE_PACKET_VERSION,
+            type = MessageType.NOISE_ENCRYPTED.value,
+            senderID = MeshPacketUtils.hexStringToByteArray(myPeerID),
+            recipientID = MeshPacketUtils.hexStringToByteArray(peerID),
+            timestamp = System.currentTimeMillis().toULong(),
+            payload = encrypted,
+            ttl = maxTtl
+        )
+        dispatchGlobal(RoutedPacket(signPacketBeforeBroadcast(packet)))
         return true
     }
 

--- a/app/src/main/java/com/bitchat/android/mesh/MessageHandler.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/MessageHandler.kt
@@ -185,6 +185,9 @@ class MessageHandler(private val myPeerID: String, private val appContext: andro
                 com.bitchat.android.model.NoisePayloadType.VERIFY_RESPONSE -> {
                     delegate?.onVerifyResponseReceived(peerID, noisePayload.data, packet.timestamp.toLong())
                 }
+                com.bitchat.android.model.NoisePayloadType.VOUCH -> {
+                    delegate?.onVouchPayloadReceived(peerID, noisePayload.data)
+                }
             }
             
         } catch (e: Exception) {
@@ -699,4 +702,5 @@ interface MessageHandlerDelegate {
     fun onReadReceiptReceived(messageID: String, peerID: String)
     fun onVerifyChallengeReceived(peerID: String, payload: ByteArray, timestampMs: Long)
     fun onVerifyResponseReceived(peerID: String, payload: ByteArray, timestampMs: Long)
+    fun onVouchPayloadReceived(peerID: String, payload: ByteArray) {}
 }

--- a/app/src/main/java/com/bitchat/android/mesh/VouchCoordinator.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/VouchCoordinator.kt
@@ -101,6 +101,7 @@ class VouchCoordinator(
                 identity.recordVouch(
                     attestation.voucheeFingerprint.hexEncodedString(),
                     senderFingerprint,
+                    attestation.voucheeSigningKey,
                     attestation.timestampMs,
                     nowMs
                 )

--- a/app/src/main/java/com/bitchat/android/mesh/VouchCoordinator.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/VouchCoordinator.kt
@@ -1,0 +1,126 @@
+package com.bitchat.android.mesh
+
+import android.util.Log
+import com.bitchat.android.identity.SecureIdentityStateManager
+import com.bitchat.android.model.PeerCapabilities
+import com.bitchat.android.model.VouchAttestation
+import com.bitchat.android.util.dataFromHexString
+import com.bitchat.android.util.hexEncodedString
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+/**
+ * Transport-neutral exchange and acceptance policy for transitive verification.
+ *
+ * All payloads supplied to [handlePayload] have already been authenticated and
+ * decrypted by the Noise session for [peerID].
+ */
+class VouchCoordinator(
+    private val scope: CoroutineScope,
+    private val identity: SecureIdentityStateManager,
+    private val connectedPeerIDs: () -> Collection<String>,
+    private val fingerprintForPeer: (String) -> String?,
+    private val peerInfo: (String) -> PeerInfo?,
+    private val signingKeyForFingerprint: (String) -> ByteArray?,
+    private val hasEstablishedSession: (String) -> Boolean,
+    private val sign: (ByteArray) -> ByteArray?,
+    private val verify: (ByteArray, ByteArray, ByteArray) -> Boolean,
+    private val send: (String, ByteArray) -> Boolean
+) {
+    init {
+        scope.launch {
+            SecureIdentityStateManager.changes.collect {
+                vouchToConnectedVerifiedPeers()
+            }
+        }
+    }
+
+    fun peerAuthenticated(peerID: String, fingerprint: String) {
+        attemptVouch(peerID, fingerprint)
+    }
+
+    fun peersUpdated(peerIDs: Collection<String>) {
+        peerIDs.forEach { peerID ->
+            fingerprintForPeer(peerID)?.let { attemptVouch(peerID, it) }
+        }
+    }
+
+    fun vouchToConnectedVerifiedPeers(nowMs: Long = System.currentTimeMillis()) {
+        connectedPeerIDs().forEach { peerID ->
+            fingerprintForPeer(peerID)?.let { attemptVouch(peerID, it, nowMs) }
+        }
+    }
+
+    fun attemptVouch(
+        peerID: String,
+        peerFingerprint: String,
+        nowMs: Long = System.currentTimeMillis()
+    ): Boolean {
+        val normalizedPeerFingerprint = peerFingerprint.lowercase()
+        if (!hasEstablishedSession(peerID) ||
+            !identity.isVerifiedFingerprint(normalizedPeerFingerprint)
+        ) return false
+
+        val capabilities = peerInfo(peerID)?.capabilities
+        if (capabilities != null && capabilities != PeerCapabilities.NONE &&
+            !capabilities.contains(PeerCapabilities.VOUCH)
+        ) return false
+
+        val lastSent = identity.lastVouchBatchSent(normalizedPeerFingerprint)
+        if (lastSent != null && nowMs - lastSent < BATCH_INTERVAL_MS) return false
+
+        val attestations = identity.mostRecentlyVerifiedFingerprints(
+            VouchAttestation.MAX_BATCH_COUNT,
+            excluding = normalizedPeerFingerprint
+        ).mapNotNull { vouchee ->
+            val fingerprintBytes = vouchee.dataFromHexString() ?: return@mapNotNull null
+            val signingKey = signingKeyForFingerprint(vouchee) ?: return@mapNotNull null
+            VouchAttestation.build(fingerprintBytes, signingKey, nowMs, sign)
+        }
+        val payload = VouchAttestation.encodeList(attestations) ?: return false
+        if (!send(peerID, payload)) return false
+        identity.markVouchBatchSent(normalizedPeerFingerprint, nowMs)
+        Log.d(TAG, "Sent ${attestations.size} vouch(es) to ${peerID.take(LOG_FINGERPRINT_LENGTH)}")
+        return true
+    }
+
+    fun handlePayload(
+        peerID: String,
+        payload: ByteArray,
+        nowMs: Long = System.currentTimeMillis()
+    ) {
+        val senderFingerprint = fingerprintForPeer(peerID)?.lowercase() ?: return
+        if (!identity.isVerifiedFingerprint(senderFingerprint)) return
+        val senderSigningKey = signingKeyForFingerprint(senderFingerprint) ?: return
+
+        var accepted = INITIAL_ACCEPTED_COUNT
+        VouchAttestation.decodeList(payload).forEach { attestation ->
+            if (!attestation.isExpired(nowMs) &&
+                verify(attestation.signature, attestation.signableBytes(), senderSigningKey) &&
+                identity.recordVouch(
+                    attestation.voucheeFingerprint.hexEncodedString(),
+                    senderFingerprint,
+                    attestation.timestampMs,
+                    nowMs
+                )
+            ) accepted++
+        }
+        if (accepted > INITIAL_ACCEPTED_COUNT) {
+            Log.i(TAG, "Accepted $accepted vouch(es) from ${peerID.take(LOG_FINGERPRINT_LENGTH)}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "VouchCoordinator"
+        private const val INITIAL_ACCEPTED_COUNT = 0
+        private const val LOG_FINGERPRINT_LENGTH = 8
+        private const val HOURS_PER_DAY = 24L
+        private const val MINUTES_PER_HOUR = 60L
+        private const val SECONDS_PER_MINUTE = 60L
+        private const val MILLIS_PER_SECOND = 1000L
+        const val BATCH_INTERVAL_MS =
+            HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLIS_PER_SECOND
+        val NOISE_PACKET_VERSION: UByte = 1u
+    }
+}

--- a/app/src/main/java/com/bitchat/android/model/NoiseEncrypted.kt
+++ b/app/src/main/java/com/bitchat/android/model/NoiseEncrypted.kt
@@ -23,6 +23,7 @@ enum class NoisePayloadType(val value: UByte) {
     DELIVERED(0x03u),           // Message was delivered
     VERIFY_CHALLENGE(0x10u),    // Verification challenge
     VERIFY_RESPONSE(0x11u),     // Verification response
+    VOUCH(0x12u),               // Transitive verification attestations
     FILE_TRANSFER(0x20u),
     /** Authenticated capabilities + Ed25519 binding for the current Noise generation. */
     PEER_STATE(0x21u);

--- a/app/src/main/java/com/bitchat/android/model/PeerCapabilities.kt
+++ b/app/src/main/java/com/bitchat/android/model/PeerCapabilities.kt
@@ -27,13 +27,18 @@ data class PeerCapabilities(val rawValue: Long) : Parcelable {
     }
 
     companion object {
+        private const val VOUCH_BIT_INDEX = 5
+        private const val PRIVATE_MEDIA_BIT_INDEX = 8
         val NONE = PeerCapabilities(0)
 
         /** Noise-encrypted private BitchatFilePacket using payload type 0x20. */
-        val PRIVATE_MEDIA = PeerCapabilities(1L shl 8)
+        val PRIVATE_MEDIA = PeerCapabilities(1L shl PRIVATE_MEDIA_BIT_INDEX)
+
+        /** Transitive verification attestations over authenticated Noise. */
+        val VOUCH = PeerCapabilities(1L shl VOUCH_BIT_INDEX)
 
         /** Capabilities implemented by this Android build. */
-        val LOCAL_SUPPORTED = PRIVATE_MEDIA
+        val LOCAL_SUPPORTED = PeerCapabilities(PRIVATE_MEDIA.rawValue or VOUCH.rawValue)
 
         /**
          * Decode the low 64 bits and ignore any future extension bytes, which

--- a/app/src/main/java/com/bitchat/android/model/VouchAttestation.kt
+++ b/app/src/main/java/com/bitchat/android/model/VouchAttestation.kt
@@ -1,0 +1,193 @@
+package com.bitchat.android.model
+
+import java.io.ByteArrayOutputStream
+
+/**
+ * An iOS-compatible, Ed25519-signed statement that the sender of the enclosing
+ * authenticated Noise payload verified [voucheeFingerprint].
+ */
+data class VouchAttestation(
+    val voucheeFingerprint: ByteArray,
+    val voucheeSigningKey: ByteArray,
+    val timestampMs: Long,
+    val signature: ByteArray
+) {
+    init {
+        require(voucheeFingerprint.size == FINGERPRINT_SIZE)
+        require(voucheeSigningKey.size == SIGNING_KEY_SIZE)
+        require(signature.size == SIGNATURE_SIZE)
+    }
+
+    fun signableBytes(): ByteArray = signableBytes(
+        voucheeFingerprint,
+        voucheeSigningKey,
+        timestampMs
+    )
+
+    fun isExpired(nowMs: Long = System.currentTimeMillis()): Boolean {
+        val age = nowMs - timestampMs
+        return age > MAX_AGE_MS || age < -MAX_CLOCK_SKEW_MS
+    }
+
+    fun encode(): ByteArray {
+        val output = ByteArrayOutputStream()
+        output.writeTlv(TYPE_FINGERPRINT, voucheeFingerprint)
+        output.writeTlv(TYPE_SIGNING_KEY, voucheeSigningKey)
+        output.writeTlv(TYPE_TIMESTAMP, timestampBytes(timestampMs))
+        output.writeTlv(TYPE_SIGNATURE, signature)
+        return output.toByteArray()
+    }
+
+    override fun equals(other: Any?): Boolean =
+        other is VouchAttestation &&
+            voucheeFingerprint.contentEquals(other.voucheeFingerprint) &&
+            voucheeSigningKey.contentEquals(other.voucheeSigningKey) &&
+            timestampMs == other.timestampMs &&
+            signature.contentEquals(other.signature)
+
+    override fun hashCode(): Int {
+        var result = voucheeFingerprint.contentHashCode()
+        result = HASH_MULTIPLIER * result + voucheeSigningKey.contentHashCode()
+        result = HASH_MULTIPLIER * result + timestampMs.hashCode()
+        return HASH_MULTIPLIER * result + signature.contentHashCode()
+    }
+
+    companion object {
+        const val MAX_BATCH_COUNT = 16
+        const val FINGERPRINT_SIZE = 32
+        const val SIGNING_KEY_SIZE = 32
+        const val SIGNATURE_SIZE = 64
+        private const val DAYS_VALID = 30L
+        private const val HOURS_PER_DAY = 24L
+        private const val MINUTES_PER_HOUR = 60L
+        private const val SECONDS_PER_MINUTE = 60L
+        private const val MILLIS_PER_SECOND = 1000L
+        const val MAX_AGE_MS =
+            DAYS_VALID * HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLIS_PER_SECOND
+        const val MAX_CLOCK_SKEW_MS =
+            MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLIS_PER_SECOND
+
+        private const val SIGNING_CONTEXT = "bitchat-vouch-v1"
+        private const val TYPE_FINGERPRINT = 0x01
+        private const val TYPE_SIGNING_KEY = 0x02
+        private const val TYPE_TIMESTAMP = 0x03
+        private const val TYPE_SIGNATURE = 0x04
+        private const val TLV_HEADER_SIZE = 2
+        private const val TLV_LENGTH_SIZE = 1
+        private const val BATCH_COUNT_SIZE = 1
+        private const val BATCH_ENTRY_LENGTH_SIZE = 2
+        private const val BITS_PER_BYTE = 8
+        private const val BYTE_MASK = 0xFF
+        private const val UINT16_MAX = 0xFFFF
+        private const val INITIAL_OFFSET = 0
+        private const val INITIAL_TIMESTAMP = 0L
+        private const val MINIMUM_TIMESTAMP_MS = 0L
+        private const val INITIAL_ENTRY_COUNT = 0
+        private const val HASH_MULTIPLIER = 31
+        private const val TIMESTAMP_LENGTH = Long.SIZE_BYTES
+
+        fun build(
+            voucheeFingerprint: ByteArray,
+            voucheeSigningKey: ByteArray,
+            timestampMs: Long = System.currentTimeMillis(),
+            sign: (ByteArray) -> ByteArray?
+        ): VouchAttestation? {
+            if (voucheeFingerprint.size != FINGERPRINT_SIZE ||
+                voucheeSigningKey.size != SIGNING_KEY_SIZE
+            ) return null
+            val signature = sign(signableBytes(voucheeFingerprint, voucheeSigningKey, timestampMs))
+                ?: return null
+            if (signature.size != SIGNATURE_SIZE) return null
+            return VouchAttestation(voucheeFingerprint, voucheeSigningKey, timestampMs, signature)
+        }
+
+        fun signableBytes(
+            voucheeFingerprint: ByteArray,
+            voucheeSigningKey: ByteArray,
+            timestampMs: Long
+        ): ByteArray = SIGNING_CONTEXT.toByteArray(Charsets.UTF_8) +
+            voucheeFingerprint + voucheeSigningKey + timestampBytes(timestampMs)
+
+        fun decode(data: ByteArray): VouchAttestation? {
+            var offset = INITIAL_OFFSET
+            var fingerprint: ByteArray? = null
+            var signingKey: ByteArray? = null
+            var timestamp: Long? = null
+            var signature: ByteArray? = null
+            while (offset < data.size) {
+                if (offset + TLV_HEADER_SIZE > data.size) return null
+                val type = data[offset++].toInt() and BYTE_MASK
+                val length = data[offset++].toInt() and BYTE_MASK
+                if (offset + length > data.size) return null
+                val value = data.copyOfRange(offset, offset + length)
+                offset += length
+                when (type) {
+                    TYPE_FINGERPRINT -> if (length == FINGERPRINT_SIZE) fingerprint = value else return null
+                    TYPE_SIGNING_KEY -> if (length == SIGNING_KEY_SIZE) signingKey = value else return null
+                    TYPE_TIMESTAMP -> if (length == TIMESTAMP_LENGTH) {
+                        val decodedTimestamp = value.fold(INITIAL_TIMESTAMP) { result, byte ->
+                            (result shl BITS_PER_BYTE) or (byte.toLong() and BYTE_MASK.toLong())
+                        }
+                        if (decodedTimestamp < MINIMUM_TIMESTAMP_MS) return null
+                        timestamp = decodedTimestamp
+                    } else return null
+                    TYPE_SIGNATURE -> if (length == SIGNATURE_SIZE) signature = value else return null
+                }
+            }
+            return VouchAttestation(
+                fingerprint ?: return null,
+                signingKey ?: return null,
+                timestamp ?: return null,
+                signature ?: return null
+            )
+        }
+
+        fun encodeList(attestations: List<VouchAttestation>): ByteArray? {
+            if (attestations.isEmpty() || attestations.size > MAX_BATCH_COUNT) return null
+            val output = ByteArrayOutputStream()
+            output.write(attestations.size)
+            attestations.forEach { attestation ->
+                val encoded = attestation.encode()
+                if (encoded.size > UINT16_MAX) return null
+                output.write(encoded.size ushr BITS_PER_BYTE)
+                output.write(encoded.size and BYTE_MASK)
+                output.write(encoded)
+            }
+            return output.toByteArray()
+        }
+
+        fun decodeList(data: ByteArray): List<VouchAttestation> {
+            if (data.size <= BATCH_COUNT_SIZE) return emptyList()
+            val limit = minOf(data[0].toInt() and BYTE_MASK, MAX_BATCH_COUNT)
+            val decoded = mutableListOf<VouchAttestation>()
+            var offset = BATCH_COUNT_SIZE
+            var entriesRead = INITIAL_ENTRY_COUNT
+            while (entriesRead < limit && offset < data.size) {
+                if (offset + BATCH_ENTRY_LENGTH_SIZE > data.size) break
+                val length = ((data[offset].toInt() and BYTE_MASK) shl BITS_PER_BYTE) or
+                    (data[offset + TLV_LENGTH_SIZE].toInt() and BYTE_MASK)
+                offset += BATCH_ENTRY_LENGTH_SIZE
+                if (offset + length > data.size) break
+                decode(data.copyOfRange(offset, offset + length))?.let(decoded::add)
+                offset += length
+                entriesRead++
+            }
+            return decoded
+        }
+
+        private const val LAST_BYTE_INDEX_OFFSET = 1
+        private const val TIMESTAMP_HIGH_BIT_OFFSET =
+            (TIMESTAMP_LENGTH - LAST_BYTE_INDEX_OFFSET) * BITS_PER_BYTE
+
+        private fun timestampBytes(timestampMs: Long): ByteArray =
+            ByteArray(TIMESTAMP_LENGTH) { index ->
+                (timestampMs ushr (TIMESTAMP_HIGH_BIT_OFFSET - index * BITS_PER_BYTE)).toByte()
+            }
+
+        private fun ByteArrayOutputStream.writeTlv(type: Int, value: ByteArray) {
+            write(type)
+            write(value.size)
+            write(value)
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/nostr/NostrDirectMessageHandler.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrDirectMessageHandler.kt
@@ -242,6 +242,7 @@ class NostrDirectMessageHandler(
             }
             NoisePayloadType.VERIFY_CHALLENGE,
             NoisePayloadType.VERIFY_RESPONSE,
+            NoisePayloadType.VOUCH,
             NoisePayloadType.PEER_STATE -> Unit // Peer state is bound to a live mesh Noise generation.
         }
     }

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -164,6 +164,7 @@ class ChatViewModel(
         messageManager = messageManager
     )
     val verifiedFingerprints = verificationHandler.verifiedFingerprints
+    val vouchedFingerprints = verificationHandler.vouchedFingerprints
 
     // Media file sending manager
     private val mediaSendingManager = MediaSendingManager(
@@ -1239,6 +1240,20 @@ class ChatViewModel(
         val fingerprint = verificationHandler.fingerprintFromNoiseBytes(noisePublicKey)
         return verifiedFingerprints.contains(fingerprint)
     }
+
+    fun isFingerprintVouched(fingerprint: String): Boolean =
+        verificationHandler.isFingerprintVouched(fingerprint)
+
+    fun isNoisePublicKeyVouched(noisePublicKey: ByteArray): Boolean =
+        verificationHandler.isFingerprintVouched(
+            verificationHandler.fingerprintFromNoiseBytes(noisePublicKey)
+        )
+
+    fun vouchersForFingerprint(fingerprint: String) =
+        verificationHandler.vouchersForFingerprint(fingerprint)
+
+    fun voucherNamesForFingerprint(fingerprint: String): List<String> =
+        verificationHandler.voucherNamesForFingerprint(fingerprint)
 
     fun unverifyFingerprint(peerID: String) {
         verificationHandler.unverifyFingerprint(peerID)

--- a/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
@@ -74,6 +74,8 @@ import com.bitchat.android.util.hexEncodedString
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 
+private val TRUST_BADGE_SPACING = 4.dp
+private val TRUST_BADGE_SIZE = 14.dp
 
 /**
  * Sheet components for ChatScreen
@@ -684,6 +686,7 @@ fun PeopleSection(
         val peerFavoritedUs by viewModel.peerFavoritedUs.collectAsStateWithLifecycle()
         val peerFingerprints by viewModel.peerFingerprints.collectAsStateWithLifecycle()
         val verifiedFingerprints by viewModel.verifiedFingerprints.collectAsStateWithLifecycle()
+        val vouchedFingerprints by viewModel.vouchedFingerprints.collectAsStateWithLifecycle()
 
         // Reactive favorite computation for all peers
         val peerFavoriteStates = remember(favoritePeers, peerFingerprints, connectedPeers) {
@@ -808,6 +811,8 @@ fun PeopleSection(
             val isFavorite = peerFavoriteStates[peerID] ?: false
             val theyFavoritedUs = peerTheyFavoritedUsStates[peerID] ?: false
             val isVerified = peerVerifiedStates[peerID] ?: false
+            val isVouched = !isVerified &&
+                peerFingerprints[peerID]?.lowercase() in vouchedFingerprints
             // fingerprint and favorite relationship resolution not needed here; UI will show Nostr globe for appended offline favorites below
 
             val noiseHex = noiseHexByPeerID[peerID]
@@ -835,6 +840,7 @@ fun PeopleSection(
                 isFavorite = isFavorite,
                 theyFavoritedUs = theyFavoritedUs,
                 isVerified = isVerified,
+                isVouched = isVouched,
                 colorScheme = colorScheme,
                 viewModel = viewModel,
                 onItemClick = { onPrivateChatStart(peerID) },
@@ -865,6 +871,7 @@ fun PeopleSection(
             val showHash = (baseNameCounts[bName] ?: 0) > 1
 
             val isVerified = viewModel.isNoisePublicKeyVerified(fav.peerNoisePublicKey, verifiedFingerprints)
+            val isVouched = !isVerified && viewModel.isNoisePublicKeyVouched(fav.peerNoisePublicKey)
 
             val unreadCount = (
                 privateChats[conversationID]?.count { msg -> msg.sender != nickname && hasUnreadPrivateMessages.contains(conversationID) } ?: 0
@@ -881,6 +888,7 @@ fun PeopleSection(
                 isFavorite = true,
                 theyFavoritedUs = fav.theyFavoritedUs,
                 isVerified = isVerified,
+                isVouched = isVouched,
                 colorScheme = colorScheme,
                 viewModel = viewModel,
                 onItemClick = { onPrivateChatStart(mappedConnectedPeerID ?: favPeerID) },
@@ -1467,6 +1475,7 @@ private fun PeerItem(
     isFavorite: Boolean,
     theyFavoritedUs: Boolean = false,
     isVerified: Boolean,
+    isVouched: Boolean,
     colorScheme: ColorScheme,
     viewModel: ChatViewModel,
     onItemClick: () -> Unit,
@@ -1562,6 +1571,23 @@ private fun PeerItem(
                     fontSize = 14.sp,
                     fontWeight = if (isMe) FontWeight.Bold else FontWeight.Medium,
                     color = baseColor.copy(alpha = SUFFIX_ALPHA)
+                )
+            }
+
+            if (isVerified) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_spec_check),
+                    contentDescription = stringResource(R.string.verify_title),
+                    modifier = Modifier.size(16.dp),
+                    tint = colorScheme.primary
+                )
+            } else if (isVouched) {
+                Spacer(modifier = Modifier.width(TRUST_BADGE_SPACING))
+                Icon(
+                    imageVector = Icons.Outlined.VerifiedUser,
+                    contentDescription = stringResource(R.string.fingerprint_status_vouched),
+                    modifier = Modifier.size(TRUST_BADGE_SIZE),
+                    tint = baseColor
                 )
             }
         }

--- a/app/src/main/java/com/bitchat/android/ui/SecurityVerificationSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SecurityVerificationSheet.kt
@@ -331,7 +331,7 @@ private fun SecurityVerificationActions(
                     voucherNames.size,
                     voucherNames.size
                 ),
-                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = BitchatFontFamily),
                 color = accent.copy(alpha = VOUCHED_SECONDARY_CONTENT_ALPHA),
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center
@@ -339,7 +339,7 @@ private fun SecurityVerificationActions(
             if (voucherNames.isNotEmpty()) {
                 Text(
                     text = voucherNames.joinToString(),
-                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = BitchatFontFamily),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.fillMaxWidth(),
                     textAlign = TextAlign.Center

--- a/app/src/main/java/com/bitchat/android/ui/SecurityVerificationSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SecurityVerificationSheet.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.NoEncryption
 import androidx.compose.material.icons.outlined.Sync
+import androidx.compose.material.icons.outlined.VerifiedUser
 import androidx.compose.material.icons.outlined.Warning as OutlinedWarning
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -37,6 +38,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -49,6 +51,8 @@ import com.bitchat.android.core.ui.component.button.CloseButton
 import com.bitchat.android.core.ui.component.sheet.LocalSheetDismiss
 import com.bitchat.android.core.ui.component.sheet.BitchatBottomSheet
 import com.bitchat.android.services.ContactDirectory
+
+private const val VOUCHED_SECONDARY_CONTENT_ALPHA = 0.8f
 
 private data class SecurityStatusInfo(
     val text: String,
@@ -68,6 +72,7 @@ fun SecurityVerificationSheet(
 
     val peerID by viewModel.selectedPrivateChatPeer.collectAsStateWithLifecycle()
     val verifiedFingerprints by viewModel.verifiedFingerprints.collectAsStateWithLifecycle()
+    val vouchedFingerprints by viewModel.vouchedFingerprints.collectAsStateWithLifecycle()
     val peerSessionStates by viewModel.peerSessionStates.collectAsStateWithLifecycle()
 
     val colorScheme = MaterialTheme.colorScheme
@@ -107,8 +112,12 @@ fun SecurityVerificationSheet(
                     activeMeshPeerID = activeMeshPeerID,
                     peerSessionStates = peerSessionStates
                 )
+                val isVouched = !isVerified &&
+                    fingerprint?.lowercase() in vouchedFingerprints
+                val voucherNames = fingerprint?.let(viewModel::voucherNamesForFingerprint).orEmpty()
                 val statusInfo = buildStatusInfo(
                     isVerified = isVerified,
+                    isVouched = isVouched,
                     sessionState = sessionState,
                     accent = accent
                 )
@@ -136,6 +145,8 @@ fun SecurityVerificationSheet(
 
                 SecurityVerificationActions(
                     isVerified = isVerified,
+                    isVouched = isVouched,
+                    voucherNames = voucherNames,
                     fingerprint = fingerprint,
                     displayName = displayName,
                     accent = accent,
@@ -175,11 +186,13 @@ private fun SecurityVerificationHeader(
 @Composable
 private fun buildStatusInfo(
     isVerified: Boolean,
+    isVouched: Boolean,
     sessionState: String?,
     accent: Color
 ): SecurityStatusInfo {
     val text = when {
         isVerified -> stringResource(R.string.fingerprint_status_verified)
+        isVouched -> stringResource(R.string.fingerprint_status_vouched)
         sessionState == "established" -> stringResource(R.string.fingerprint_status_encrypted)
         sessionState == "handshaking" -> stringResource(R.string.fingerprint_status_handshaking)
         sessionState == "failed" -> stringResource(R.string.fingerprint_status_failed)
@@ -187,6 +200,7 @@ private fun buildStatusInfo(
     }
     val icon = when {
         isVerified -> Icons.Filled.Verified
+        isVouched -> Icons.Outlined.VerifiedUser
         sessionState == "handshaking" -> Icons.Outlined.Sync
         sessionState == "failed" -> Icons.Outlined.OutlinedWarning
         sessionState == "established" -> Icons.Filled.Lock
@@ -194,6 +208,7 @@ private fun buildStatusInfo(
     }
     val tint = when {
         isVerified -> Color(0xFF32D74B)
+        isVouched -> accent
         sessionState == "failed" -> Color(0xFFFF3B30)
         sessionState == "handshaking" -> Color(0xFFFF9500)
         sessionState == "established" -> Color(0xFF32D74B)
@@ -245,6 +260,8 @@ private fun SecurityStatusCard(
 @Composable
 private fun SecurityVerificationActions(
     isVerified: Boolean,
+    isVouched: Boolean,
+    voucherNames: List<String>,
     fingerprint: String?,
     displayName: String,
     accent: Color,
@@ -301,6 +318,34 @@ private fun SecurityVerificationActions(
             )
         }
     } else {
+        if (isVouched) {
+            VerificationStatusRow(
+                icon = Icons.Outlined.VerifiedUser,
+                iconTint = accent,
+                text = stringResource(R.string.fingerprint_vouched_label),
+                textTint = accent
+            )
+            Text(
+                text = pluralStringResource(
+                    R.plurals.fingerprint_vouched_message,
+                    voucherNames.size,
+                    voucherNames.size
+                ),
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = accent.copy(alpha = VOUCHED_SECONDARY_CONTENT_ALPHA),
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+            if (voucherNames.isNotEmpty()) {
+                Text(
+                    text = voucherNames.joinToString(),
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
         VerificationStatusRow(
             icon = Icons.Filled.Warning,
             iconTint = Color(0xFFFF9500),

--- a/app/src/main/java/com/bitchat/android/ui/VerificationHandler.kt
+++ b/app/src/main/java/com/bitchat/android/ui/VerificationHandler.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import java.security.MessageDigest
 import java.util.Date
@@ -33,20 +34,36 @@ class VerificationHandler(
     private val notificationManager: NotificationManager,
     private val messageManager: MessageManager
 ) {
+    companion object {
+        private const val FINGERPRINT_NAME_PREFIX_LENGTH = 8
+    }
+
     // Helper to get current mesh service (may change after panic clear)
     private val meshService: MeshService
         get() = getMeshService()
 
     private val _verifiedFingerprints = MutableStateFlow<Set<String>>(emptySet())
     val verifiedFingerprints: StateFlow<Set<String>> = _verifiedFingerprints.asStateFlow()
+    private val _vouchedFingerprints = MutableStateFlow<Set<String>>(emptySet())
+    val vouchedFingerprints: StateFlow<Set<String>> = _vouchedFingerprints.asStateFlow()
 
     private val pendingQRVerifications = ConcurrentHashMap<String, PendingVerification>()
     private val lastVerifyNonceByPeer = ConcurrentHashMap<String, ByteArray>()
     private val lastInboundVerifyChallengeAt = ConcurrentHashMap<String, Long>()
     private val lastMutualToastAt = ConcurrentHashMap<String, Long>()
 
+    init {
+        scope.launch {
+            SecureIdentityStateManager.changes.collect {
+                _verifiedFingerprints.value = identityManager.getVerifiedFingerprints()
+                _vouchedFingerprints.value = identityManager.getVouchedFingerprints()
+            }
+        }
+    }
+
     fun loadVerifiedFingerprints() {
         _verifiedFingerprints.value = identityManager.getVerifiedFingerprints()
+        _vouchedFingerprints.value = identityManager.getVouchedFingerprints()
     }
 
     fun isPeerVerified(peerID: String): Boolean {
@@ -59,6 +76,18 @@ class VerificationHandler(
         val fingerprint = fingerprintFromNoiseBytes(noisePublicKey)
         return _verifiedFingerprints.value.contains(fingerprint)
     }
+
+    fun isFingerprintVouched(fingerprint: String): Boolean =
+        _vouchedFingerprints.value.contains(fingerprint.lowercase())
+
+    fun vouchersForFingerprint(fingerprint: String): List<SecureIdentityStateManager.VouchRecord> =
+        identityManager.validVouchers(fingerprint)
+
+    fun voucherNamesForFingerprint(fingerprint: String): List<String> =
+        identityManager.validVouchers(fingerprint).map { record ->
+            identityManager.getCachedFingerprintNickname(record.voucherFingerprint)
+                ?: record.voucherFingerprint.take(FINGERPRINT_NAME_PREFIX_LENGTH)
+        }
 
     fun unverifyFingerprint(peerID: String) {
         val fingerprint = meshService.getPeerFingerprint(peerID) ?: return

--- a/app/src/main/java/com/bitchat/android/ui/VerificationHandler.kt
+++ b/app/src/main/java/com/bitchat/android/ui/VerificationHandler.kt
@@ -13,6 +13,8 @@ import com.bitchat.android.services.VerificationService
 import com.bitchat.android.util.dataFromHexString
 import com.bitchat.android.util.hexEncodedString
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,6 +38,7 @@ class VerificationHandler(
 ) {
     companion object {
         private const val FINGERPRINT_NAME_PREFIX_LENGTH = 8
+        private const val MINIMUM_EXPIRY_REFRESH_DELAY_MS = 1L
     }
 
     // Helper to get current mesh service (may change after panic clear)
@@ -51,19 +54,30 @@ class VerificationHandler(
     private val lastVerifyNonceByPeer = ConcurrentHashMap<String, ByteArray>()
     private val lastInboundVerifyChallengeAt = ConcurrentHashMap<String, Long>()
     private val lastMutualToastAt = ConcurrentHashMap<String, Long>()
+    private var vouchExpiryRefreshJob: Job? = null
 
     init {
         scope.launch {
             SecureIdentityStateManager.changes.collect {
-                _verifiedFingerprints.value = identityManager.getVerifiedFingerprints()
-                _vouchedFingerprints.value = identityManager.getVouchedFingerprints()
+                refreshIdentityState()
             }
         }
     }
 
     fun loadVerifiedFingerprints() {
+        refreshIdentityState()
+    }
+
+    private fun refreshIdentityState(nowMs: Long = System.currentTimeMillis()) {
         _verifiedFingerprints.value = identityManager.getVerifiedFingerprints()
-        _vouchedFingerprints.value = identityManager.getVouchedFingerprints()
+        _vouchedFingerprints.value = identityManager.getVouchedFingerprints(nowMs)
+        vouchExpiryRefreshJob?.cancel()
+        val nextExpiryMs = identityManager.nextVouchExpiryMs(nowMs) ?: return
+        val refreshDelayMs = (nextExpiryMs - nowMs).coerceAtLeast(MINIMUM_EXPIRY_REFRESH_DELAY_MS)
+        vouchExpiryRefreshJob = scope.launch {
+            delay(refreshDelayMs)
+            refreshIdentityState()
+        }
     }
 
     fun isPeerVerified(peerID: String): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -453,11 +453,17 @@
   <string name="fingerprint_pending">Handshake pending</string>
   <string name="fingerprint_no_peer">Open a private chat to view fingerprints</string>
   <string name="fingerprint_status_verified">Encrypted &amp; verified</string>
+  <string name="fingerprint_status_vouched" tools:ignore="MissingTranslation">Encrypted &amp; vouched</string>
   <string name="fingerprint_status_encrypted">Encrypted</string>
   <string name="fingerprint_status_handshaking">Handshaking</string>
   <string name="fingerprint_status_failed">Handshake failed</string>
   <string name="fingerprint_status_uninitialized">Not encrypted</string>
   <string name="fingerprint_verified_label">Verified</string>
+  <string name="fingerprint_vouched_label" tools:ignore="MissingTranslation">Vouched</string>
+  <plurals name="fingerprint_vouched_message" tools:ignore="MissingTranslation">
+    <item quantity="one">Vouched for by %1$d person you verified</item>
+    <item quantity="other">Vouched for by %1$d people you verified</item>
+  </plurals>
   <string name="fingerprint_verified_message">You have verified this person\'s identity.</string>
   <string name="fingerprint_not_verified_label">Not verified</string>
   <string name="fingerprint_not_verified_message_fmt">Compare these fingerprints with %1$s using a secure channel.</string>

--- a/app/src/test/kotlin/com/bitchat/android/identity/VouchPersistenceTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/identity/VouchPersistenceTest.kt
@@ -1,0 +1,113 @@
+package com.bitchat.android.identity
+
+import android.content.Context
+import com.bitchat.android.model.VouchAttestation
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class VouchPersistenceTest {
+    private lateinit var manager: SecureIdentityStateManager
+    private lateinit var prefs: android.content.SharedPreferences
+    private val voucher = fingerprint(VOUCHER_INDEX)
+    private val vouchee = fingerprint(VOUCHEE_INDEX)
+
+    @Before
+    fun setup() {
+        prefs = RuntimeEnvironment.getApplication().getSharedPreferences(
+            "$PREFS_PREFIX${UUID.randomUUID()}",
+            Context.MODE_PRIVATE
+        )
+        manager = SecureIdentityStateManager(prefs, testOnly = true)
+        manager.clearIdentityData()
+        manager.setVerifiedFingerprint(voucher, true)
+    }
+
+    @After
+    fun tearDown() = manager.clearIdentityData()
+
+    @Test
+    fun `vouch persists and derives trust only while voucher remains verified`() {
+        assertTrue(manager.recordVouch(vouchee, voucher, TEST_NOW_MS, TEST_NOW_MS))
+        assertTrue(manager.isVouched(vouchee, TEST_NOW_MS))
+        assertTrue(SecureIdentityStateManager(prefs, testOnly = true).isVouched(vouchee, TEST_NOW_MS))
+
+        manager.setVerifiedFingerprint(voucher, false)
+        assertFalse(manager.isVouched(vouchee, TEST_NOW_MS))
+        manager.setVerifiedFingerprint(voucher, true)
+        assertTrue(manager.isVouched(vouchee, TEST_NOW_MS))
+    }
+
+    @Test
+    fun `storage rejects self verified stale and future vouches`() {
+        assertFalse(manager.recordVouch(voucher, voucher, TEST_NOW_MS, TEST_NOW_MS))
+        manager.setVerifiedFingerprint(vouchee, true)
+        assertFalse(manager.recordVouch(vouchee, voucher, TEST_NOW_MS, TEST_NOW_MS))
+        manager.setVerifiedFingerprint(vouchee, false)
+        assertFalse(
+            manager.recordVouch(
+                vouchee,
+                voucher,
+                TEST_NOW_MS - VouchAttestation.MAX_AGE_MS - INVALID_TIME_DELTA_MS,
+                TEST_NOW_MS
+            )
+        )
+        assertFalse(
+            manager.recordVouch(
+                vouchee,
+                voucher,
+                TEST_NOW_MS + VouchAttestation.MAX_CLOCK_SKEW_MS + INVALID_TIME_DELTA_MS,
+                TEST_NOW_MS
+            )
+        )
+    }
+
+    @Test
+    fun `only the most recent bounded voucher set is retained`() {
+        repeat(SecureIdentityStateManager.MAX_VOUCHERS_PER_VOUCHEE + EXTRA_VOUCHER_COUNT) { index ->
+            val candidate = fingerprint(index + FIRST_GENERATED_VOUCHER_INDEX)
+            manager.setVerifiedFingerprint(candidate, true)
+            manager.recordVouch(vouchee, candidate, TEST_NOW_MS + index, TEST_NOW_MS)
+        }
+
+        val records = manager.validVouchers(vouchee, TEST_NOW_MS)
+        assertEquals(SecureIdentityStateManager.MAX_VOUCHERS_PER_VOUCHEE, records.size)
+        assertFalse(records.any { it.voucherFingerprint == fingerprint(FIRST_GENERATED_VOUCHER_INDEX) })
+    }
+
+    @Test
+    fun `rate limit and vouch graph clear with panic wipe`() {
+        manager.markVouchBatchSent(voucher, TEST_NOW_MS)
+        manager.recordVouch(vouchee, voucher, TEST_NOW_MS, TEST_NOW_MS)
+        assertEquals(TEST_NOW_MS, manager.lastVouchBatchSent(voucher))
+
+        manager.clearIdentityData()
+        assertEquals(null, manager.lastVouchBatchSent(voucher))
+        assertTrue(manager.validVouchers(vouchee, TEST_NOW_MS).isEmpty())
+    }
+
+    private fun fingerprint(index: Int): String =
+        index.toString(HEX_RADIX).padStart(FINGERPRINT_HEX_LENGTH, FINGERPRINT_PAD_CHAR)
+            .takeLast(FINGERPRINT_HEX_LENGTH)
+
+    companion object {
+        private const val PREFS_PREFIX = "vouch-persistence-"
+        private const val VOUCHER_INDEX = 1
+        private const val VOUCHEE_INDEX = 2
+        private const val FIRST_GENERATED_VOUCHER_INDEX = 10
+        private const val EXTRA_VOUCHER_COUNT = 2
+        private const val INVALID_TIME_DELTA_MS = 1L
+        private const val TEST_NOW_MS = 1_700_000_000_000L
+        private const val HEX_RADIX = 16
+        private const val FINGERPRINT_HEX_LENGTH = VouchAttestation.FINGERPRINT_SIZE * 2
+        private const val FINGERPRINT_PAD_CHAR = '0'
+    }
+}

--- a/app/src/test/kotlin/com/bitchat/android/identity/VouchPersistenceTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/identity/VouchPersistenceTest.kt
@@ -1,6 +1,8 @@
 package com.bitchat.android.identity
 
 import android.content.Context
+import com.bitchat.android.model.AuthenticatedPeerState
+import com.bitchat.android.model.PeerCapabilities
 import com.bitchat.android.model.VouchAttestation
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -19,6 +21,9 @@ class VouchPersistenceTest {
     private lateinit var prefs: android.content.SharedPreferences
     private val voucher = fingerprint(VOUCHER_INDEX)
     private val vouchee = fingerprint(VOUCHEE_INDEX)
+    private val voucheeSigningKey = ByteArray(VouchAttestation.SIGNING_KEY_SIZE) {
+        VOUCHEE_SIGNING_KEY_BYTE
+    }
 
     @Before
     fun setup() {
@@ -29,6 +34,10 @@ class VouchPersistenceTest {
         manager = SecureIdentityStateManager(prefs, testOnly = true)
         manager.clearIdentityData()
         manager.setVerifiedFingerprint(voucher, true)
+        manager.storeAuthenticatedPeerState(
+            vouchee,
+            AuthenticatedPeerState(PeerCapabilities.VOUCH, voucheeSigningKey)
+        )
     }
 
     @After
@@ -36,7 +45,9 @@ class VouchPersistenceTest {
 
     @Test
     fun `vouch persists and derives trust only while voucher remains verified`() {
-        assertTrue(manager.recordVouch(vouchee, voucher, TEST_NOW_MS, TEST_NOW_MS))
+        assertTrue(
+            manager.recordVouch(vouchee, voucher, voucheeSigningKey, TEST_NOW_MS, TEST_NOW_MS)
+        )
         assertTrue(manager.isVouched(vouchee, TEST_NOW_MS))
         assertTrue(SecureIdentityStateManager(prefs, testOnly = true).isVouched(vouchee, TEST_NOW_MS))
 
@@ -48,14 +59,19 @@ class VouchPersistenceTest {
 
     @Test
     fun `storage rejects self verified stale and future vouches`() {
-        assertFalse(manager.recordVouch(voucher, voucher, TEST_NOW_MS, TEST_NOW_MS))
+        assertFalse(
+            manager.recordVouch(voucher, voucher, voucheeSigningKey, TEST_NOW_MS, TEST_NOW_MS)
+        )
         manager.setVerifiedFingerprint(vouchee, true)
-        assertFalse(manager.recordVouch(vouchee, voucher, TEST_NOW_MS, TEST_NOW_MS))
+        assertFalse(
+            manager.recordVouch(vouchee, voucher, voucheeSigningKey, TEST_NOW_MS, TEST_NOW_MS)
+        )
         manager.setVerifiedFingerprint(vouchee, false)
         assertFalse(
             manager.recordVouch(
                 vouchee,
                 voucher,
+                voucheeSigningKey,
                 TEST_NOW_MS - VouchAttestation.MAX_AGE_MS - INVALID_TIME_DELTA_MS,
                 TEST_NOW_MS
             )
@@ -64,6 +80,7 @@ class VouchPersistenceTest {
             manager.recordVouch(
                 vouchee,
                 voucher,
+                voucheeSigningKey,
                 TEST_NOW_MS + VouchAttestation.MAX_CLOCK_SKEW_MS + INVALID_TIME_DELTA_MS,
                 TEST_NOW_MS
             )
@@ -75,7 +92,13 @@ class VouchPersistenceTest {
         repeat(SecureIdentityStateManager.MAX_VOUCHERS_PER_VOUCHEE + EXTRA_VOUCHER_COUNT) { index ->
             val candidate = fingerprint(index + FIRST_GENERATED_VOUCHER_INDEX)
             manager.setVerifiedFingerprint(candidate, true)
-            manager.recordVouch(vouchee, candidate, TEST_NOW_MS + index, TEST_NOW_MS)
+            manager.recordVouch(
+                vouchee,
+                candidate,
+                voucheeSigningKey,
+                TEST_NOW_MS + index,
+                TEST_NOW_MS
+            )
         }
 
         val records = manager.validVouchers(vouchee, TEST_NOW_MS)
@@ -84,14 +107,62 @@ class VouchPersistenceTest {
     }
 
     @Test
+    fun `vouch only counts for the attested authenticated signing key`() {
+        assertTrue(
+            manager.recordVouch(vouchee, voucher, voucheeSigningKey, TEST_NOW_MS, TEST_NOW_MS)
+        )
+        assertTrue(manager.isVouched(vouchee, TEST_NOW_MS))
+
+        manager.storeAuthenticatedPeerState(
+            vouchee,
+            AuthenticatedPeerState(PeerCapabilities.VOUCH, rotatedSigningKey())
+        )
+        assertFalse(manager.isVouched(vouchee, TEST_NOW_MS))
+
+        manager.storeAuthenticatedPeerState(
+            vouchee,
+            AuthenticatedPeerState(PeerCapabilities.VOUCH, voucheeSigningKey)
+        )
+        assertTrue(manager.isVouched(vouchee, TEST_NOW_MS))
+    }
+
+    @Test
+    fun `next expiry tracks when derived trust must refresh`() {
+        manager.recordVouch(vouchee, voucher, voucheeSigningKey, TEST_NOW_MS, TEST_NOW_MS)
+        val expectedExpiry = TEST_NOW_MS + VouchAttestation.MAX_AGE_MS + EXPIRY_TRANSITION_OFFSET_MS
+
+        assertEquals(expectedExpiry, manager.nextVouchExpiryMs(TEST_NOW_MS))
+        assertEquals(null, manager.nextVouchExpiryMs(expectedExpiry))
+    }
+
+    @Test
     fun `rate limit and vouch graph clear with panic wipe`() {
         manager.markVouchBatchSent(voucher, TEST_NOW_MS)
-        manager.recordVouch(vouchee, voucher, TEST_NOW_MS, TEST_NOW_MS)
+        manager.recordVouch(vouchee, voucher, voucheeSigningKey, TEST_NOW_MS, TEST_NOW_MS)
         assertEquals(TEST_NOW_MS, manager.lastVouchBatchSent(voucher))
 
         manager.clearIdentityData()
         assertEquals(null, manager.lastVouchBatchSent(voucher))
         assertTrue(manager.validVouchers(vouchee, TEST_NOW_MS).isEmpty())
+    }
+
+    @Test
+    fun `manager surviving panic cannot recreate vouch state`() {
+        val wipingManager = SecureIdentityStateManager(prefs, testOnly = true)
+        wipingManager.clearIdentityData()
+
+        assertFalse(
+            manager.recordVouch(vouchee, voucher, voucheeSigningKey, TEST_NOW_MS, TEST_NOW_MS)
+        )
+        manager.markVouchBatchSent(voucher, TEST_NOW_MS)
+
+        val reloaded = SecureIdentityStateManager(prefs, testOnly = true)
+        assertTrue(reloaded.validVouchers(vouchee, TEST_NOW_MS).isEmpty())
+        assertEquals(null, reloaded.lastVouchBatchSent(voucher))
+    }
+
+    private fun rotatedSigningKey() = ByteArray(VouchAttestation.SIGNING_KEY_SIZE) {
+        ROTATED_SIGNING_KEY_BYTE
     }
 
     private fun fingerprint(index: Int): String =
@@ -105,6 +176,9 @@ class VouchPersistenceTest {
         private const val FIRST_GENERATED_VOUCHER_INDEX = 10
         private const val EXTRA_VOUCHER_COUNT = 2
         private const val INVALID_TIME_DELTA_MS = 1L
+        private const val EXPIRY_TRANSITION_OFFSET_MS = 1L
+        private const val VOUCHEE_SIGNING_KEY_BYTE: Byte = 0x31
+        private const val ROTATED_SIGNING_KEY_BYTE: Byte = 0x32
         private const val TEST_NOW_MS = 1_700_000_000_000L
         private const val HEX_RADIX = 16
         private const val FINGERPRINT_HEX_LENGTH = VouchAttestation.FINGERPRINT_SIZE * 2

--- a/app/src/test/kotlin/com/bitchat/android/mesh/VouchCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/mesh/VouchCoordinatorTest.kt
@@ -1,0 +1,133 @@
+package com.bitchat.android.mesh
+
+import android.content.Context
+import com.bitchat.android.identity.SecureIdentityStateManager
+import com.bitchat.android.model.PeerCapabilities
+import com.bitchat.android.model.VouchAttestation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class VouchCoordinatorTest {
+    private lateinit var identity: SecureIdentityStateManager
+    private lateinit var scope: CoroutineScope
+    private val sentPayloads = mutableListOf<ByteArray>()
+    private val peerFingerprint = fingerprint(PEER_FINGERPRINT_INDEX)
+    private val voucheeFingerprint = fingerprint(VOUCHEE_FINGERPRINT_INDEX)
+    private var capabilities = PeerCapabilities.VOUCH
+
+    @Before
+    fun setup() {
+        val prefs = RuntimeEnvironment.getApplication().getSharedPreferences(
+            "$PREFS_PREFIX${UUID.randomUUID()}",
+            Context.MODE_PRIVATE
+        )
+        identity = SecureIdentityStateManager(prefs, testOnly = true)
+        identity.clearIdentityData()
+        identity.setVerifiedFingerprint(peerFingerprint, true)
+        identity.setVerifiedFingerprint(voucheeFingerprint, true)
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+        identity.clearIdentityData()
+    }
+
+    @Test
+    fun `send policy excludes recipient and persists interval`() {
+        val coordinator = coordinator()
+
+        assertTrue(coordinator.attemptVouch(PEER_ID, peerFingerprint, TEST_NOW_MS))
+        val firstBatch = VouchAttestation.decodeList(sentPayloads.single())
+        assertEquals(SINGLE_ATTESTATION_COUNT, firstBatch.size)
+        assertEquals(voucheeFingerprint, firstBatch.single().voucheeFingerprint.toHex())
+        assertFalse(
+            coordinator.attemptVouch(
+                PEER_ID,
+                peerFingerprint,
+                TEST_NOW_MS + VouchCoordinator.BATCH_INTERVAL_MS - BEFORE_INTERVAL_DELTA_MS
+            )
+        )
+        assertTrue(
+            coordinator.attemptVouch(
+                PEER_ID,
+                peerFingerprint,
+                TEST_NOW_MS + VouchCoordinator.BATCH_INTERVAL_MS
+            )
+        )
+    }
+
+    @Test
+    fun `unsupported capability blocks send but unknown remains race tolerant`() {
+        capabilities = PeerCapabilities.PRIVATE_MEDIA
+        assertFalse(coordinator().attemptVouch(PEER_ID, peerFingerprint, TEST_NOW_MS))
+
+        capabilities = PeerCapabilities.NONE
+        assertTrue(coordinator().attemptVouch(PEER_ID, peerFingerprint, TEST_NOW_MS))
+    }
+
+    private fun coordinator() = VouchCoordinator(
+        scope = scope,
+        identity = identity,
+        connectedPeerIDs = { listOf(PEER_ID) },
+        fingerprintForPeer = { peerFingerprint },
+        peerInfo = {
+            PeerInfo(
+                id = PEER_ID,
+                nickname = PEER_NICKNAME,
+                isConnected = true,
+                isDirectConnection = true,
+                noisePublicKey = ByteArray(VouchAttestation.FINGERPRINT_SIZE),
+                signingPublicKey = ByteArray(VouchAttestation.SIGNING_KEY_SIZE),
+                isVerifiedNickname = true,
+                lastSeen = TEST_NOW_MS,
+                capabilities = capabilities
+            )
+        },
+        signingKeyForFingerprint = { ByteArray(VouchAttestation.SIGNING_KEY_SIZE) },
+        hasEstablishedSession = { true },
+        sign = { ByteArray(VouchAttestation.SIGNATURE_SIZE) },
+        verify = { _, _, _ -> true },
+        send = { _, payload -> sentPayloads.add(payload) }
+    )
+
+    private fun fingerprint(index: Int): String =
+        index.toString(HEX_RADIX)
+            .padStart(FINGERPRINT_HEX_LENGTH, FINGERPRINT_PAD_CHAR)
+            .takeLast(FINGERPRINT_HEX_LENGTH)
+
+    private fun ByteArray.toHex(): String = joinToString(HEX_SEPARATOR) {
+        HEX_BYTE_FORMAT.format(it.toInt() and BYTE_MASK)
+    }
+
+    companion object {
+        private const val PREFS_PREFIX = "vouch-coordinator-"
+        private const val PEER_ID = "peer-id"
+        private const val PEER_NICKNAME = "peer"
+        private const val PEER_FINGERPRINT_INDEX = 1
+        private const val VOUCHEE_FINGERPRINT_INDEX = 2
+        private const val SINGLE_ATTESTATION_COUNT = 1
+        private const val BEFORE_INTERVAL_DELTA_MS = 1L
+        private const val TEST_NOW_MS = 1_700_000_000_000L
+        private const val HEX_RADIX = 16
+        private const val FINGERPRINT_HEX_LENGTH = VouchAttestation.FINGERPRINT_SIZE * 2
+        private const val FINGERPRINT_PAD_CHAR = '0'
+        private const val HEX_SEPARATOR = ""
+        private const val HEX_BYTE_FORMAT = "%02x"
+        private const val BYTE_MASK = 0xFF
+    }
+}

--- a/app/src/test/kotlin/com/bitchat/android/model/IdentityAnnouncementTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/model/IdentityAnnouncementTest.kt
@@ -59,17 +59,15 @@ class IdentityAnnouncementTest {
     }
 
     @Test
-    fun `local announcement send advertises private media`() {
+    fun `local announcement send advertises vouch and private media`() {
         val encoded = IdentityAnnouncement.forLocalPeer(nickname, noiseKey, signingKey).encode()!!
 
         assertArrayEquals(
-            byteArrayOf(0x05, 0x02, 0x00, 0x01),
+            byteArrayOf(0x05, 0x02, 0x20, 0x01),
             encoded.takeLast(4).toByteArray()
         )
-        assertTrue(
-            IdentityAnnouncement.decode(encoded)!!
-                .capabilities!!
-                .contains(PeerCapabilities.PRIVATE_MEDIA)
-        )
+        val capabilities = IdentityAnnouncement.decode(encoded)!!.capabilities!!
+        assertTrue(capabilities.contains(PeerCapabilities.PRIVATE_MEDIA))
+        assertTrue(capabilities.contains(PeerCapabilities.VOUCH))
     }
 }

--- a/app/src/test/kotlin/com/bitchat/android/model/VouchAttestationTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/model/VouchAttestationTest.kt
@@ -1,0 +1,89 @@
+package com.bitchat.android.model
+
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.SecureRandom
+
+class VouchAttestationTest {
+    private val privateKey = Ed25519PrivateKeyParameters(SecureRandom())
+    private val publicKey: Ed25519PublicKeyParameters = privateKey.generatePublicKey()
+    private val fingerprint = ByteArray(VouchAttestation.FINGERPRINT_SIZE) { FINGERPRINT_BYTE }
+    private val voucheeKey = ByteArray(VouchAttestation.SIGNING_KEY_SIZE) { SIGNING_KEY_BYTE }
+
+    @Test
+    fun `attestation round trips with iOS wire format and verifies`() {
+        val attestation = buildAttestation()
+        val decoded = VouchAttestation.decode(attestation.encode())!!
+
+        assertEquals(attestation, decoded)
+        assertTrue(verify(decoded.signature, decoded.signableBytes(), publicKey.encoded))
+        assertArrayEquals(fingerprint, decoded.voucheeFingerprint)
+    }
+
+    @Test
+    fun `unknown TLV is skipped but truncation is rejected`() {
+        val encoded = buildAttestation().encode()
+        val withUnknown = encoded + byteArrayOf(UNKNOWN_TLV_TYPE, UNKNOWN_TLV_LENGTH, UNKNOWN_TLV_VALUE)
+
+        assertEquals(buildAttestation(), VouchAttestation.decode(withUnknown))
+        assertEquals(null, VouchAttestation.decode(encoded.copyOf(encoded.size - TRUNCATED_BYTE_COUNT)))
+    }
+
+    @Test
+    fun `tampering and expiry are rejected`() {
+        val attestation = buildAttestation()
+        val tampered = attestation.signableBytes().copyOf().also {
+            it[it.lastIndex] = (it.last().toInt() xor TAMPER_MASK).toByte()
+        }
+        assertFalse(verify(attestation.signature, tampered, publicKey.encoded))
+        assertTrue(attestation.isExpired(TEST_TIMESTAMP_MS + VouchAttestation.MAX_AGE_MS + EXPIRY_DELTA_MS))
+        assertTrue(attestation.isExpired(TEST_TIMESTAMP_MS - VouchAttestation.MAX_CLOCK_SKEW_MS - EXPIRY_DELTA_MS))
+    }
+
+    @Test
+    fun `batch caps encoding and decoding`() {
+        val attestations = List(VouchAttestation.MAX_BATCH_COUNT) { buildAttestation() }
+        val encoded = VouchAttestation.encodeList(attestations)!!
+        assertEquals(VouchAttestation.MAX_BATCH_COUNT, VouchAttestation.decodeList(encoded).size)
+        assertEquals(null, VouchAttestation.encodeList(attestations + buildAttestation()))
+
+        val dishonestCount = encoded.copyOf().also { it[BATCH_COUNT_OFFSET] = UByte.MAX_VALUE.toByte() }
+        assertEquals(VouchAttestation.MAX_BATCH_COUNT, VouchAttestation.decodeList(dishonestCount).size)
+    }
+
+    private fun buildAttestation(): VouchAttestation =
+        requireNotNull(VouchAttestation.build(fingerprint, voucheeKey, TEST_TIMESTAMP_MS, ::sign))
+
+    private fun sign(data: ByteArray): ByteArray {
+        val signer = Ed25519Signer()
+        signer.init(true, privateKey)
+        signer.update(data, 0, data.size)
+        return signer.generateSignature()
+    }
+
+    private fun verify(signature: ByteArray, data: ByteArray, publicKey: ByteArray): Boolean {
+        val verifier = Ed25519Signer()
+        verifier.init(false, Ed25519PublicKeyParameters(publicKey, 0))
+        verifier.update(data, 0, data.size)
+        return verifier.verifySignature(signature)
+    }
+
+    companion object {
+        private const val TEST_TIMESTAMP_MS = 1_700_000_000_000L
+        private const val FINGERPRINT_BYTE: Byte = 0x11
+        private const val SIGNING_KEY_BYTE: Byte = 0x22
+        private const val UNKNOWN_TLV_TYPE: Byte = 0x7F
+        private const val UNKNOWN_TLV_LENGTH: Byte = 0x01
+        private const val UNKNOWN_TLV_VALUE: Byte = 0x42
+        private const val TRUNCATED_BYTE_COUNT = 1
+        private const val TAMPER_MASK = 0x01
+        private const val EXPIRY_DELTA_MS = 1L
+        private const val BATCH_COUNT_OFFSET = 0
+    }
+}


### PR DESCRIPTION
## Summary

- port iOS transitive verification with Noise payload type `0x12` and the vouch capability bit
- encode, sign, verify, persist, expire, and rate-limit bounded vouch attestation batches
- derive a distinct vouched trust tier and surface it in the peer list and fingerprint sheet
- retry exchange on authentication, verified announcements, and local verification changes to avoid the capability race
- ignore vouch payloads received over Nostr

## Security and compatibility

- signatures cover `bitchat-vouch-v1 | vouchee fingerprint | vouchee signing key | timestamp`
- accepts vouches only from explicitly verified Noise peers with an announce-bound Ed25519 key
- enforces the iOS 30-day expiry, 1-hour future-skew allowance, 16-entry batch bound, 8-voucher storage cap, and 24-hour send interval
- vouch trust is derived: unverifying a voucher immediately retires their attestations
- all protocol and policy values use named constants

## Validation

- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug`
- `git diff --check`

Closes #758