### PR TITLE
fix: stop duplicate detection dropping distinct packets that share a 64-byte prefix

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
@@ -3,6 +3,7 @@ package com.bitchat.android.mesh
 import android.util.Log
 import com.bitchat.android.crypto.EncryptionService
 import com.bitchat.android.protocol.BitchatPacket
+import com.bitchat.android.sync.PacketIdUtil
 import com.bitchat.android.protocol.MessageType
 import com.bitchat.android.model.RoutedPacket
 import com.bitchat.android.noise.AuthenticatedNoiseSession
@@ -241,18 +242,28 @@ class SecurityManager(private val encryptionService: EncryptionService, private 
     /**
      * Generate message ID for duplicate detection
      */
+    /**
+     * Identity used for replay and duplicate detection.
+     *
+     * This was a 32-bit `contentHashCode()` over at most the first 64 bytes of
+     * the payload. Two packets from the same peer in the same millisecond that
+     * agreed on that prefix collided, and a collision here is a *dropped
+     * message* — the second packet is discarded as a duplicate and there is no
+     * signal that it happened.
+     *
+     * `PacketIdUtil` is the identity the rest of the stack already uses for
+     * exactly this question (gossip sync membership, message IDs in
+     * `MessageHandler`), and iOS derives it the same way: the first 16 bytes of
+     * SHA-256 over type, senderID, timestamp and the **whole** payload. Using
+     * it here makes the security path agree with the sync path instead of
+     * carrying a weaker private notion of "same packet".
+     *
+     * Peer scoping is kept: `PacketIdUtil` covers the packet's own senderID,
+     * while this key is scoped by the peer the packet was received from, and
+     * those are not the same thing for a relayed packet.
+     */
     private fun generateMessageID(packet: BitchatPacket, peerID: String): String {
-        return when (MessageType.fromValue(packet.type)) {
-            MessageType.FRAGMENT -> {
-                // For fragments, include the payload hash to distinguish different fragments
-                "${packet.timestamp}-$peerID-${packet.type}-${packet.payload.contentHashCode()}"
-            }
-            else -> {
-                // For other messages, use a truncated payload hash
-                val payloadHash = packet.payload.sliceArray(0 until minOf(64, packet.payload.size)).contentHashCode()
-                "${packet.timestamp}-$peerID-$payloadHash"
-            }
-        }
+        return "$peerID-${PacketIdUtil.computeIdHex(packet)}"
     }
     
     /**

--- a/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/SecurityManager.kt
@@ -239,29 +239,7 @@ class SecurityManager(private val encryptionService: EncryptionService, private 
         return encryptionService.getCombinedPublicKeyData()
     }
     
-    /**
-     * Generate message ID for duplicate detection
-     */
-    /**
-     * Identity used for replay and duplicate detection.
-     *
-     * This was a 32-bit `contentHashCode()` over at most the first 64 bytes of
-     * the payload. Two packets from the same peer in the same millisecond that
-     * agreed on that prefix collided, and a collision here is a *dropped
-     * message* — the second packet is discarded as a duplicate and there is no
-     * signal that it happened.
-     *
-     * `PacketIdUtil` is the identity the rest of the stack already uses for
-     * exactly this question (gossip sync membership, message IDs in
-     * `MessageHandler`), and iOS derives it the same way: the first 16 bytes of
-     * SHA-256 over type, senderID, timestamp and the **whole** payload. Using
-     * it here makes the security path agree with the sync path instead of
-     * carrying a weaker private notion of "same packet".
-     *
-     * Peer scoping is kept: `PacketIdUtil` covers the packet's own senderID,
-     * while this key is scoped by the peer the packet was received from, and
-     * those are not the same thing for a relayed packet.
-     */
+    /** Deduplicates by peer and a hash of packet type, sender, timestamp, and full payload. */
     private fun generateMessageID(packet: BitchatPacket, peerID: String): String {
         return "$peerID-${PacketIdUtil.computeIdHex(packet)}"
     }

--- a/app/src/test/kotlin/com/bitchat/android/mesh/SecurityManagerTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/mesh/SecurityManagerTest.kt
@@ -598,4 +598,65 @@ class SecurityManagerTest {
 
     private fun String.hexToBytes(): ByteArray =
         chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    // Duplicate-detection identity.
+
+    /**
+     * Two distinct packets that agree on their first 64 bytes and share a
+     * timestamp. The old key hashed only that prefix, with a 32-bit
+     * `contentHashCode`, so these were "the same packet" and the second was
+     * silently dropped.
+     */
+    private fun prefixSharingPair(): Pair<BitchatPacket, BitchatPacket> {
+        val shared = ByteArray(64) { 0x7 }
+        val first = BitchatPacket(
+            version = 1u,
+            type = MessageType.NOISE_ENCRYPTED.value,
+            senderID = otherPeerID.hexToByteArrayForTest(),
+            recipientID = myPeerID.hexToByteArrayForTest(),
+            timestamp = 1_700_000_000_000uL,
+            payload = shared + byteArrayOf(0x01, 0x02, 0x03),
+            ttl = 7u
+        )
+        val second = first.copy(payload = shared + byteArrayOf(0x0A, 0x0B, 0x0C))
+        return first to second
+    }
+
+    @Test
+    fun `packets differing only past the first 64 bytes are not treated as duplicates`() {
+        val (first, second) = prefixSharingPair()
+
+        assertTrue(securityManager.validatePacket(first, otherPeerID))
+        assertTrue(
+            "A distinct packet must not be dropped as a duplicate",
+            securityManager.validatePacket(second, otherPeerID)
+        )
+    }
+
+    @Test
+    fun `a genuine replay of the same packet is still rejected`() {
+        // The other half: strengthening the identity must not weaken replay
+        // protection, which is the reason this cache exists.
+        val (first, _) = prefixSharingPair()
+
+        assertTrue(securityManager.validatePacket(first, otherPeerID))
+        assertFalse(
+            "The identical packet must still be caught",
+            securityManager.validatePacket(first, otherPeerID)
+        )
+    }
+
+    @Test
+    fun `the same packet from two different peers is tracked separately`() {
+        // Peer scoping is deliberately kept: PacketIdUtil covers the packet's
+        // own senderID, which is not the peer it was received from once a
+        // packet has been relayed.
+        val (first, _) = prefixSharingPair()
+
+        assertTrue(securityManager.validatePacket(first, otherPeerID))
+        assertTrue(securityManager.validatePacket(first, unknownPeerID))
+    }
+
+    private fun String.hexToByteArrayForTest(): ByteArray =
+        chunked(2).map { it.toInt(16).toByte() }.toByteArray()
 }


### PR DESCRIPTION
Replay and duplicate detection in `SecurityManager` keyed on this:

```kotlin
val payloadHash = packet.payload.sliceArray(0 until minOf(64, packet.payload.size)).contentHashCode()
"${packet.timestamp}-$peerID-$payloadHash"
```

A 32-bit `contentHashCode` over **at most the first 64 bytes** of the payload. Two packets from the same peer in the same millisecond that agree on that prefix are the same packet as far as this cache is concerned, and a collision here is not a false alarm — it is a **dropped message**. `validatePacket` returns false, the packet is discarded, and nothing anywhere reports that it happened.

## Why this is worth changing rather than tuning

The repo already has the right answer to "are these the same packet". `PacketIdUtil` — first 16 bytes of SHA-256 over type, senderID, timestamp and the **whole** payload — is what `GossipSyncManager` uses for sync membership and what `MessageHandler` uses to assign message IDs. iOS derives it identically (`bitchat/Sync/PacketIdUtil.swift`), so it is also the cross-platform notion.

So the security path was carrying its own weaker private definition while the strong one sat in the same source tree, already used for the same question. Using it makes the two agree, and the `FRAGMENT` special case disappears on the way — it existed only because the general branch truncated at 64 bytes, and the full payload is covered either way now.

**Peer scoping is deliberately kept.** `PacketIdUtil` covers the packet's own `senderID`, which is not the same thing as the peer it was received from once a packet has been relayed, so the key stays `"$peerID-$packetId"` rather than becoming the bare packet ID.

## What is not claimed

This is not a fix for a forged-packet attack. `validatePacket` already records only packets that pass signature verification, with a comment explaining exactly why, so an attacker cannot poison the cache against a peer without that peer's signature. What changes here is accidental collision between two honest packets, and the fact that the security layer and the sync layer no longer disagree about packet identity.

## Verification

Local run of the CI job (`testDebugUnitTest lintDebug`, JDK 21). Counts from `--rerun-tasks` on both sides so they are real full-suite runs, not incremental leftovers:

- **608 → 611 tests, 0 failures, lint clean.** Per-class diff shows one class changed — `SecurityManagerTest`, 24 → 27 — and nothing else moved.
- **The collision test fails on unmodified `main`**, which is the point: two packets sharing a 64-byte prefix and a timestamp, second one silently dropped.
- The other two pass before *and* after by design — replay of an identical packet still rejected, and the same packet from two different peers still tracked separately. They are there so that strengthening the identity cannot quietly weaken what the cache exists to do.

**CI has not run.** Fork PRs here sit at `action_required` until a maintainer approves the workflow, so the local run is the evidence, not a green check.
