### PR TITLE
fix(nostr): do not pick relays around (0, 0) for an undecodable geohash

### DIFF
--- a/app/src/main/java/com/bitchat/android/geohash/Geohash.kt
+++ b/app/src/main/java/com/bitchat/android/geohash/Geohash.kt
@@ -67,6 +67,13 @@ object Geohash {
     }
 
     /**
+     * True when every character of [geohash] is a base32 geohash digit and the
+     * string is non-empty, i.e. when it names an actual cell.
+     */
+    fun isValid(geohash: String): Boolean =
+        geohash.isNotEmpty() && geohash.lowercase().all { charToValue.containsKey(it) }
+
+    /**
      * Decodes a geohash string to the center latitude/longitude of its cell.
      * @return Pair(latitude, longitude)
      */
@@ -78,7 +85,30 @@ object Geohash {
     }
 
     /**
+     * Decodes a geohash string to the center latitude/longitude of its cell, or
+     * null when the string does not name a cell.
+     *
+     * Prefer this over [decodeToCenter] wherever the string can come from
+     * outside: an empty or malformed geohash decodes to the (0, 0) box, and
+     * (0, 0) is a real place in the Gulf of Guinea, so a caller that cannot
+     * tell the two apart silently acts on a location the user never chose.
+     */
+    fun decodeToCenterOrNull(geohash: String): Pair<Double, Double>? =
+        if (isValid(geohash)) decodeToCenter(geohash) else null
+
+    /**
+     * Decodes a geohash string to a bounding box, or null when the string does
+     * not name a cell.  See [decodeToCenterOrNull].
+     */
+    fun decodeToBoundsOrNull(geohash: String): Bounds? =
+        if (isValid(geohash)) decodeToBounds(geohash) else null
+
+    /**
      * Decodes a geohash string to bounding box (lat/lon min/max).
+     *
+     * An empty or malformed geohash yields the degenerate box at (0, 0); use
+     * [decodeToBoundsOrNull] when that has to be distinguishable from a real
+     * cell there.
      */
     fun decodeToBounds(geohash: String): Bounds {
         if (geohash.isEmpty()) return Bounds(0.0, 0.0, 0.0, 0.0)

--- a/app/src/main/java/com/bitchat/android/nostr/RelayDirectory.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/RelayDirectory.kt
@@ -88,10 +88,10 @@ object RelayDirectory {
     fun closestRelaysForGeohash(geohash: String, nRelays: Int): List<String> {
         val snapshot = synchronized(relaysLock) { relays.toList() }
         if (snapshot.isEmpty()) return emptyList()
-        val center = try {
-            val c = com.bitchat.android.geohash.Geohash.decodeToCenter(geohash)
-            c
-        } catch (e: Exception) {
+        // An empty or malformed geohash decodes to (0, 0), which would pick the
+        // relays closest to the Gulf of Guinea rather than declining to choose.
+        val center = com.bitchat.android.geohash.Geohash.decodeToCenterOrNull(geohash)
+        if (center == null) {
             Log.e(TAG, "Failed to decode geohash")
             return emptyList()
         }

--- a/app/src/test/java/com/bitchat/android/geohash/GeohashValidityTest.kt
+++ b/app/src/test/java/com/bitchat/android/geohash/GeohashValidityTest.kt
@@ -1,0 +1,61 @@
+package com.bitchat.android.geohash
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A geohash that names no cell has to be distinguishable from one that names a
+ * cell at (0, 0): the origin is a real place in the Gulf of Guinea, so anything
+ * that picks relays or geocodes a name from a decoded centre would otherwise
+ * act on a location the user never chose.
+ */
+class GeohashValidityTest {
+
+    @Test
+    fun `base32 strings are valid regardless of case`() {
+        assertTrue(Geohash.isValid("u4pruydqqvj"))
+        assertTrue(Geohash.isValid("U4PRUYDQQVJ"))
+        assertTrue(Geohash.isValid("9"))
+    }
+
+    @Test
+    fun `empty and malformed strings are invalid`() {
+        assertFalse(Geohash.isValid(""))
+        // a, i, l and o are not geohash digits
+        assertFalse(Geohash.isValid("hello"))
+        assertFalse(Geohash.isValid("u4pr!"))
+        assertFalse(Geohash.isValid("café"))
+    }
+
+    @Test
+    fun `nullable decoders reject what the plain ones map onto the origin`() {
+        assertEquals(0.0 to 0.0, Geohash.decodeToCenter(""))
+        assertEquals(0.0 to 0.0, Geohash.decodeToCenter("hello"))
+
+        assertNull(Geohash.decodeToCenterOrNull(""))
+        assertNull(Geohash.decodeToCenterOrNull("hello"))
+        assertNull(Geohash.decodeToBoundsOrNull(""))
+        assertNull(Geohash.decodeToBoundsOrNull("hello"))
+    }
+
+    @Test
+    fun `nullable decoders agree with the plain ones on real cells`() {
+        val geohash = "u4pruydqqvj"
+        assertEquals(Geohash.decodeToCenter(geohash), Geohash.decodeToCenterOrNull(geohash))
+        assertEquals(Geohash.decodeToBounds(geohash), Geohash.decodeToBoundsOrNull(geohash))
+        assertNotNull(Geohash.decodeToCenterOrNull("s000"))
+    }
+
+    @Test
+    fun `a cell at the origin still decodes`() {
+        // "s000..." is the cell containing (0, 0) — a valid geohash, not a failure.
+        val center = Geohash.decodeToCenterOrNull("s0000")
+        assertNotNull(center)
+        assertTrue(center!!.first in -1.0..1.0)
+        assertTrue(center.second in -1.0..1.0)
+    }
+}


### PR DESCRIPTION
`RelayDirectory.closestRelaysForGeohash` guards the decode:

```kotlin
val center = try {
    Geohash.decodeToCenter(geohash)
} catch (e: Exception) {
    Log.e(TAG, "Failed to decode geohash")
    return emptyList()
}
```

but `decodeToCenter` never throws. An empty or malformed geohash decodes to the degenerate box at (0, 0), so instead of declining, the app sorts every relay by distance to the Gulf of Guinea and connects to the five closest — `NostrRelayManager.ensureGeohashRelaysConnected` then caches that set for the geohash.

The underlying problem is that the decoder cannot say "this names no cell": (0, 0) is a real place, so `decodeToCenter("")` and `decodeToCenter("s0000")` are indistinguishable to a caller.

- first commit adds `Geohash.isValid`, `decodeToCenterOrNull` and `decodeToBoundsOrNull`, leaving the existing decoders alone (the globe view wants a box back regardless);
- second commit uses the nullable decoder in `RelayDirectory`, so the empty-list path the code already intended is the one that runs.

`./gradlew :app:testDebugUnitTest --tests "com.bitchat.android.geohash.*"` passes locally, including the five new cases in `GeohashValidityTest` (`tests="5" failures="0"`), which cover: base32 accepted in either case, `a/i/l/o` and punctuation rejected, the nullable decoders returning null exactly where the plain ones return the origin, agreement on real cells, and `s0000` — the cell that actually contains (0, 0) — still decoding.