### PR TITLE
Prepare Android 2.0.1 release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.bitchat.droid"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 37
-        versionName = "2.0.0"
+        versionCode = 38
+        versionName = "2.0.1"
         buildConfigField(
             "String",
             "GITHUB_RELEASE_CERT_SHA256",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,6 +111,13 @@ android {
     }
 }
 
+composeCompiler {
+    // Kotlin 2.4.10's optional Compose group-key mapping depends on unspecified
+    // class-file iteration order. Keep the normal R8 mapping, but omit that
+    // augmentation until its producer is deterministic across clean builds.
+    includeComposeMappingFile.set(false)
+}
+
 kotlin {
     jvmToolchain(21)
     compilerOptions {

--- a/docs/reproducible-builds.md
+++ b/docs/reproducible-builds.md
@@ -33,10 +33,13 @@ The build uses a clean source tree, an isolated Gradle user home, UTC, a stable
 locale, `SOURCE_DATE_EPOCH` from the Git commit, no Gradle build or configuration
 cache, fresh tasks, a non-incremental in-process Kotlin compiler, and R8's
 deterministic-debugging mode. The R8 mode uses one compiler thread and disables
-randomized input shuffling so the ProGuard map embedded in each AAB is stable.
-Native builds remap source paths and release validation rejects host paths in
-packaged libraries. The container overlays a canonical `local.properties`, so
-an ignored Android Studio file cannot redirect Gradle to a host-specific SDK.
+randomized input shuffling. The regular R8 ProGuard map remains embedded in each
+AAB. Kotlin 2.4.10's optional Compose group-key mapping augmentation is disabled
+because its duplicate-key selection depends on unspecified class-file iteration
+order across clean builds. Native builds remap source paths and release
+validation rejects host paths in packaged libraries. The container overlays a
+canonical `local.properties`, so an ignored Android Studio file cannot redirect
+Gradle to a host-specific SDK.
 
 AGP's embedded VCS record is disabled because its Git discovery depends on the
 host checkout layout. The canonical `BUILDINFO.json` and GitHub provenance

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         targetSdk = libs.versions.targetSdk.get().toInt()
         // Wear releases use a separate high range because Play requires every artifact in
         // one application ID to have a unique version code across all form factors.
-        versionCode = 1_000_000_001
-        versionName = "0.1.0"
+        versionCode = 1_000_000_002
+        versionName = "0.1.1"
 
         vectorDrawables {
             useSupportLibrary = true

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -65,6 +65,13 @@ android {
     }
 }
 
+composeCompiler {
+    // Kotlin 2.4.10's optional Compose group-key mapping depends on unspecified
+    // class-file iteration order. Keep the normal R8 mapping, but omit that
+    // augmentation until its producer is deterministic across clean builds.
+    includeComposeMappingFile.set(false)
+}
+
 // Shared bitchat protocol stack: compiled from :app sources in place (never moved/copied by hand).
 // AGP's source directory sets no longer support include/exclude filters, so a Sync task
 // materializes a filtered mirror into build/sharedSrc and that directory is added as a source


### PR DESCRIPTION
## Summary
- bump the phone app to 2.0.1 (version code 38)
- bump the Wear OS app to 0.1.1 (version code 1000000002)
- disable Kotlin 2.4.10 optional Compose group-key mapping augmentation in minified phone and Wear builds
- retain normal R8 optimization and ProGuard mapping

## Context
The v2.0.0 release gate was stopped before signing or publication because independent AAB replicas differed in mapping metadata. R8 deterministic mode stabilized the normal mapping, but the first v2.0.1 PR run exposed a second source: Kotlin 2.4.10 Compose group-key mapping consumes class files in unspecified order and resolves duplicate keys by encounter order. The plugin provides a supported `includeComposeMappingFile` switch; disabling this optional augmentation preserves normal R8 retracing while removing that nondeterministic producer.

## Validation
- release-guide version and application-ID assertions pass
- Gradle configuration check passes
- `produceReleaseComposeMapping` and related tasks are absent from both module task graphs
- first PR run: every APK and executable AAB entry matched; only the optional Compose-augmented ProGuard maps differed
- updated full test, lint, debug, and two-replica release checks are running in CI

## Risk
Normal R8 mapping remains embedded. Group-key-based Compose stack traces will not receive the optional Compose-specific deobfuscation augmentation until its producer is deterministic.