### PR TITLE
docs: flag MAX_PAYLOAD_LENGTH must stay in sync with iOS

### DIFF
--- a/app/src/main/java/com/bitchat/android/util/AppConstants.kt
+++ b/app/src/main/java/com/bitchat/android/util/AppConstants.kt
@@ -67,6 +67,9 @@ object AppConstants {
 
     object Protocol {
         const val COMPRESSION_THRESHOLD_BYTES: Int = 100
+        // MUST stay in sync with iOS's FileTransferLimits.maxFramedFileBytes
+        // (LocalPackages/BitFoundation/Sources/BitFoundation/FileTransferLimits.swift in permissionlesstech/bitchat).
+        // Reference issue #1618, which fixed a mismatch where iOS's ceiling was ~1.13 MiB instead of 10 MiB.
         const val MAX_PAYLOAD_LENGTH: Int = 10_485_760
     }
 


### PR DESCRIPTION
Companion to permissionlesstech/bitchat#1618, which raised iOS's decompressed payload ceiling from ~1.13 MiB to 10 MiB to match this constant. Adding a comment here so the next change to either constant doesn't silently reintroduce the cross-platform mismatch.

Refs #1618

# Description

This is a documentation-only companion to permissionlesstech/bitchat#1618. That issue was caused by iOS's `FileTransferLimits.maxFramedFileBytes` (~1.13 MiB) and Android's `MAX_PAYLOAD_LENGTH` (10 MiB) silently going out of sync, which caused legitimate large compressed messages from Android to be silently dropped on iOS. The iOS PR raised its ceiling to 10 MiB to match this constant.

This PR adds a comment above `MAX_PAYLOAD_LENGTH` here noting it must stay in sync with iOS's `FileTransferLimits.maxFramedFileBytes`, so the next change to either value doesn't silently reintroduce the mismatch. No value or behavior change.

## Checklist
<!--
  To help us keep the issue tracker clean and work as efficient as possible,
  please make sure that you have done all of the following.
  You can tick the boxes below by placing an x inside the brackets like this: [x]
-->
- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
<!-- - [ ] I have run the automated code checks using `./gradlew checkstyle spotbugsPlayDebug spotbugsDebug :app:lintPlayDebug` -->
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests