### PR TITLE
Remove periodic GATT RSSI polling

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothGattClientManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothGattClientManager.kt
@@ -95,9 +95,6 @@ class BluetoothGattClientManager(
     private var scanWatchdogJob: Job? = null
     private var scanDutyCycleJob: Job? = null
     
-    // RSSI monitoring state
-    private var rssiMonitoringJob: Job? = null
-    
     // State management
     private var isActive = false
     
@@ -133,8 +130,6 @@ class BluetoothGattClientManager(
         
         connectionScope.launch {
             applyPowerProfile(powerManager.profile.value)
-            // Start RSSI monitoring
-            startRSSIMonitoring()
         }
         
         return true
@@ -151,7 +146,6 @@ class BluetoothGattClientManager(
         if (!isActive) {
             // Idempotent stop
             stopScanning()
-            stopRSSIMonitoring()
             return
         }
 
@@ -167,7 +161,6 @@ class BluetoothGattClientManager(
             } catch (_: Exception) { }
             
             stopScanning()
-            stopRSSIMonitoring()
             Log.i(TAG, "GATT client manager stopped")
         }
     }
@@ -183,40 +176,6 @@ class BluetoothGattClientManager(
         } else {
             stopScanning()
         }
-    }
-    
-    /**
-     * Start periodic RSSI monitoring for all client connections
-     */
-    private fun startRSSIMonitoring() {
-        rssiMonitoringJob?.cancel()
-        rssiMonitoringJob = connectionScope.launch {
-            while (isActive) {
-                try {
-                    // Request RSSI from all client connections
-                    val connectedDevices = connectionTracker.getConnectedDevices()
-                    connectedDevices.values.filter { it.isClient && it.gatt != null }.forEach { deviceConn ->
-                        try {
-                            deviceConn.gatt?.readRemoteRssi()
-                        } catch (e: Exception) {
-                            Log.d(TAG, "Failed to request RSSI from ${deviceConn.device.address}: ${e.message}")
-                        }
-                    }
-                    delay(powerManager.profile.value.ble.rssiPollIntervalMs)
-                } catch (e: Exception) {
-                    Log.w(TAG, "Error in RSSI monitoring: ${e.message}")
-                    delay(powerManager.profile.value.ble.rssiPollIntervalMs)
-                }
-            }
-        }
-    }
-    
-    /**
-     * Stop RSSI monitoring
-     */
-    private fun stopRSSIMonitoring() {
-        rssiMonitoringJob?.cancel()
-        rssiMonitoringJob = null
     }
     
     /**
@@ -627,17 +586,6 @@ class BluetoothGattClientManager(
                 }
             }
             
-            override fun onReadRemoteRssi(gatt: BluetoothGatt, rssi: Int, status: Int) {
-                val deviceAddress = gatt.device.address
-                if (status == BluetoothGatt.GATT_SUCCESS) {
-                    // Update the connection tracker with new RSSI value
-                    connectionTracker.updateDeviceConnectionIfCurrent(deviceAddress, linkID) {
-                        it.copy(rssi = rssi)
-                    }
-                } else {
-                    Log.d(TAG, "Failed to read RSSI for $deviceAddress, status: $status")
-                }
-            }
         }
         
         try {

--- a/app/src/main/java/com/bitchat/android/mesh/PowerManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/PowerManager.kt
@@ -46,7 +46,6 @@ class PowerManager private constructor(context: Context) : LifecycleEventObserve
         val scanOnMs: Long,
         val scanOffMs: Long,
         val continuousScan: Boolean,
-        val rssiPollIntervalMs: Long,
         val maxConnections: Int = 8
     )
 
@@ -318,24 +317,22 @@ internal object PowerProfileResolver {
                 PowerManager.BleSchedule(
                     scanOnMs = 1_000L,
                     scanOffMs = 29_000L,
-                    continuousScan = false,
-                    rssiPollIntervalMs = backgroundRssiInterval(batteryBand)
+                    continuousScan = false
                 )
             isBackground ->
                 PowerManager.BleSchedule(
                     scanOnMs = 1_000L,
                     scanOffMs = 59_000L,
-                    continuousScan = false,
-                    rssiPollIntervalMs = backgroundRssiInterval(batteryBand)
+                    continuousScan = false
                 )
             mode == PowerManager.PowerMode.PERFORMANCE ->
-                PowerManager.BleSchedule(Long.MAX_VALUE, 0L, true, 5_000L)
+                PowerManager.BleSchedule(Long.MAX_VALUE, 0L, true)
             mode == PowerManager.PowerMode.BALANCED ->
-                PowerManager.BleSchedule(8_000L, 2_000L, false, 10_000L)
+                PowerManager.BleSchedule(8_000L, 2_000L, false)
             mode == PowerManager.PowerMode.POWER_SAVER ->
-                PowerManager.BleSchedule(2_000L, 28_000L, false, 30_000L)
+                PowerManager.BleSchedule(2_000L, 28_000L, false)
             else ->
-                PowerManager.BleSchedule(1_000L, 29_000L, false, 60_000L)
+                PowerManager.BleSchedule(1_000L, 29_000L, false)
         }
 
         val announcementInterval = when {
@@ -407,10 +404,4 @@ internal object PowerProfileResolver {
         discoverySessionRefreshMinMs = minRefreshMinutes * 60_000L,
         discoveryStaleMs = staleMinutes * 60_000L
     )
-
-    private fun backgroundRssiInterval(band: PowerManager.BatteryBand): Long = when (band) {
-        PowerManager.BatteryBand.NORMAL -> 60_000L
-        PowerManager.BatteryBand.LOW -> 120_000L
-        PowerManager.BatteryBand.CRITICAL -> 300_000L
-    }
 }

--- a/app/src/main/java/com/bitchat/android/util/AppConstants.kt
+++ b/app/src/main/java/com/bitchat/android/util/AppConstants.kt
@@ -23,9 +23,6 @@ object AppConstants {
         const val CONNECTION_CLEANUP_INTERVAL_MS: Long = 30_000L
         const val BROADCAST_CLEANUP_DELAY_MS: Long = 500L
 
-        // GATT client RSSI updates
-        const val RSSI_UPDATE_INTERVAL_MS: Long = 5_000L
-
         object Gatt {
             val SERVICE_UUID: UUID = UUID.fromString("F47B5E2D-4A9E-4C5A-9B3F-8E1D2C3A4B5C")
             val CHARACTERISTIC_UUID: UUID = UUID.fromString("A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D")


### PR DESCRIPTION
## Summary

- stop periodically calling `readRemoteRssi()` for active GATT client links
- remove the unused RSSI polling intervals from power profiles
- preserve scan-result RSSI for peer discovery, weak-signal filtering, and diagnostic snapshots

## Behavior and risk

Connected-link RSSI no longer refreshes after connection. Core discovery, connection management, routing, and messaging continue using the existing scan and transport paths. No UI layout changes are included, so screenshots are not applicable.

## Validation

- `./gradlew :app:assembleDebug :wear:assembleDebug testDebugUnitTest lintDebug clientRewriteContractTest`
- Mesh Lab: blocked (not run). Its required setup clears app data and changes device settings, and that destructive device authorization was not included in this request.