### PR TITLE
fix: stop an injected fragment from destroying or poisoning a reassembly

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/FragmentManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/FragmentManager.kt
@@ -241,7 +241,19 @@ class FragmentManager {
                     return null
                 }
 
-                val oldEntrySize = fragmentMap[fragmentPayload.index]?.size ?: 0
+                val heldEntry = fragmentMap[fragmentPayload.index]
+                if (heldEntry != null && !heldEntry.contentEquals(fragmentPayload.data)) {
+                    // Duplicate delivery is normal in a mesh, but one index of a
+                    // stream must always carry the same bytes. Overwriting
+                    // last-wins let a crafted duplicate replace bytes already
+                    // received from the real sender. This protects indices
+                    // already held; an index still empty when the injected
+                    // fragment arrives is filled by whichever copy wins the
+                    // race, and nothing here can tell them apart.
+                    Log.w(TAG, "Rejecting fragment for $fragmentIDString: index ${fragmentPayload.index} already holds different bytes")
+                    return null
+                }
+                val oldEntrySize = heldEntry?.size ?: 0
                 val newSize = currentSize - oldEntrySize + fragmentPayload.data.size
                 val maxTotalBytes = com.bitchat.android.util.AppConstants.Fragmentation.MAX_FRAGMENT_TOTAL_BYTES
                 if (newSize > maxTotalBytes) {

--- a/app/src/main/java/com/bitchat/android/mesh/FragmentManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/FragmentManager.kt
@@ -197,8 +197,15 @@ class FragmentManager {
             synchronized(fragmentStateLock) {
                 fragmentMetadata[fragmentIDString]?.let { (expectedType, expectedTotal, _) ->
                     if (expectedTotal != fragmentPayload.total || expectedType != fragmentPayload.originalType) {
+                        // Reject the fragment, keep the stream. Fragment packets
+                        // are unauthenticated and both halves of the key are
+                        // attacker-choosable, so discarding the set here let one
+                        // crafted packet destroy a legitimate in-flight
+                        // reassembly. Nothing from a conflicting header is ever
+                        // stored, so keeping the set stays inside the same
+                        // memory bound; a stream that genuinely stalls is reaped
+                        // by the timeout sweep.
                         Log.w(TAG, "Rejecting fragment for $fragmentIDString: inconsistent metadata")
-                        removeFragmentSetLocked(fragmentIDString)
                         return null
                     }
                 }
@@ -239,7 +246,13 @@ class FragmentManager {
                 val maxTotalBytes = com.bitchat.android.util.AppConstants.Fragmentation.MAX_FRAGMENT_TOTAL_BYTES
                 if (newSize > maxTotalBytes) {
                     Log.w(TAG, "Rejecting fragment for $fragmentIDString: cumulative size $newSize exceeds cap $maxTotalBytes")
-                    removeFragmentSetLocked(fragmentIDString)
+                    // Only a set this fragment itself created has nothing worth
+                    // preserving. An oversized fragment must not be able to
+                    // destroy an assembly it did not start — same reasoning the
+                    // global-cap branch below already applies.
+                    if (isNewSet) {
+                        removeFragmentSetLocked(fragmentIDString)
+                    }
                     return null
                 }
 

--- a/app/src/test/java/com/bitchat/android/mesh/FragmentManagerTest.kt
+++ b/app/src/test/java/com/bitchat/android/mesh/FragmentManagerTest.kt
@@ -252,4 +252,112 @@ class FragmentManagerTest {
         }
         return result
     }
+
+    // Injected-fragment hardening. Fragment packets are unauthenticated and
+    // both halves of the reassembly key are attacker-choosable, so a stream in
+    // flight has to survive a crafted packet aimed at it. Ports the storage
+    // rules from permissionlesstech/bitchat#1515.
+
+    /** A real packet, fragmented the way the sender would fragment it. */
+    private fun honestStream(): Pair<BitchatPacket, List<BitchatPacket>> {
+        val payload = ByteArray(1200) { (it % 251).toByte() }
+        val packet = BitchatPacket(
+            version = 1u,
+            type = MessageType.FILE_TRANSFER.value,
+            senderID = hexStringToByteArray(senderID),
+            recipientID = hexStringToByteArray(recipientID),
+            timestamp = 1u,
+            payload = payload,
+            ttl = 7u
+        )
+        val fragments = fragmentManager.createFragments(packet)
+        assertTrue("Need a multi-fragment stream", fragments.size >= 3)
+        return packet to fragments
+    }
+
+    /** Same stream key as [honest], but attacker-chosen contents. */
+    private fun injected(
+        honest: BitchatPacket,
+        index: Int,
+        total: Int,
+        data: ByteArray,
+        originalType: UByte
+    ): BitchatPacket {
+        val decoded = FragmentPayload.decode(honest.payload)!!
+        return honest.copy(
+            payload = FragmentPayload(
+                fragmentID = decoded.fragmentID,
+                index = index,
+                total = total,
+                originalType = originalType,
+                data = data
+            ).encode()
+        )
+    }
+
+    private fun feedAllButLast(fragments: List<BitchatPacket>) {
+        fragments.dropLast(1).forEach {
+            assertNull("No fragment before the last should complete", fragmentManager.handleFragment(it))
+        }
+    }
+
+    private fun assertCompletes(original: BitchatPacket, last: BitchatPacket) {
+        val reassembled = fragmentManager.handleFragment(last)
+        assertNotNull("The honest stream must still complete", reassembled)
+        assertTrue(
+            "Reassembled payload must be the honest bytes",
+            original.payload.contentEquals(reassembled!!.payload)
+        )
+    }
+
+    @Test
+    fun `a conflicting total is rejected without destroying the stream`() {
+        val (original, fragments) = honestStream()
+        feedAllButLast(fragments)
+
+        val decoded = FragmentPayload.decode(fragments[0].payload)!!
+        assertNull(
+            fragmentManager.handleFragment(
+                injected(fragments[0], index = 0, total = decoded.total - 1,
+                         data = ByteArray(4), originalType = decoded.originalType)
+            )
+        )
+
+        assertCompletes(original, fragments.last())
+    }
+
+    @Test
+    fun `a conflicting original type is rejected without destroying the stream`() {
+        val (original, fragments) = honestStream()
+        feedAllButLast(fragments)
+
+        val decoded = FragmentPayload.decode(fragments[0].payload)!!
+        assertNull(
+            fragmentManager.handleFragment(
+                injected(fragments[0], index = 0, total = decoded.total,
+                         data = ByteArray(4), originalType = MessageType.ANNOUNCE.value)
+            )
+        )
+
+        assertCompletes(original, fragments.last())
+    }
+
+    @Test
+    fun `an oversized fragment cannot wipe an assembly it did not start`() {
+        val (original, fragments) = honestStream()
+        feedAllButLast(fragments)
+
+        val decoded = FragmentPayload.decode(fragments[0].payload)!!
+        val oversized = ByteArray(
+            com.bitchat.android.util.AppConstants.Fragmentation.MAX_FRAGMENT_TOTAL_BYTES + 1
+        )
+        assertNull(
+            fragmentManager.handleFragment(
+                injected(fragments[0], index = decoded.total - 1, total = decoded.total,
+                         data = oversized, originalType = decoded.originalType)
+            )
+        )
+
+        assertCompletes(original, fragments.last())
+    }
 }

--- a/app/src/test/java/com/bitchat/android/mesh/FragmentManagerTest.kt
+++ b/app/src/test/java/com/bitchat/android/mesh/FragmentManagerTest.kt
@@ -343,6 +343,37 @@ class FragmentManagerTest {
     }
 
     @Test
+    fun `an index already held keeps its first bytes`() {
+        val (original, fragments) = honestStream()
+        feedAllButLast(fragments)
+
+        // Same stream, same index, different bytes: last-wins would swap the
+        // real sender's bytes out from under the reassembly.
+        val decoded = FragmentPayload.decode(fragments[0].payload)!!
+        assertNull(
+            fragmentManager.handleFragment(
+                injected(fragments[0], index = 0, total = decoded.total,
+                         data = ByteArray(decoded.data.size) { 0x66 },
+                         originalType = decoded.originalType)
+            )
+        )
+
+        assertCompletes(original, fragments.last())
+    }
+
+    @Test
+    fun `an identical duplicate is still accepted`() {
+        // Duplicate delivery is normal in a mesh; only a *differing* duplicate
+        // is an attack, so redelivery must not be turned into a rejection.
+        val (original, fragments) = honestStream()
+        feedAllButLast(fragments)
+
+        assertNull(fragmentManager.handleFragment(fragments[0]))
+
+        assertCompletes(original, fragments.last())
+    }
+
+    @Test
     fun `an oversized fragment cannot wipe an assembly it did not start`() {
         val (original, fragments) = honestStream()
         feedAllButLast(fragments)


### PR DESCRIPTION
Ports the storage-layer hardening from permissionlesstech/bitchat#1515 to this reassembler. jack verified those bugs empirically on the iOS side ("we verified all three bugs with a side-by-side harness against main, and they're real") and said that PR should land; two of the three, plus index poisoning, are present here.

## Threat model, same as iOS

`.fragment` packets are unauthenticated and bypass the deduplicator, and both halves of `(fragmentID, sender)` are attacker-choosable. A fragment stream is broadcast, so its ID is observable in radio range. So a stream in flight has to survive a crafted packet aimed at it.

## What was wrong

**1. One packet destroys an assembly, via metadata conflict.** `FragmentManager` correctly pins `(originalType, total)` on the first fragment — that part was already right, and it is why the iOS truncation bug does not exist here. But on a mismatch it called `removeFragmentSetLocked`, so a single fragment claiming a different `total` for a stream someone else owns wipes it. The victim sees a transfer that never completes.

**2. One packet destroys an assembly, via the size cap.** Tripping `MAX_FRAGMENT_TOTAL_BYTES` also discarded the whole set, so an injected oversized fragment at any index wipes a legitimate stream. The global-cap branch immediately below already got this right — it only clears the set when `isNewSet` — so this was an inconsistency inside the same function.

**3. Index poisoning.** `fragmentMap[index] = data` overwrote unconditionally, so a duplicate at an already-held index carrying different bytes replaced what the real sender delivered. Last-wins, one packet.

## What this changes

A conflicting header is rejected without touching the stream. Nothing from a conflicting header was ever stored, so retaining the set stays inside the same memory bound, and a genuinely stalled stream is still reaped by the timeout sweep. An oversized fragment only clears a set it created. An index already held is immutable.

**Byte-identical redelivery stays accepted.** Duplicates are normal in a mesh; only a *differing* duplicate is an attack. Turning redelivery into a rejection would be its own bug, so that case is pinned as well.

## What this does not fix

It does not make reassembly unforgeable, and the same caveat jack drew on #1515 applies here. First-wins protects indices *already held*. A fragment that reaches an index before the honest one does is the first accepted value there, and the stream reassembles around it. What changes is cost: full replacement and one-packet destruction stop working, and corrupting a specific byte range now needs the attacker to win a race at each index it wants.

## Verification

Local run of the CI job (`testDebugUnitTest lintDebug`, JDK 21), measured with `--rerun-tasks` so the counts are a real full-suite run rather than incremental leftovers:

- **608 → 613 tests, 0 failures, lint clean.** The delta is exactly the 5 added, all in `FragmentManagerTest`, and no other class moved.
- **4 of the 5 fail on unmodified `main`** — the two conflict cases, the index-poisoning case, and the oversize case. The fifth is `an identical duplicate is still accepted`, which passes both before and after; it is there to catch this fix over-rejecting, so it is supposed to pass on main.
- Tests drive real fragments from `createFragments` on a genuine `BitchatPacket` and inject against the stream's own `fragmentID`, rather than hand-built bytes, so completion actually exercises `BitchatPacket.fromBinaryData`.

**CI has not run.** Fork PRs here sit at `action_required` until a maintainer approves the workflow, so the local run above is the evidence, not a green check.
