### PR TITLE
ui: use shared green CloseButton in private and channel headers

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatHeader.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.foundation.layout.RowScope
 import com.bitchat.android.R
 import com.bitchat.android.core.ui.component.button.BitChatBrandButton
+import com.bitchat.android.core.ui.component.button.CloseButton
 import com.bitchat.android.net.ArtiTorManager
 import com.bitchat.android.net.TorMode
 import com.bitchat.android.ui.theme.BitchatMotion
@@ -620,17 +621,7 @@ private fun ChannelHeader(
         title = "#$channel",
         onTitleClick = onSidebarClick
     ) {
-        ConversationHeaderAction(
-            onClick = onBackClick,
-            contentDescription = stringResource(R.string.close_plain)
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_spec_close),
-                contentDescription = stringResource(R.string.close_plain),
-                modifier = Modifier.size(HeaderIconSize),
-                tint = colorScheme.onSurfaceVariant
-            )
-        }
+        CloseButton(onClick = onBackClick)
     }
 }
 

--- a/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
@@ -1024,17 +1024,7 @@ fun PrivateChatSheet(
                         }
 
                         val dismiss = LocalSheetDismiss.current
-                        ConversationHeaderAction(
-                            onClick = { dismiss?.invoke() ?: onDismiss() },
-                            contentDescription = stringResource(R.string.close_plain)
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_spec_close),
-                                contentDescription = null,
-                                modifier = Modifier.size(HeaderIconSize),
-                                tint = colorScheme.onSurfaceVariant
-                            )
-                        }
+                        CloseButton(onClick = { dismiss?.invoke() ?: onDismiss() })
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Replace muted grey `ic_spec_close` actions in private and channel conversation headers with the shared sheet `CloseButton`
- Keeps exit chrome consistent with bottom sheets (primary green X, no background)

## Test plan
- [ ] Open a private chat and confirm the header X is primary green
- [ ] Open a channel chat and confirm the header X matches
- [ ] Confirm close still dismisses the conversation as before


Made with [Cursor](https://cursor.com)