### PR TITLE
Re-sync suggestion popups when the composer text is set in code

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -100,11 +100,14 @@ fun ChatScreen(viewModel: ChatViewModel) {
     var isScrolledUp by remember { mutableStateOf(false) }
 
     LaunchedEffect(selectedPrivatePeer) {
-        messageText = TextFieldValue(
-            selectedPrivatePeer
-                ?.let(viewModel::conversationDraft)
-                .orEmpty()
-        )
+        val draft = selectedPrivatePeer
+            ?.let(viewModel::conversationDraft)
+            .orEmpty()
+        messageText = TextFieldValue(draft)
+        // Setting the field in code does not run onMessageTextChange, so the
+        // popups have to be re-synced with the restored draft here.
+        viewModel.updateCommandSuggestions(draft)
+        viewModel.updateMentionSuggestions(draft)
     }
 
     // Show password dialog when needed
@@ -342,6 +345,11 @@ fun ChatScreen(viewModel: ChatViewModel) {
                         text = newText,
                         selection = TextRange(newText.length)
                     )
+                    // Setting the field in code does not run onMessageTextChange, so
+                    // the popups have to be re-synced with the new text here. The
+                    // inserted mention ends with a space, which hides an open popup.
+                    viewModel.updateCommandSuggestions(newText)
+                    viewModel.updateMentionSuggestions(newText)
                 },
                 onMessageLongPress = { message ->
                     // Message long press - open user action sheet with message context

--- a/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatScreen.kt
@@ -348,6 +348,9 @@ fun ChatScreen(viewModel: ChatViewModel) {
                     // Setting the field in code does not run onMessageTextChange, so
                     // the popups have to be re-synced with the new text here. The
                     // inserted mention ends with a space, which hides an open popup.
+                    // The draft write is skipped the same way; without it, switching
+                    // conversations restores the field without the tapped-in mention.
+                    viewModel.setConversationDraft(selectedPrivatePeer, newText)
                     viewModel.updateCommandSuggestions(newText)
                     viewModel.updateMentionSuggestions(newText)
                 },
@@ -439,6 +442,12 @@ fun ChatScreen(viewModel: ChatViewModel) {
                         text = commandText,
                         selection = TextRange(commandText.length)
                     )
+                    // A code-driven edit skips onMessageTextChange: persist the
+                    // draft and re-sync both popups, same as the other
+                    // programmatic-edit sites.
+                    viewModel.setConversationDraft(selectedPrivatePeer, commandText)
+                    viewModel.updateCommandSuggestions(commandText)
+                    viewModel.updateMentionSuggestions(commandText)
                 },
                 onMentionSuggestionClick = { mention: String ->
                     val mentionText = viewModel.selectMentionSuggestion(mention, messageText.text)
@@ -446,6 +455,12 @@ fun ChatScreen(viewModel: ChatViewModel) {
                         text = mentionText,
                         selection = TextRange(mentionText.length)
                     )
+                    // A code-driven edit skips onMessageTextChange: persist the
+                    // draft and re-sync both popups, same as the other
+                    // programmatic-edit sites.
+                    viewModel.setConversationDraft(selectedPrivatePeer, mentionText)
+                    viewModel.updateCommandSuggestions(mentionText)
+                    viewModel.updateMentionSuggestions(mentionText)
                 },
                 selectedPrivatePeer = null,
                 currentChannel = currentChannel,

--- a/app/src/test/java/com/bitchat/android/ui/CommandProcessorTest.kt
+++ b/app/src/test/java/com/bitchat/android/ui/CommandProcessorTest.kt
@@ -219,6 +219,20 @@ class CommandProcessorTest() {
   }
 
   @Test
+  fun `command suggestions close once the input grows past the command`() {
+    // The command popup only shows while the whole input is a prefix of a
+    // command name or alias, and none of them contains a space or an @. An
+    // input that can match the mention popup has already closed the command
+    // popup.
+    commandProcessor.updateCommandSuggestions("/m")
+    assertTrue(chatState.getShowCommandSuggestionsValue())
+
+    commandProcessor.updateCommandSuggestions("/msg @ali")
+    assertFalse(chatState.getShowCommandSuggestionsValue())
+    assertTrue(chatState.getCommandSuggestionsValue().isEmpty())
+  }
+
+  @Test
   fun `a restored command draft reopens the command popup`() {
     // Switching conversations restores the draft in code; re-syncing with the
     // restored text brings the popup back for a command draft.

--- a/app/src/test/java/com/bitchat/android/ui/CommandProcessorTest.kt
+++ b/app/src/test/java/com/bitchat/android/ui/CommandProcessorTest.kt
@@ -188,4 +188,48 @@ class CommandProcessorTest() {
     assertFalse(chatState.getShowMentionSuggestionsValue())
     assertTrue(chatState.getMentionSuggestionsValue().isEmpty())
   }
+
+  @Test
+  fun `text set to an inserted mention hides both popups`() {
+    // A command popup is open while the user taps a nickname in the message list.
+    commandProcessor.updateCommandSuggestions("/")
+    assertTrue(chatState.getShowCommandSuggestionsValue())
+
+    // The composer re-syncs both popups with the inserted text, which ends in a
+    // space, so neither popup matches it.
+    commandProcessor.updateCommandSuggestions("/ @alice ")
+    commandProcessor.updateMentionSuggestions("/ @alice ", meshService, viewModel = null)
+    assertFalse(chatState.getShowCommandSuggestionsValue())
+    assertTrue(chatState.getCommandSuggestionsValue().isEmpty())
+    assertFalse(chatState.getShowMentionSuggestionsValue())
+    assertTrue(chatState.getMentionSuggestionsValue().isEmpty())
+  }
+
+  @Test
+  fun `a mention followed by a space no longer matches the mention popup`() {
+    whenever(meshService.myPeerID).thenReturn("me")
+    whenever(meshService.getPeerNicknames()).thenReturn(mapOf("peer-1" to "alice"))
+
+    commandProcessor.updateMentionSuggestions("@a", meshService, viewModel = null)
+    assertTrue(chatState.getShowMentionSuggestionsValue())
+
+    commandProcessor.updateMentionSuggestions("@alice ", meshService, viewModel = null)
+    assertFalse(chatState.getShowMentionSuggestionsValue())
+    assertTrue(chatState.getMentionSuggestionsValue().isEmpty())
+  }
+
+  @Test
+  fun `a restored command draft reopens the command popup`() {
+    // Switching conversations restores the draft in code; re-syncing with the
+    // restored text brings the popup back for a command draft.
+    commandProcessor.updateCommandSuggestions("/j")
+    assertTrue(chatState.getShowCommandSuggestionsValue())
+    assertTrue(chatState.getCommandSuggestionsValue().isNotEmpty())
+
+    // An empty restored draft leaves both popups hidden.
+    commandProcessor.updateCommandSuggestions("")
+    commandProcessor.updateMentionSuggestions("", meshService, viewModel = null)
+    assertFalse(chatState.getShowCommandSuggestionsValue())
+    assertFalse(chatState.getShowMentionSuggestionsValue())
+  }
 }


### PR DESCRIPTION
# Description

When a suggestion popup is open and the app sets the composer text itself, the popup stays up over the new text. The popups are updated only from the field's text-change handler, which a code-driven change does not run. #847 fixed this for the send path, the case #250 reported. While working on that fix, two more places with the same older bug were found:

- Tapping a nickname in the message list, which inserts `@name ` into the field.
- Switching private conversations, which restores that conversation's draft into the field.

## Changes

**Re-sync both popups with the new text at both sites.** Instead of a blanket clear, each site calls `updateCommandSuggestions` and `updateMentionSuggestions` with the text it just set, the same calls the text-change handler makes while typing. The popup state then always matches the field content: an inserted mention ends with a space, so an open popup hides, and a restored draft that starts with `/` brings the command popup back the way typing it would.

The iOS app already works this way: its composer drives autocomplete from `onChange(of: messageText)`, which runs for code-driven changes too, so a mention insert or a restored draft re-syncs the popup there. This change brings Android to the same behavior.

## Tests

Three cases in `CommandProcessorTest`:
- `text set to an inserted mention hides both popups` pins the nickname-tap shape (`/ @alice `).
- `a mention followed by a space no longer matches the mention popup` pins the trailing-space rule the fix relies on.
- `a restored command draft reopens the command popup` pins the draft-restore behavior for a command draft and for an empty draft.

The unit tests do not drive Compose, so they cover the functions the two sites call rather than the sites themselves.

## Validation

- `./gradlew testDebugUnitTest`: 748 tests, 0 failures, 3 pre-existing skips.
- `./gradlew lintDebug`: passes, no new issues on the changed files.
- `./gradlew assembleDebug`: builds.

Both sites need a second peer to reach from the UI (a nickname on someone else's message, or a private conversation), so I could not walk them on a single emulator the way #847's send path was walked. The behavior each site relies on is pinned by the tests above.

## Does not do

No change to how the popups behave while typing, to sending, or to what the suggestions contain. The send-path dismissal from #847 is untouched.

## Checklist
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>) — no issue exists for these two; found while working on #250 (PR #847)
- [x] If it is a core feature, I have added automated tests
