### PR TITLE
fix: use Android plurals for the "nearby peers" notification body

### DIFF
--- a/app/src/main/java/com/bitchat/android/service/PeerAvailabilityNotifier.kt
+++ b/app/src/main/java/com/bitchat/android/service/PeerAvailabilityNotifier.kt
@@ -145,11 +145,11 @@ private class AndroidPeerAvailabilityTextProvider(
     }
 
     override fun body(peerCount: Int): String {
-        return if (peerCount == 1) {
-            context.getString(R.string.notification_active_peers_one)
-        } else {
-            context.getString(R.string.notification_active_peers_many, peerCount)
-        }
+        return context.resources.getQuantityString(
+            R.plurals.notification_active_peers_body,
+            peerCount,
+            peerCount
+        )
     }
 }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d رسالة من %2$d أشخاص</string>
     <string name="notification_more_conversations">و%1$d محادثات أخرى</string>
     <string name="notification_active_peers_title">مستخدمون قريبون!</string>
-    <string name="notification_active_peers_one">شخص واحد قريب</string>
-    <string name="notification_active_peers_many">%1$d أشخاص قريبون</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">شخص واحد قريب</item>
+        <item quantity="other">%1$d أشخاص قريبون</item>
+    </plurals>
     <string name="notification_new_messages">رسائل جديدة</string>
     <string name="notification_new_location_messages">رسائل موقع جديدة</string>
     <string name="notification_mentions_in">تم ذكرك في %1$s</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%2$d জন থেকে %1$d বার্তা</string>
     <string name="notification_more_conversations">এবং %1$d আরো কথোপকথন</string>
     <string name="notification_active_peers_title">কাছাকাছি bitchatter!</string>
-    <string name="notification_active_peers_one">কাছাকাছি ১ জন</string>
-    <string name="notification_active_peers_many">কাছাকাছি %1$d জন</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">কাছাকাছি ১ জন</item>
+        <item quantity="other">কাছাকাছি %1$d জন</item>
+    </plurals>
     <string name="notification_new_messages">নতুন বার্তা</string>
     <string name="notification_new_location_messages">নতুন অবস্থান বার্তা</string>
     <string name="notification_mentions_in">%1$s এ উল্লিখিত</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d Nachrichten von %2$d Personen</string>
     <string name="notification_more_conversations">und %1$d weitere Unterhaltungen</string>
     <string name="notification_active_peers_title">bitchatter in der Nähe!</string>
-    <string name="notification_active_peers_one">1 Person in der Nähe</string>
-    <string name="notification_active_peers_many">%1$d Personen in der Nähe</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 Person in der Nähe</item>
+        <item quantity="other">%1$d Personen in der Nähe</item>
+    </plurals>
     <string name="notification_new_messages">Neue Nachrichten</string>
     <string name="notification_new_location_messages">Neue Standort‑Nachrichten</string>
     <string name="notification_mentions_in">Erwähnt in %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d mensajes de %2$d personas</string>
     <string name="notification_more_conversations">y %1$d conversaciones más</string>
     <string name="notification_active_peers_title">¡bitchatters cerca!</string>
-    <string name="notification_active_peers_one">1 persona cerca</string>
-    <string name="notification_active_peers_many">%1$d personas cerca</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 persona cerca</item>
+        <item quantity="other">%1$d personas cerca</item>
+    </plurals>
     <string name="notification_new_messages">Nuevos mensajes</string>
     <string name="notification_new_location_messages">Nuevos mensajes de ubicación</string>
     <string name="notification_mentions_in">Mencionado en %1$s</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d پیام از %2$d نفر</string>
     <string name="notification_more_conversations">و %1$d گفت‌وگوی دیگر</string>
     <string name="notification_active_peers_title">کاربران bitchat در نزدیکی!</string>
-    <string name="notification_active_peers_one">۱ نفر در نزدیکی</string>
-    <string name="notification_active_peers_many">%1$d نفر در نزدیکی</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">۱ نفر در نزدیکی</item>
+        <item quantity="other">%1$d نفر در نزدیکی</item>
+    </plurals>
     <string name="notification_new_messages">پیام‌های جدید</string>
     <string name="notification_new_location_messages">پیام‌های مکانی جدید</string>
     <string name="notification_mentions_in">ذکر شده در %1$s</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d mensahe mula sa %2$d tao</string>
     <string name="notification_more_conversations">at %1$d pang usapan</string>
     <string name="notification_active_peers_title">mga bitchatter na malapit!</string>
-    <string name="notification_active_peers_one">1 tao sa paligid</string>
-    <string name="notification_active_peers_many">%1$d tao sa paligid</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 tao sa paligid</item>
+        <item quantity="other">%1$d tao sa paligid</item>
+    </plurals>
     <string name="notification_new_messages">Mga bagong mensahe</string>
     <string name="notification_new_location_messages">Mga mensahe sa lokasyon</string>
     <string name="notification_mentions_in">Nabanggit sa %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d messages de %2$d personnes</string>
     <string name="notification_more_conversations">et %1$d conversations de plus</string>
     <string name="notification_active_peers_title">bitchatters à proximité !</string>
-    <string name="notification_active_peers_one">1 personne à proximité</string>
-    <string name="notification_active_peers_many">%1$d personnes à proximité</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 personne à proximité</item>
+        <item quantity="other">%1$d personnes à proximité</item>
+    </plurals>
     <string name="notification_new_messages">Nouveaux messages</string>
     <string name="notification_new_location_messages">Nouveaux messages de lieu</string>
     <string name="notification_mentions_in">Mentionné dans %1$s</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -93,8 +93,10 @@
   <string name="notification_messages_from_people">%1$d הודעות מ-%2$d אנשים</string>
   <string name="notification_more_conversations">ועוד %1$d שיחות</string>
   <string name="notification_active_peers_title">👥 יש בצ׳אטרים בקרבת מקום!</string>
-  <string name="notification_active_peers_one">אדם אחד בסביבה</string>
-  <string name="notification_active_peers_many">%1$d אנשים בסביבה</string>
+  <plurals name="notification_active_peers_body">
+      <item quantity="one">אדם אחד בסביבה</item>
+      <item quantity="other">%1$d אנשים בסביבה</item>
+  </plurals>
   <string name="notification_new_messages">הודעות חדשות</string>
   <string name="notification_new_location_messages">הודעות מיקום חדשות</string>
   <string name="notification_mentions_in">אוזכרת ב-%1$s</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%2$d लोगों से %1$d संदेश</string>
     <string name="notification_more_conversations">और %1$d वार्तालाप</string>
     <string name="notification_active_peers_title">पास में उपयोगकर्ता!</string>
-    <string name="notification_active_peers_one">पास में 1 व्यक्ति</string>
-    <string name="notification_active_peers_many">पास में %1$d लोग</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">पास में 1 व्यक्ति</item>
+        <item quantity="other">पास में %1$d लोग</item>
+    </plurals>
     <string name="notification_new_messages">नए संदेश</string>
     <string name="notification_new_location_messages">नई स्थान संदेश</string>
     <string name="notification_mentions_in">%1$s में उल्लेख</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d pesan dari %2$d orang</string>
     <string name="notification_more_conversations">dan %1$d percakapan lagi</string>
     <string name="notification_active_peers_title">bitchatter terdekat!</string>
-    <string name="notification_active_peers_one">1 orang terdekat</string>
-    <string name="notification_active_peers_many">%1$d orang terdekat</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 orang terdekat</item>
+        <item quantity="other">%1$d orang terdekat</item>
+    </plurals>
     <string name="notification_new_messages">Pesan baru</string>
     <string name="notification_new_location_messages">Pesan lokasi baru</string>
     <string name="notification_mentions_in">Disebut di %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d messaggi da %2$d persone</string>
     <string name="notification_more_conversations">e altre %1$d conversazioni</string>
     <string name="notification_active_peers_title">bitchatter nelle vicinanze!</string>
-    <string name="notification_active_peers_one">1 persona nei dintorni</string>
-    <string name="notification_active_peers_many">%1$d persone nei dintorni</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 persona nei dintorni</item>
+        <item quantity="other">%1$d persone nei dintorni</item>
+    </plurals>
     <string name="notification_new_messages">Nuovi messaggi</string>
     <string name="notification_new_location_messages">Nuovi messaggi di posizione</string>
     <string name="notification_mentions_in">Menzionato in %1$s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%2$d 人からの %1$d 件のメッセージ</string>
     <string name="notification_more_conversations">ほか %1$d 会話</string>
     <string name="notification_active_peers_title">近くに bitchatter ！</string>
-    <string name="notification_active_peers_one">近くに 1 人</string>
-    <string name="notification_active_peers_many">近くに %1$d 人</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">近くに 1 人</item>
+        <item quantity="other">近くに %1$d 人</item>
+    </plurals>
     <string name="notification_new_messages">新着メッセージ</string>
     <string name="notification_new_location_messages">新しい位置情報メッセージ</string>
     <string name="notification_mentions_in">%1$s でのメンション</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%2$d ადამიანიდან %1$d შეტყობინება</string>
     <string name="notification_more_conversations">და კიდევ %1$d საუბარი</string>
     <string name="notification_active_peers_title">bitchatter-ები ახლოს!</string>
-    <string name="notification_active_peers_one">1 ადამიანი ახლოს</string>
-    <string name="notification_active_peers_many">ახლოს %1$d ადამიანი</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 ადამიანი ახლოს</item>
+        <item quantity="other">ახლოს %1$d ადამიანი</item>
+    </plurals>
     <string name="notification_new_messages">ახალი შეტყობინებები</string>
     <string name="notification_new_location_messages">მდებარეობის ახალი შეტყობინებები</string>
     <string name="notification_mentions_in">ხსენება %1$s-ში</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%2$d명에게서 %1$d개의 메시지</string>
     <string name="notification_more_conversations">그리고 %1$d개의 대화 더</string>
     <string name="notification_active_peers_title">근처 bitchatter!</string>
-    <string name="notification_active_peers_one">근처 1명</string>
-    <string name="notification_active_peers_many">근처 %1$d명</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">근처 1명</item>
+        <item quantity="other">근처 %1$d명</item>
+    </plurals>
     <string name="notification_new_messages">새 메시지</string>
     <string name="notification_new_location_messages">새 위치 메시지</string>
     <string name="notification_mentions_in">%1$s에서 언급됨</string>

--- a/app/src/main/res/values-mg/strings.xml
+++ b/app/src/main/res/values-mg/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d hafatra avy amin\'ny olona %2$d</string>
     <string name="notification_more_conversations">ary %1$d resaka hafa</string>
     <string name="notification_active_peers_title">bitchatter akaiky!</string>
-    <string name="notification_active_peers_one">Olona 1 manodidina</string>
-    <string name="notification_active_peers_many">Olona %1$d manodidina</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">Olona 1 manodidina</item>
+        <item quantity="other">Olona %1$d manodidina</item>
+    </plurals>
     <string name="notification_new_messages">Hafatra vaovao</string>
     <string name="notification_new_location_messages">Hafatra Toerana Vaovao</string>
     <string name="notification_mentions_in">Voatonona ao amin\'ny %1$s</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -44,8 +44,10 @@
   <string name="notification_messages_from_people">%1$d mesej daripada %2$d orang</string>
   <string name="notification_more_conversations">dan %1$d perbualan lagi</string>
   <string name="notification_active_peers_title">👥 bitchatter berdekatan!</string>
-  <string name="notification_active_peers_one">1 orang berdekatan</string>
-  <string name="notification_active_peers_many">%1$d orang berdekatan</string>
+  <plurals name="notification_active_peers_body">
+      <item quantity="one">1 orang berdekatan</item>
+      <item quantity="other">%1$d orang berdekatan</item>
+  </plurals>
   <string name="notification_new_messages">Mesej Baharu</string>
   <string name="notification_new_location_messages">Mesej Lokasi Baharu</string>
   <string name="notification_mentions_in">Disebut dalam %1$s</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d सन्देश %2$d जनाबाट</string>
     <string name="notification_more_conversations">र %1$d अरू कुराकानी</string>
     <string name="notification_active_peers_title">नजिकै bitchatter हरू!</string>
-    <string name="notification_active_peers_one">१ जना नजिकै</string>
-    <string name="notification_active_peers_many">%1$d जना नजिकै</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">१ जना नजिकै</item>
+        <item quantity="other">%1$d जना नजिकै</item>
+    </plurals>
     <string name="notification_new_messages">नयाँ सन्देश</string>
     <string name="notification_new_location_messages">नयाँ स्थान सन्देश</string>
     <string name="notification_mentions_in">%1$s मा उल्लेख</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d berichten van %2$d personen</string>
     <string name="notification_more_conversations">en %1$d meer conversaties</string>
     <string name="notification_active_peers_title">bitchatters in de buurt!</string>
-    <string name="notification_active_peers_one">1 persoon in de buurt</string>
-    <string name="notification_active_peers_many">%1$d personen in de buurt</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 persoon in de buurt</item>
+        <item quantity="other">%1$d personen in de buurt</item>
+    </plurals>
     <string name="notification_new_messages">Nieuwe berichten</string>
     <string name="notification_new_location_messages">Nieuwe locatieberichten</string>
     <string name="notification_mentions_in">Vermeld in %1$s</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%2$d لوکان کولوں %1$d پیغام</string>
     <string name="notification_more_conversations">تے %1$d ہور گلاں</string>
     <string name="notification_active_peers_title">نیڑے bitchatter!</string>
-    <string name="notification_active_peers_one">نیڑے 1 بندہ</string>
-    <string name="notification_active_peers_many">نیڑے %1$d بندے</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">نیڑے 1 بندہ</item>
+        <item quantity="other">نیڑے %1$d بندے</item>
+    </plurals>
     <string name="notification_new_messages">نویں پیغام</string>
     <string name="notification_new_location_messages">نویں لوکیشن پیغام</string>
     <string name="notification_mentions_in">%1$s وچ ذکر ہویا</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -95,8 +95,10 @@
     <string name="notification_messages_from_people">%1$d wiadomości od %2$d osób</string>
     <string name="notification_more_conversations">i jeszcze %1$d rozmów</string>
     <string name="notification_active_peers_title">👥 bitchatowicze w pobliżu!</string>
-    <string name="notification_active_peers_one">1 osoba w pobliżu</string>
-    <string name="notification_active_peers_many">%1$d osób w pobliżu</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 osoba w pobliżu</item>
+        <item quantity="other">%1$d osób w pobliżu</item>
+    </plurals>
     <string name="notification_new_messages">Nowe wiadomości</string>
     <string name="notification_new_location_messages">Nowe wiadomości lokalizacyjne</string>
     <string name="notification_mentions_in">Wzmianka w %1$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d mensagens de %2$d pessoas</string>
     <string name="notification_more_conversations">e mais %1$d conversas</string>
     <string name="notification_active_peers_title">pessoas do bitchat por perto!</string>
-    <string name="notification_active_peers_one">1 pessoa por perto</string>
-    <string name="notification_active_peers_many">%1$d pessoas por perto</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 pessoa por perto</item>
+        <item quantity="other">%1$d pessoas por perto</item>
+    </plurals>
     <string name="notification_new_messages">Novas mensagens</string>
     <string name="notification_new_location_messages">Novas mensagens de localização</string>
     <string name="notification_mentions_in">Mencionado em %1$s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d mensagens de %2$d pessoas</string>
     <string name="notification_more_conversations">e mais %1$d conversas</string>
     <string name="notification_active_peers_title">bitchatters por perto!</string>
-    <string name="notification_active_peers_one">1 pessoa por perto</string>
-    <string name="notification_active_peers_many">%1$d pessoas por perto</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 pessoa por perto</item>
+        <item quantity="other">%1$d pessoas por perto</item>
+    </plurals>
     <string name="notification_new_messages">Novas mensagens</string>
     <string name="notification_new_location_messages">Novas mensagens de localização</string>
     <string name="notification_mentions_in">Mencionado em %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -41,8 +41,10 @@
     <string name="notification_messages_from_people">%1$d сообщений от %2$d людей</string>
     <string name="notification_more_conversations">и ещё %1$d бесед</string>
     <string name="notification_active_peers_title">bitchatter рядом!</string>
-    <string name="notification_active_peers_one">Рядом 1 человек</string>
-    <string name="notification_active_peers_many">Рядом %1$d человек</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">Рядом 1 человек</item>
+        <item quantity="other">Рядом %1$d человек</item>
+    </plurals>
     <string name="notification_new_messages">Новые сообщения</string>
     <string name="notification_new_location_messages">Новые сообщения локаций</string>
     <string name="notification_mentions_in">Упоминание в %1$s</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -41,8 +41,10 @@
     <string name="notification_messages_from_people">%1$d meddelanden från %2$d personer</string>
     <string name="notification_more_conversations">och %1$d fler konversationer</string>
     <string name="notification_active_peers_title">bitchatter i närheten!</string>
-    <string name="notification_active_peers_one">1 person i närheten</string>
-    <string name="notification_active_peers_many">%1$d personer i närheten</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 person i närheten</item>
+        <item quantity="other">%1$d personer i närheten</item>
+    </plurals>
     <string name="notification_new_messages">Nya meddelanden</string>
     <string name="notification_new_location_messages">Nya platsmeddelanden</string>
     <string name="notification_mentions_in">Nämnd i %1$s</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -79,8 +79,10 @@
   <string name="notification_messages_from_people">%2$d நபர்களிடமிருந்து %1$d செய்திகள்</string>
   <string name="notification_more_conversations">மற்றும் %1$d மேலும் உரையாடல்கள்</string>
   <string name="notification_active_peers_title">👥 அருகில் bitchatters!</string>
-  <string name="notification_active_peers_one">1 நபர் அருகில் உள்ளார்</string>
-  <string name="notification_active_peers_many">%1$d நபர்கள் அருகில் உள்ளனர்</string>
+  <plurals name="notification_active_peers_body">
+      <item quantity="one">1 நபர் அருகில் உள்ளார்</item>
+      <item quantity="other">%1$d நபர்கள் அருகில் உள்ளனர்</item>
+  </plurals>
   <string name="notification_new_messages">புதிய செய்திகள்</string>
   <string name="notification_new_location_messages">புதிய இருப்பிட செய்திகள்</string>
   <string name="notification_mentions_in">%1$s இல் குறிப்பிடப்பட்டது</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">ข้อความ %1$d จาก %2$d คน</string>
     <string name="notification_more_conversations">และการสนทนาอีก %1$d รายการ</string>
     <string name="notification_active_peers_title">มีผู้ใช้ใกล้คุณ!</string>
-    <string name="notification_active_peers_one">มี 1 คนใกล้คุณ</string>
-    <string name="notification_active_peers_many">มี %1$d คนใกล้คุณ</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">มี 1 คนใกล้คุณ</item>
+        <item quantity="other">มี %1$d คนใกล้คุณ</item>
+    </plurals>
     <string name="notification_new_messages">ข้อความใหม่</string>
     <string name="notification_new_location_messages">ข้อความตำแหน่งใหม่</string>
     <string name="notification_mentions_in">ถูกกล่าวถึงใน %1$s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -41,8 +41,10 @@
     <string name="notification_messages_from_people">%2$d kişiden %1$d mesaj</string>
     <string name="notification_more_conversations">ve %1$d sohbet daha</string>
     <string name="notification_active_peers_title">yakında bitchatter’lar!</string>
-    <string name="notification_active_peers_one">Yakında 1 kişi</string>
-    <string name="notification_active_peers_many">Yakında %1$d kişi</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">Yakında 1 kişi</item>
+        <item quantity="other">Yakında %1$d kişi</item>
+    </plurals>
     <string name="notification_new_messages">Yeni mesajlar</string>
     <string name="notification_new_location_messages">Yeni konum mesajları</string>
     <string name="notification_mentions_in">%1$s içinde bahsedildi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -80,8 +80,10 @@
     <string name="notification_messages_from_people">%1$d повідомлень від %2$d людей</string>
     <string name="notification_more_conversations">і ще %1$d розмов</string>
     <string name="notification_active_peers_title">👥 bitchat-користувачі поруч!</string>
-    <string name="notification_active_peers_one">1 людина поруч</string>
-    <string name="notification_active_peers_many">%1$d людей поруч</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 людина поруч</item>
+        <item quantity="other">%1$d людей поруч</item>
+    </plurals>
     <string name="notification_new_messages">Нові повідомлення</string>
     <string name="notification_new_location_messages">Нові повідомлення в геолокації</string>
     <string name="notification_mentions_in">Згадка в %1$s</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%2$d لوگوں سے %1$d پیغامات</string>
     <string name="notification_more_conversations">اور %1$d مزید گفتگو</string>
     <string name="notification_active_peers_title">قریب میں bitchatter!</string>
-    <string name="notification_active_peers_one">قریب میں 1 شخص</string>
-    <string name="notification_active_peers_many">قریب میں %1$d لوگ</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">قریب میں 1 شخص</item>
+        <item quantity="other">قریب میں %1$d لوگ</item>
+    </plurals>
     <string name="notification_new_messages">نئے پیغامات</string>
     <string name="notification_new_location_messages">نئے مقام کے پیغامات</string>
     <string name="notification_mentions_in">%1$s میں ذکر</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">%1$d tin nhắn từ %2$d người</string>
     <string name="notification_more_conversations">và %1$d cuộc trò chuyện khác</string>
     <string name="notification_active_peers_title">bitchatter gần đó!</string>
-    <string name="notification_active_peers_one">1 người gần đó</string>
-    <string name="notification_active_peers_many">%1$d người gần đó</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">1 người gần đó</item>
+        <item quantity="other">%1$d người gần đó</item>
+    </plurals>
     <string name="notification_new_messages">Tin nhắn mới</string>
     <string name="notification_new_location_messages">Tin nhắn vị trí mới</string>
     <string name="notification_mentions_in">Được nhắc đến trong %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -93,8 +93,10 @@
   <string name="notification_messages_from_people">来自 %2$d 人的 %1$d 条消息</string>
   <string name="notification_more_conversations">还有 %1$d 个对话</string>
   <string name="notification_active_peers_title">👥 附近有 bitchat 用户！</string>
-  <string name="notification_active_peers_one">附近有 1 人</string>
-  <string name="notification_active_peers_many">附近有 %1$d 人</string>
+  <plurals name="notification_active_peers_body">
+      <item quantity="one">附近有 1 人</item>
+      <item quantity="other">附近有 %1$d 人</item>
+  </plurals>
   <string name="notification_new_messages">新消息</string>
   <string name="notification_new_location_messages">新的位置消息</string>
   <string name="notification_mentions_in">在 %1$s 中被提及</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -93,8 +93,10 @@
   <string name="notification_messages_from_people">來自 %2$d 位使用者的 %1$d 則訊息</string>
   <string name="notification_more_conversations">還有 %1$d 個對話</string>
   <string name="notification_active_peers_title">👥 附近有 bitchat 使用者！</string>
-  <string name="notification_active_peers_one">附近有 1 人</string>
-  <string name="notification_active_peers_many">附近有 %1$d 人</string>
+  <plurals name="notification_active_peers_body">
+      <item quantity="one">附近有 1 人</item>
+      <item quantity="other">附近有 %1$d 人</item>
+  </plurals>
   <string name="notification_new_messages">新訊息</string>
   <string name="notification_new_location_messages">新位置訊息</string>
   <string name="notification_mentions_in">在 %1$s 中被提及</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -47,8 +47,10 @@
     <string name="notification_messages_from_people">来自 %2$d 位的 %1$d 条消息</string>
     <string name="notification_more_conversations">以及另外 %1$d 个会话</string>
     <string name="notification_active_peers_title">附近的 bitchatter！</string>
-    <string name="notification_active_peers_one">附近 1 人</string>
-    <string name="notification_active_peers_many">附近 %1$d 人</string>
+    <plurals name="notification_active_peers_body">
+        <item quantity="one">附近 1 人</item>
+        <item quantity="other">附近 %1$d 人</item>
+    </plurals>
     <string name="notification_new_messages">新消息</string>
     <string name="notification_new_location_messages">新的地点消息</string>
     <string name="notification_mentions_in">在 %1$s 中被提及</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,8 +48,10 @@
   <string name="notification_messages_from_people">%1$d messages from %2$d people</string>
   <string name="notification_more_conversations">and %1$d more conversations</string>
   <string name="notification_active_peers_title">bitchatters nearby!</string>
-  <string name="notification_active_peers_one">1 person around</string>
-  <string name="notification_active_peers_many">%1$d people around</string>
+  <plurals name="notification_active_peers_body">
+      <item quantity="one">1 person around</item>
+      <item quantity="other">%1$d people around</item>
+  </plurals>
   <string name="notification_new_messages">New Messages</string>
   <string name="notification_new_location_messages">New Location Messages</string>
   <string name="notification_mentions_in">Mentioned in %1$s</string>


### PR DESCRIPTION
notification_active_peers_one/_many were plain `<string>` resources selected with a manual `peerCount == 1` check in `PeerAvailabilityNotifier`, instead of Android's native `<plurals>` resource type — unlike every other pluralized string already in this app (`people_count`, `notification_and_more`, `location_notes_title`, all `<plurals>`). A one/other split in code can't represent the CLDR plural categories some locales need.

## Evidence
Checked the shipped translations against their locale's plural rules:
- **Polish** (`values-pl`): uses "osób" (5+, genitive plural) for every count ≥ 2, including 2-4 where "osoby" is grammatically required.
- **Arabic** (`values-ar`): uses the plural form for count 2, where Arabic requires a dual form.

Both are real, currently-shipping grammatical errors caused by the one/other split having nowhere to put the missing categories.

## Change
- Converted `notification_active_peers_one`/`_many` into a `notification_active_peers_body` `<plurals>` resource across all 34 locale `strings.xml` files. Translated text is preserved verbatim — only the resource shape changed (`one`/`other` items instead of two flat strings).
- Switched `PeerAvailabilityNotifier`'s body lookup to `context.resources.getQuantityString(R.plurals.notification_active_peers_body, peerCount, peerCount)`, matching the existing `getQuantityString(R.plurals.people_count, count, count)` pattern used elsewhere in the app.

This does not add the missing `few`/`two` forms Polish and Arabic still need for full correctness — that needs a native speaker to get right. What it fixes is the resource structure, so those forms can be added per-locale later without another code change, instead of being structurally impossible under the old one/other split.

## Testing
- `./gradlew :app:compileDebugKotlin` — green
- `./gradlew :app:processDebugResources` — green (all 34 edited `strings.xml` files parse and build under AAPT2)
- `./gradlew :app:testDebugUnitTest --tests "com.bitchat.android.service.PeerAvailabilityNotifierTest"` — 7/7 pass (this test uses a fake `TextProvider`, so it's unaffected by the change either way, but confirms nothing else in the notifier broke)