### PR TITLE
Fix Wear chat auto-scroll timing

### DIFF
--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -42,6 +42,8 @@ import com.bitchat.android.model.BitchatMessage
 import com.bitchat.watch.ui.theme.BitchatMotion
 import com.bitchat.watch.ui.theme.ChatVisualTokens
 import com.bitchat.watch.ui.theme.LocalBitchatPalette
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 
 /**
  * The shared chat body for global chat and DM threads, following the classic messenger
@@ -106,11 +108,19 @@ fun ChatScaffold(
     }
 
     // Stick to bottom: follow new messages while resting at the newest.
+    // Capture this when the message count changes, before the new layout can temporarily make
+    // canScrollForward true and report that the user is browsing history.
+    val followNewest = remember(messages.size) { atNewest }
     LaunchedEffect(columnState, messages.size) {
-        if (messages.isNotEmpty() && atNewest) {
-            // scrollBy to the end of the range: animateScrollToItem stops as soon as the
-            // item is partially visible, which left the last message cropped.
-            columnState.scroll { scrollBy(Float.MAX_VALUE) }
+        if (messages.isNotEmpty() && followNewest) {
+            scrollToNewestAfterItemsMeasured(
+                expectedItemCount = messages.size,
+                measuredItemCounts = snapshotFlow { columnState.layoutInfo.totalItemsCount }
+            ) {
+                // scrollBy to the end of the range: animateScrollToItem stops as soon as the
+                // item is partially visible, which left the last message cropped.
+                columnState.scroll { scrollBy(Float.MAX_VALUE) }
+            }
         }
     }
 
@@ -126,6 +136,15 @@ fun ChatScaffold(
         actionBar = actionBar,
         modifier = Modifier.fillMaxSize()
     )
+}
+
+internal suspend fun scrollToNewestAfterItemsMeasured(
+    expectedItemCount: Int,
+    measuredItemCounts: Flow<Int>,
+    scrollToEnd: suspend () -> Unit
+) {
+    measuredItemCounts.first { it >= expectedItemCount }
+    scrollToEnd()
 }
 
 @Composable

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -113,9 +113,21 @@ fun ChatScaffold(
     val followNewest = remember(messages.size) { atNewest }
     LaunchedEffect(columnState, messages.size) {
         if (messages.isNotEmpty() && followNewest) {
+            val expectedSingleMessageKey = messages.singleOrNull()?.id
             scrollToNewestAfterItemsMeasured(
                 expectedItemCount = messages.size,
-                measuredItemCounts = snapshotFlow { columnState.layoutInfo.totalItemsCount }
+                expectedSingleMessageKey = expectedSingleMessageKey,
+                measuredLayouts = snapshotFlow {
+                    val layoutInfo = columnState.layoutInfo
+                    MeasuredChatLayout(
+                        itemCount = layoutInfo.totalItemsCount,
+                        singleVisibleItemKey = if (expectedSingleMessageKey != null) {
+                            layoutInfo.visibleItems.singleOrNull()?.key
+                        } else {
+                            null
+                        }
+                    )
+                }
             ) {
                 // scrollBy to the end of the range: animateScrollToItem stops as soon as the
                 // item is partially visible, which left the last message cropped.
@@ -138,12 +150,22 @@ fun ChatScaffold(
     )
 }
 
+internal data class MeasuredChatLayout(
+    val itemCount: Int,
+    val singleVisibleItemKey: Any?
+)
+
 internal suspend fun scrollToNewestAfterItemsMeasured(
     expectedItemCount: Int,
-    measuredItemCounts: Flow<Int>,
+    expectedSingleMessageKey: Any?,
+    measuredLayouts: Flow<MeasuredChatLayout>,
     scrollToEnd: suspend () -> Unit
 ) {
-    measuredItemCounts.first { it >= expectedItemCount }
+    measuredLayouts.first { layout ->
+        layout.itemCount >= expectedItemCount &&
+            (expectedSingleMessageKey == null ||
+                layout.singleVisibleItemKey == expectedSingleMessageKey)
+    }
     scrollToEnd()
 }
 

--- a/wear/src/test/java/com/bitchat/watch/ui/ChatAutoScrollTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/ChatAutoScrollTest.kt
@@ -12,13 +12,14 @@ class ChatAutoScrollTest {
 
     @Test
     fun `newest scroll waits until appended message is measured`() = runTest {
-        val measuredItemCount = MutableStateFlow(3)
+        val measuredLayouts = MutableStateFlow(MeasuredChatLayout(3, null))
         var scrollCount = 0
 
         val scrollJob = launch(start = CoroutineStart.UNDISPATCHED) {
             scrollToNewestAfterItemsMeasured(
                 expectedItemCount = 4,
-                measuredItemCounts = measuredItemCount
+                expectedSingleMessageKey = null,
+                measuredLayouts = measuredLayouts
             ) {
                 scrollCount += 1
             }
@@ -27,7 +28,7 @@ class ChatAutoScrollTest {
         assertFalse(scrollJob.isCompleted)
         assertEquals(0, scrollCount)
 
-        measuredItemCount.value = 4
+        measuredLayouts.value = MeasuredChatLayout(4, null)
         scrollJob.join()
 
         assertEquals(1, scrollCount)
@@ -35,15 +36,46 @@ class ChatAutoScrollTest {
 
     @Test
     fun `newest scroll runs immediately when messages are already measured`() = runTest {
-        val measuredItemCount = MutableStateFlow(4)
+        val measuredLayouts = MutableStateFlow(MeasuredChatLayout(4, null))
         var scrollCount = 0
 
         scrollToNewestAfterItemsMeasured(
             expectedItemCount = 4,
-            measuredItemCounts = measuredItemCount
+            expectedSingleMessageKey = null,
+            measuredLayouts = measuredLayouts
         ) {
             scrollCount += 1
         }
+
+        assertEquals(1, scrollCount)
+    }
+
+    @Test
+    fun `first message waits past stale empty placeholder layout`() = runTest {
+        val messageKey = "first-message"
+        val measuredLayouts = MutableStateFlow(
+            MeasuredChatLayout(itemCount = 1, singleVisibleItemKey = "empty-placeholder")
+        )
+        var scrollCount = 0
+
+        val scrollJob = launch(start = CoroutineStart.UNDISPATCHED) {
+            scrollToNewestAfterItemsMeasured(
+                expectedItemCount = 1,
+                expectedSingleMessageKey = messageKey,
+                measuredLayouts = measuredLayouts
+            ) {
+                scrollCount += 1
+            }
+        }
+
+        assertFalse(scrollJob.isCompleted)
+        assertEquals(0, scrollCount)
+
+        measuredLayouts.value = MeasuredChatLayout(
+            itemCount = 1,
+            singleVisibleItemKey = messageKey
+        )
+        scrollJob.join()
 
         assertEquals(1, scrollCount)
     }

--- a/wear/src/test/java/com/bitchat/watch/ui/ChatAutoScrollTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/ChatAutoScrollTest.kt
@@ -1,0 +1,50 @@
+package com.bitchat.watch.ui
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ChatAutoScrollTest {
+
+    @Test
+    fun `newest scroll waits until appended message is measured`() = runTest {
+        val measuredItemCount = MutableStateFlow(3)
+        var scrollCount = 0
+
+        val scrollJob = launch(start = CoroutineStart.UNDISPATCHED) {
+            scrollToNewestAfterItemsMeasured(
+                expectedItemCount = 4,
+                measuredItemCounts = measuredItemCount
+            ) {
+                scrollCount += 1
+            }
+        }
+
+        assertFalse(scrollJob.isCompleted)
+        assertEquals(0, scrollCount)
+
+        measuredItemCount.value = 4
+        scrollJob.join()
+
+        assertEquals(1, scrollCount)
+    }
+
+    @Test
+    fun `newest scroll runs immediately when messages are already measured`() = runTest {
+        val measuredItemCount = MutableStateFlow(4)
+        var scrollCount = 0
+
+        scrollToNewestAfterItemsMeasured(
+            expectedItemCount = 4,
+            measuredItemCounts = measuredItemCount
+        ) {
+            scrollCount += 1
+        }
+
+        assertEquals(1, scrollCount)
+    }
+}


### PR DESCRIPTION
# Description

Fix Wear public chats and DMs failing to follow the newest message when message data and lazy-list measurement complete in different frames.

The shared chat scaffold now:

- captures whether the conversation was following the newest message before a message-count update
- waits until `TransformingLazyColumn` has measured the updated item count before scrolling
- keeps the existing exact scroll-to-end behavior so the final message is not partially cropped

## Risk

Low and isolated to Wear Compose scroll coordination. Users browsing older messages remain in place because auto-scroll is still gated by the pre-update newest-message state.

## Tests

- `./gradlew :wear:testDebugUnitTest --tests com.bitchat.watch.ui.ChatAutoScrollTest`
- `./gradlew testDebugUnitTest lintDebug :wear:assembleDebug`

The focused tests cover both a stale measured count and an already-current layout. An initial full-suite run hit the existing intermittent `FragmentManagerTest.test reassembly`; that test passed immediately in isolation and the complete command passed on rerun.

## Visual review

Compared the merge base and this branch on Wear OS 6.1 / Android 16 (API 36) at 384 × 384 with 14 deterministic synthetic messages injected after the empty chat rendered.

The race did not reproduce in that emulator run: both captures were pixel-identical and showed the newest synthetic message. This is a behavioral timing change rather than a styling change, so the coroutine regression test is the reliable evidence. Screenshots and raw emulator output remain local and were not uploaded.

## Checklist

- [ ] I have read the contribution guidelines
- [x] I have performed a self-review of my code
- [ ] No corresponding issue; reported directly
- [x] I have added automated regression tests
