### PR TITLE
Hide the command and mention popups after a message is sent

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -386,6 +386,9 @@ fun ChatScreen(viewModel: ChatViewModel) {
                     if (accepted) {
                         messageText = TextFieldValue("")
                         viewModel.setConversationDraft(selectedPrivatePeer, "")
+                        // Clearing the field in code does not run onMessageTextChange,
+                        // so the popups have to be dismissed here.
+                        viewModel.clearSuggestions()
                         forceScrollToBottom = !forceScrollToBottom
                     }
                 }

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -1341,7 +1341,11 @@ class ChatViewModel(
     fun updateCommandSuggestions(input: String) {
         commandProcessor.updateCommandSuggestions(input)
     }
-    
+
+    fun clearSuggestions() {
+        commandProcessor.clearSuggestions()
+    }
+
     fun selectCommandSuggestion(suggestion: CommandSuggestion): String {
         return commandProcessor.selectCommandSuggestion(suggestion)
     }

--- a/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
+++ b/app/src/main/java/com/bitchat/android/ui/CommandProcessor.kt
@@ -465,6 +465,18 @@ class CommandProcessor(
         messageManager.addMessage(systemMessage)
     }
     
+    /**
+     * Dismiss the command and mention popups. The composer clears its field in code
+     * after a send, which does not run onValueChange, so the popups need an explicit
+     * clear.
+     */
+    fun clearSuggestions() {
+        state.setShowCommandSuggestions(false)
+        state.setCommandSuggestions(emptyList())
+        state.setShowMentionSuggestions(false)
+        state.setMentionSuggestions(emptyList())
+    }
+
     // MARK: - Command Autocomplete
 
     fun updateCommandSuggestions(input: String) {

--- a/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
+++ b/app/src/main/java/com/bitchat/android/ui/MeshPeerListSheet.kt
@@ -1849,7 +1849,9 @@ fun PrivateChatSheet(
                         onMessageTextChange = { newText ->
                             messageText = newText
                             viewModel.setConversationDraft(peerID, newText.text)
-                            viewModel.updateMentionSuggestions(newText.text)
+                            // Do not update the shared suggestion state here: this sheet
+                            // renders its own popups as hidden, so an update only leaves
+                            // a stale popup behind for the main composer.
                         },
                         onSend = {
                             if (messageText.text.trim().isNotEmpty()) {

--- a/app/src/test/java/com/bitchat/android/ui/CommandProcessorTest.kt
+++ b/app/src/test/java/com/bitchat/android/ui/CommandProcessorTest.kt
@@ -8,6 +8,7 @@ import com.bitchat.android.geohash.GeohashChannelLevel
 import com.bitchat.android.mesh.MeshService
 import com.bitchat.android.model.BitchatMessage
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -160,5 +161,31 @@ class CommandProcessorTest() {
       chatState.getChannelMessagesValue()["geo:$geohash"]?.single()?.content
     )
     assertEquals(0, chatState.getMessagesValue().size)
+  }
+
+  @Test
+  fun `clearSuggestions hides the command suggestion popup`() {
+    // Typing "/" opens the command popup.
+    commandProcessor.updateCommandSuggestions("/")
+    assertTrue(chatState.getShowCommandSuggestionsValue())
+
+    // The send handlers call this after clearing the field in code, which does
+    // not run the text-change handler that normally hides the popup.
+    commandProcessor.clearSuggestions()
+    assertFalse(chatState.getShowCommandSuggestionsValue())
+    assertTrue(chatState.getCommandSuggestionsValue().isEmpty())
+  }
+
+  @Test
+  fun `clearSuggestions hides the mention suggestion popup`() {
+    whenever(meshService.getPeerNicknames()).thenReturn(mapOf("peer-1" to "alice"))
+
+    // Typing "@a" opens the mention popup.
+    commandProcessor.updateMentionSuggestions("@a", meshService, viewModel = null)
+    assertTrue(chatState.getShowMentionSuggestionsValue())
+
+    commandProcessor.clearSuggestions()
+    assertFalse(chatState.getShowMentionSuggestionsValue())
+    assertTrue(chatState.getMentionSuggestionsValue().isEmpty())
   }
 }


### PR DESCRIPTION
# Description

When you type a slash command and send it without tapping the autocomplete list, the command popup stays on screen with its old suggestions. The send path clears the input field in code, and the popup is hidden only from the field's text-change handler, which a code-driven clear does not run, so the flag that shows the popup is never turned off. The mention popup (the `@name` list) has the same cause.

Fixes #250.

## Changes

**Add `CommandProcessor.clearSuggestions()` and call it from `ChatScreen`'s send handler.** The new function hides both popups and empties their suggestion lists, the same resets `selectCommandSuggestion` and `selectMentionSuggestion` already do inline. `ChatViewModel` exposes it next to the other suggestion methods, and the send handler calls it where the field is already cleared.

**Stop the private chat sheet from feeding the shared suggestion state.** That composer called `updateMentionSuggestions` on every keystroke while rendering its own popups as hidden, so the only effect was on the main composer behind it: typing `@` in the sheet and then sending or dismissing left a stale mention popup on the main screen. The sheet keeps its draft handling and drops that call.

## Tests

Two cases in `CommandProcessorTest`:
- `clearSuggestions hides the command suggestion popup` opens the popup with `/`, calls `clearSuggestions()`, and asserts the popup is hidden and its list empty.
- `clearSuggestions hides the mention suggestion popup` does the same for the mention popup, opened with `@a` against a stub peer.

These cover the function the send handler calls. The unit tests here do not drive Compose, so the send handler itself is not exercised.

## Validation

- `./gradlew testDebugUnitTest`: 736 tests, 0 failures, 3 pre-existing skips.
- `./gradlew lintDebug`: passes, no new issues on the changed files.
- `./gradlew assembleDebug`: builds.
- Reproduced on an Android 15 emulator: on main, sending `/w` leaves the popup on screen over the cleared field; with this change the popup is dismissed. Screenshots below.

## Does not do

No change to sending, to what the suggestions contain, or to how the popups open while typing in the main composer. Voice, image, and file sends are untouched.

## Checklist
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [x] If it is a core feature, I have added automated tests
