### PR TITLE
Prevent private messages from merging across conversations

### DIFF
--- a/app/src/main/java/com/bitchat/android/services/AppStateStore.kt
+++ b/app/src/main/java/com/bitchat/android/services/AppStateStore.kt
@@ -280,11 +280,7 @@ object AppStateStore {
             counts[conversationID] = (counts[conversationID] ?: 0) + 1
             _unreadPrivateMessageCounts.value = counts
         }
-        val aliases = runCatching {
-            ContactDirectory.aliasesForConversation(peerID) +
-                ContactDirectory.aliasesForConversation(conversationID) +
-                listOfNotNull(msg.senderPeerID)
-        }.getOrDefault(setOf(peerID, conversationID))
+        val aliases = privateConversationAliases(peerID, conversationID)
         val displayName = ContactDirectory.resolve(conversationID).displayName
             ?: msg.sender.takeUnless {
                 it.isBlank() || it == "system" || it == _nickname.value
@@ -320,11 +316,7 @@ object AppStateStore {
             _selectedPrivateChatPeer.value
                 ?.let(ContactDirectory::canonicalConversationId)
                 ?.equals(conversationID, ignoreCase = true) == true
-        val aliases = runCatching {
-            ContactDirectory.aliasesForConversation(peerID) +
-                ContactDirectory.aliasesForConversation(conversationID) +
-                listOfNotNull(msg.senderPeerID)
-        }.getOrDefault(setOf(peerID, conversationID))
+        val aliases = privateConversationAliases(peerID, conversationID)
         val displayName = ContactDirectory.resolve(conversationID).displayName
             ?: (existingMessages + msg)
                 .lastOrNull { candidate ->
@@ -342,6 +334,20 @@ object AppStateStore {
             generation = privateConversationGeneration
         )
     }
+
+    /**
+     * Derive aliases from the routed conversation, never from the message author.
+     *
+     * For outgoing messages senderPeerID is our own ID, which is shared by every private chat.
+     * Persisting it as an alias would merge otherwise unrelated conversation histories.
+     */
+    private fun privateConversationAliases(
+        peerID: String,
+        conversationID: String
+    ): Set<String> = runCatching {
+        ContactDirectory.aliasesForConversation(peerID) +
+            ContactDirectory.aliasesForConversation(conversationID)
+    }.getOrDefault(setOf(peerID, conversationID))
 
     fun hasSeenMessage(messageID: String): Boolean = synchronized(this) {
         messageID in seenMessageIds

--- a/app/src/test/kotlin/com/bitchat/android/services/IncomingMessageAdmissionTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/services/IncomingMessageAdmissionTest.kt
@@ -186,6 +186,51 @@ class IncomingMessageAdmissionTest {
     }
 
     @Test
+    fun `outgoing messages to different peers keep separate persisted conversations`() {
+        val state = ChatState(TestScope())
+        state.setNickname("me")
+        val manager = PrivateChatManager(
+            state = state,
+            messageManager = MessageManager(state),
+            dataManager = DataManager(context),
+            noiseSessionDelegate = testNoiseDelegate()
+        )
+
+        runBlocking {
+            assertTrue(
+                manager.sendPrivateMessageDurably(
+                    content = "only for alice",
+                    peerID = "peer-a",
+                    recipientNickname = "alice",
+                    senderNickname = "me",
+                    myPeerID = "self"
+                ) { _, _, _, _ -> }
+            )
+            assertTrue(
+                manager.sendPrivateMessageDurably(
+                    content = "only for bob",
+                    peerID = "peer-b",
+                    recipientNickname = "bob",
+                    senderNickname = "me",
+                    myPeerID = "self"
+                ) { _, _, _, _ -> }
+            )
+
+            val alice = repository.loadConversationAndWait("peer-a")
+            val bob = repository.loadConversationAndWait("peer-b")
+
+            assertEquals(
+                listOf("only for alice"),
+                alice?.chats?.getValue("peer-a")?.map { it.content }
+            )
+            assertEquals(
+                listOf("only for bob"),
+                bob?.chats?.getValue("peer-b")?.map { it.content }
+            )
+        }
+    }
+
+    @Test
     fun `outgoing callback is suppressed when durable storage fails`() {
         val failingRepository = ConversationRepository(
             context = context,


### PR DESCRIPTION
## Summary

- derive persistence aliases only from the routed conversation and canonical contact aliases
- stop treating the message author as a conversation alias; outgoing messages use the same local peer ID in every chat, which could merge contact A and contact B
- add an end-to-end regression that sends durable messages to two peers with one local identity and reloads both persisted histories

## Testing

- `./gradlew :app:testDebugUnitTest` — 524 tests passed
- Mesh Lab: not run. Its two-device DM scenario covers one counterpart, while reproducing two distinct contacts requires a third device or the data-clearing identity-reset flow.

## Scope

This prevents future cross-conversation merges. It intentionally does not guess how to split histories already merged on affected installs: persisted outgoing rows do not retain a reliable remote peer ID, so an automatic repair could misroute or delete private history.