### PR TITLE
fix(panic): clear in-memory networking caches, router outbox, and Nostr queues on panic wipe (#807)

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -1583,6 +1583,7 @@ class BluetoothMeshService(private val context: Context) : TransportBridgeServic
             securityManager.clearAllData()
             peerManager.clearAllPeers()
             peerManager.clearAllFingerprints()
+            try { gossipSyncManager.clear() } catch (_: Exception) { }
         } catch (e: Exception) {
             Log.e(TAG, "Error clearing mesh service internal data: ${e.message}")
         }

--- a/app/src/main/java/com/bitchat/android/mesh/MeshCore.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/MeshCore.kt
@@ -987,6 +987,7 @@ class MeshCore(
         securityManager.clearAllData()
         peerManager.clearAllPeers()
         peerManager.clearAllFingerprints()
+        try { gossipSyncManager.clear() } catch (_: Exception) { }
     }
 
     fun clearAllEncryptionData() {

--- a/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrRelayManager.kt
@@ -679,6 +679,24 @@ class NostrRelayManager private constructor() {
             Log.e(TAG, "Failed to clear subscriptions: ${e.message}")
         }
     }
+
+    /**
+     * Clear all subscription tracking, deduplication cache, message queue, and connections for panic mode.
+     */
+    fun clearAllOnPanic() {
+        try {
+            val wasConnected = desiredConnected.get()
+            clearAllSubscriptions()
+            clearDeduplicationCache()
+            disconnect()
+            if (wasConnected) {
+                desiredConnected.set(true)
+            }
+            Log.w(TAG, "🚨 Cleared NostrRelayManager subscriptions, cache, and connections for panic mode")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to clear NostrRelayManager on panic: ${e.message}")
+        }
+    }
     
     /**
      * Get detailed status for all relays

--- a/app/src/main/java/com/bitchat/android/service/MeshServiceHolder.kt
+++ b/app/src/main/java/com/bitchat/android/service/MeshServiceHolder.kt
@@ -136,6 +136,7 @@ object MeshServiceHolder {
     @Synchronized
     fun clear() {
         android.util.Log.d(TAG, "Clearing BluetoothMeshService from holder")
+        try { sharedGossipSyncManager?.clear() } catch (_: Exception) { }
         try { sharedGossipSyncManager?.stop() } catch (_: Exception) { }
         sharedGossipSyncManager = null
         activeGossipOwners.clear()

--- a/app/src/main/java/com/bitchat/android/services/MessageRouter.kt
+++ b/app/src/main/java/com/bitchat/android/services/MessageRouter.kt
@@ -99,6 +99,12 @@ class MessageRouter private constructor(
         startOutboxScheduler()
     }
 
+    fun clearAll() {
+        outbox.clear()
+        retryState.clear()
+        Log.d(TAG, "Cleared all MessageRouter outbox messages and retry state")
+    }
+
     // Listener for favorites changes to flush outbox when npub mapping appears/changes
     private val favoriteListener = object: com.bitchat.android.favorites.FavoritesChangeListener {
 

--- a/app/src/main/java/com/bitchat/android/sync/GossipSyncManager.kt
+++ b/app/src/main/java/com/bitchat/android/sync/GossipSyncManager.kt
@@ -79,6 +79,15 @@ class GossipSyncManager(
         cleanupJob?.cancel(); cleanupJob = null
     }
 
+    @Synchronized
+    fun clear() {
+        synchronized(messages) {
+            messages.clear()
+        }
+        latestAnnouncementByPeer.clear()
+        Log.d(TAG, "Cleared all gossip sync messages and announcements")
+    }
+
     fun scheduleInitialSync(delayMs: Long = 5_000L) {
         scope.launch(Dispatchers.IO) {
             delay(delayMs)

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -1445,9 +1445,12 @@ class ChatViewModel(
         dataManager.clearAllData()
         conversationListPreferences.clearAll()
         
-        // Clear seen message store
+        // Clear seen message store and MessageRouter outbox
         try {
             com.bitchat.android.services.SeenMessageStore.getInstance(getApplication()).clear()
+        } catch (_: Exception) { }
+        try {
+            com.bitchat.android.services.MessageRouter.tryGetInstance()?.clearAll()
         } catch (_: Exception) { }
         
         // Clear all cryptographic data

--- a/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/GeohashViewModel.kt
@@ -119,6 +119,8 @@ class GeohashViewModel(
         geoTimer = null
         try { NostrIdentityBridge.clearAllAssociations(getApplication()) } catch (_: Exception) {}
         NostrBackgroundRuntime.resetSubscriptions()
+        try { com.bitchat.android.nostr.NostrRelayManager.getInstance(getApplication()).clearAllOnPanic() } catch (_: Exception) {}
+        try { com.bitchat.android.nostr.LocationNotesManager.getInstance().stop() } catch (_: Exception) {}
     }
 
     fun sendGeohashMessage(content: String, channel: com.bitchat.android.geohash.GeohashChannel, myPeerID: String, nickname: String?) {


### PR DESCRIPTION
# Description
Fixes Panic Mode data leakage where previously sent/received messages would reappear in the chat UI after sending a new message post-panic wipe (#807).

### Root Cause
Panic Mode previously wiped persistent storage (`ConversationDatabase`) and primary UI state stores (`AppStateStore`, `ChatState`), but left in-memory networking queues active:
- `GossipSyncManager` retained cached broadcast messages and peer announcements.
- `MessageRouter` retained queued outbox messages awaiting retry.
- `NostrRelayManager` retained pending message queues, deduplication caches, and active WebSocket subscriptions.

When a user sent a new message post-wipe, transport sync ticks and outbox retry handlers re-admitted pre-panic messages back into `AppStateStore`.

### Implementation Summary
- Added `clear()` to `GossipSyncManager` to purge stored broadcast packets and peer announcements.
- Added `clearAll()` to `MessageRouter` to purge outbox retry queues.
- Added `clearAllOnPanic()` to `NostrRelayManager` to disconnect, clear subscriptions, deduplication caches, and message queues.
- Stopped `LocationNotesManager` in `panicReset()`.
- Chained all in-memory network purges into `ChatViewModel.performPanicClearAllData()`, `BluetoothMeshService.clearAllInternalData()`, `MeshCore.clearAllInternalData()`, `MeshServiceHolder.clear()`, and `GeohashViewModel.panicReset()`.

## Checklist
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
- [x] I have mentioned the corresponding issue and the relevant keyword (Closes: #807) in the description
- [x] If it is a core feature, I have added automated tests
