### PR TITLE
Fix onboarding skip-button jump between permission screens

### DIFF
--- a/app/src/main/java/com/bitchat/android/onboarding/BackgroundLocationPermissionScreen.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/BackgroundLocationPermissionScreen.kt
@@ -37,6 +37,9 @@ import com.bitchat.android.R
 
 /**
  * Explanation screen shown before requesting background location permission.
+ *
+ * Bottom action layout matches [BatteryOptimizationEnabledContent] so the
+ * primary / check-again / skip buttons stay pixel-aligned across the two screens.
  */
 @Composable
 fun BackgroundLocationPermissionScreen(
@@ -46,132 +49,125 @@ fun BackgroundLocationPermissionScreen(
     onSkip: () -> Unit
 ) {
     val colorScheme = MaterialTheme.colorScheme
-    val scrollState = rememberScrollState()
 
-    Box(modifier = modifier) {
+    Box(
+        modifier = modifier.padding(24.dp),
+        contentAlignment = Alignment.Center
+    ) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 88.dp)
-                .verticalScroll(scrollState),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            modifier = Modifier.fillMaxSize()
         ) {
-            Spacer(modifier = Modifier.height(24.dp))
-
-            HeaderSection(colorScheme)
-
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = colorScheme.surfaceVariant.copy(alpha = 0.25f),
-                shape = RoundedCornerShape(12.dp)
-            ) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.Top,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.LocationOn,
-                            contentDescription = stringResource(R.string.cd_location_services),
-                            tint = colorScheme.primary,
-                            modifier = Modifier
-                                .padding(top = 2.dp)
-                                .size(20.dp)
-                        )
-                        Column {
-                            Text(
-                                text = stringResource(R.string.background_location_required_title),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Medium,
-                                color = colorScheme.onBackground
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                text = stringResource(R.string.background_location_explanation),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = colorScheme.onBackground.copy(alpha = 0.8f)
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = stringResource(R.string.background_location_settings_tip),
-                                style = MaterialTheme.typography.bodySmall.copy(
-                                    fontFamily = BitchatFontFamily
-                                ),
-                                color = colorScheme.onBackground.copy(alpha = 0.8f)
-                            )
-                        }
-                    }
-                }
-            }
-
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = colorScheme.surfaceVariant.copy(alpha = 0.25f),
-                shape = RoundedCornerShape(12.dp)
-            ) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.Top,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Security,
-                            contentDescription = stringResource(R.string.cd_privacy_protected),
-                            tint = colorScheme.primary,
-                            modifier = Modifier
-                                .padding(top = 2.dp)
-                                .size(20.dp)
-                        )
-                        Column {
-                            Text(
-                                text = stringResource(R.string.background_location_needs_for),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Medium,
-                                color = colorScheme.onBackground
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                text = stringResource(R.string.background_location_needs_bullets),
-                                style = MaterialTheme.typography.bodySmall,
-                                fontFamily = BitchatFontFamily,
-                                color = colorScheme.onBackground.copy(alpha = 0.8f)
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = stringResource(R.string.background_location_privacy_note),
-                                style = MaterialTheme.typography.bodySmall.copy(
-                                    fontFamily = BitchatFontFamily,
-                                    fontWeight = FontWeight.Medium
-                                ),
-                                color = colorScheme.onBackground
-                            )
-                        }
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
-        }
-
-        Surface(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth(),
-            color = colorScheme.surface,
-            shadowElevation = 8.dp
-        ) {
+            // Scrollable content area
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(bottom = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                HeaderSection(colorScheme)
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = colorScheme.surfaceVariant.copy(alpha = 0.25f),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.Top,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.LocationOn,
+                                contentDescription = stringResource(R.string.cd_location_services),
+                                tint = colorScheme.primary,
+                                modifier = Modifier
+                                    .padding(top = 2.dp)
+                                    .size(20.dp)
+                            )
+                            Column {
+                                Text(
+                                    text = stringResource(R.string.background_location_required_title),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.Medium,
+                                    color = colorScheme.onBackground
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = stringResource(R.string.background_location_explanation),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = colorScheme.onBackground.copy(alpha = 0.8f)
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = stringResource(R.string.background_location_settings_tip),
+                                    style = MaterialTheme.typography.bodySmall.copy(
+                                        fontFamily = BitchatFontFamily
+                                    ),
+                                    color = colorScheme.onBackground.copy(alpha = 0.8f)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = colorScheme.surfaceVariant.copy(alpha = 0.25f),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.Top,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Security,
+                                contentDescription = stringResource(R.string.cd_privacy_protected),
+                                tint = colorScheme.primary,
+                                modifier = Modifier
+                                    .padding(top = 2.dp)
+                                    .size(20.dp)
+                            )
+                            Column {
+                                Text(
+                                    text = stringResource(R.string.background_location_needs_for),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.Medium,
+                                    color = colorScheme.onBackground
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = stringResource(R.string.background_location_needs_bullets),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    fontFamily = BitchatFontFamily,
+                                    color = colorScheme.onBackground.copy(alpha = 0.8f)
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = stringResource(R.string.background_location_privacy_note),
+                                    style = MaterialTheme.typography.bodySmall.copy(
+                                        fontFamily = BitchatFontFamily,
+                                        fontWeight = FontWeight.Medium
+                                    ),
+                                    color = colorScheme.onBackground
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Fixed buttons at the bottom — same structure/spacing as battery optimization
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Button(
                     onClick = onContinue,
@@ -185,8 +181,7 @@ fun BackgroundLocationPermissionScreen(
                         style = MaterialTheme.typography.bodyMedium.copy(
                             fontFamily = BitchatFontFamily,
                             fontWeight = FontWeight.Bold
-                        ),
-                        modifier = Modifier.padding(vertical = 4.dp)
+                        )
                     )
                 }
 

--- a/app/src/main/java/com/bitchat/android/onboarding/BackgroundLocationPermissionScreen.kt
+++ b/app/src/main/java/com/bitchat/android/onboarding/BackgroundLocationPermissionScreen.kt
@@ -38,8 +38,8 @@ import com.bitchat.android.R
 /**
  * Explanation screen shown before requesting background location permission.
  *
- * Bottom action layout matches [BatteryOptimizationEnabledContent] so the
- * primary / check-again / skip buttons stay pixel-aligned across the two screens.
+ * Bottom action layout matches the battery optimization skip screen so the
+ * primary / check-again / skip buttons stay pixel-aligned across both screens.
  */
 @Composable
 fun BackgroundLocationPermissionScreen(


### PR DESCRIPTION
## Summary
- Align the background location onboarding footer with the battery optimization skip screen layout (`24.dp` outer padding, weighted scroll content, fixed bottom actions with `12.dp` spacing).
- Remove the elevated footer surface and extra primary-button text padding that made the buttons jump when moving between the two screens.

## Test plan
- [ ] Fresh install / clear onboarding prefs and walk through battery optimization → background location (or skip path that hits both).
- [ ] Confirm primary / Check again / Skip for now stay pixel-aligned with no vertical jump between screens.
- [ ] Confirm scrolling still works on the background location screen with long content.
- [ ] Confirm skip and grant actions still work on both screens.


Made with [Cursor](https://cursor.com)