### PR TITLE
fix(nostr): accept an uppercase npub, reject a mixed-case one

### DIFF
--- a/app/src/main/java/com/bitchat/android/nostr/Bech32.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/Bech32.kt
@@ -28,6 +28,13 @@ object Bech32 {
      * alphanumeric mode. Mixed case is invalid and is rejected.
      */
     fun decode(bech32String: String): Pair<String, ByteArray> {
+        // BIP-173 restricts every character to printable US-ASCII, 33..126.
+        // This has to run before the case test and before lowercase(): a
+        // non-ASCII uppercase homoglyph such as U+212A KELVIN SIGN reads as
+        // uppercase, so an otherwise all-uppercase string carrying one shows no
+        // mixed case, and lowercase() then folds it into an ASCII 'k'.
+        require(bech32String.all { it.code in 33..126 }) { "Invalid character" }
+
         val hasLower = bech32String.any { it.isLowerCase() }
         val hasUpper = bech32String.any { it.isUpperCase() }
         require(!(hasLower && hasUpper)) { "Mixed case" }

--- a/app/src/main/java/com/bitchat/android/nostr/Bech32.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/Bech32.kt
@@ -22,14 +22,23 @@ object Bech32 {
     /**
      * Decode bech32 string
      * Returns (hrp, data) pair
+     *
+     * Per BIP-173 a bech32 string is either all lowercase or all uppercase;
+     * the uppercase form is what QR encoders emit, since it fits the compact
+     * alphanumeric mode. Mixed case is invalid and is rejected.
      */
     fun decode(bech32String: String): Pair<String, ByteArray> {
-        val separatorIndex = bech32String.lastIndexOf('1')
+        val hasLower = bech32String.any { it.isLowerCase() }
+        val hasUpper = bech32String.any { it.isUpperCase() }
+        require(!(hasLower && hasUpper)) { "Mixed case" }
+        val normalized = bech32String.lowercase()
+
+        val separatorIndex = normalized.lastIndexOf('1')
         require(separatorIndex >= 0) { "No separator found" }
-        
-        val hrp = bech32String.substring(0, separatorIndex)
-        val dataString = bech32String.substring(separatorIndex + 1)
-        
+
+        val hrp = normalized.substring(0, separatorIndex)
+        val dataString = normalized.substring(separatorIndex + 1)
+
         // Validate HRP contains only ASCII
         require(hrp.all { it.code < 128 }) { "Invalid HRP characters" }
         

--- a/app/src/test/java/com/bitchat/android/nostr/Bech32CaseTest.kt
+++ b/app/src/test/java/com/bitchat/android/nostr/Bech32CaseTest.kt
@@ -1,0 +1,53 @@
+package com.bitchat.android.nostr
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * BIP-173 allows a bech32 string to be all lowercase or all uppercase, and
+ * forbids mixing the two. The uppercase form is what QR encoders emit — it fits
+ * the alphanumeric mode, which is denser — so an npub scanned from a QR code
+ * can arrive uppercased.
+ */
+class Bech32CaseTest {
+
+    private val pubkey = ByteArray(32) { (it + 1).toByte() }
+
+    @Test
+    fun `uppercase decodes to the same payload as lowercase`() {
+        val npub = Bech32.encode("npub", pubkey)
+        val (lowerHrp, lowerData) = Bech32.decode(npub)
+        val (upperHrp, upperData) = Bech32.decode(npub.uppercase())
+
+        assertEquals("npub", lowerHrp)
+        assertEquals("npub", upperHrp)
+        assertArrayEquals(pubkey, lowerData)
+        assertArrayEquals(pubkey, upperData)
+    }
+
+    @Test
+    fun `mixed case is rejected`() {
+        val npub = Bech32.encode("npub", pubkey)
+        val mixed = npub.substring(0, 6).uppercase() + npub.substring(6)
+
+        assertThrows(IllegalArgumentException::class.java) { Bech32.decode(mixed) }
+    }
+
+    @Test
+    fun `a corrupted uppercase string still fails the checksum`() {
+        val npub = Bech32.encode("npub", pubkey).uppercase()
+        val flipped = npub.dropLast(1) + if (npub.last() == 'Q') 'P' else 'Q'
+
+        assertThrows(IllegalArgumentException::class.java) { Bech32.decode(flipped) }
+    }
+
+    @Test
+    fun `round trip through encode and decode is stable`() {
+        val npub = Bech32.encode("npub", pubkey)
+        val (hrp, data) = Bech32.decode(npub)
+        assertEquals("npub", hrp)
+        assertEquals(npub, Bech32.encode(hrp, data))
+    }
+}

--- a/app/src/test/java/com/bitchat/android/nostr/Bech32CaseTest.kt
+++ b/app/src/test/java/com/bitchat/android/nostr/Bech32CaseTest.kt
@@ -3,6 +3,7 @@ package com.bitchat.android.nostr
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 
 /**
@@ -41,6 +42,18 @@ class Bech32CaseTest {
         val flipped = npub.dropLast(1) + if (npub.last() == 'Q') 'P' else 'Q'
 
         assertThrows(IllegalArgumentException::class.java) { Bech32.decode(flipped) }
+    }
+
+    @Test
+    fun `a non-ascii homoglyph is rejected rather than folded to ascii`() {
+        val npub = Bech32.encode("npub", pubkey).uppercase()
+        // U+212A KELVIN SIGN is uppercase and lowercases to an ASCII 'k', so an
+        // all-uppercase string carrying one passes a naive mixed-case test and
+        // then folds into a perfectly valid npub.
+        val kelvin = npub.replace("K", "\u212A")
+        assumeTrue(kelvin != npub)
+
+        assertThrows(IllegalArgumentException::class.java) { Bech32.decode(kelvin) }
     }
 
     @Test


### PR DESCRIPTION
BIP-173 says a bech32 string is either all lowercase or all uppercase, and that mixing the two is invalid. `Bech32.decode` looked up each character in the lowercase charset directly:

```kotlin
val index = CHARSET.indexOf(char)
require(index >= 0) { "Invalid character: $char" }
```

so an all-uppercase npub failed on the first character, before the checksum was ever considered. That is the form QR encoders produce — uppercase fits QR's alphanumeric mode, which is denser — so an npub scanned from a QR code or pasted from a site that displays it uppercased could not be decoded.

`ContactIdentityResolver.nostrPubkeyHex` already lowercases at the call site, which is the workaround; `NostrClient.sendPrivateMessage` passes the string through untouched, so that path simply failed.

Now the case is normalised once inside the decoder, after rejecting a mixed-case string outright (which the old code only rejected by accident, since uppercase characters were not in the charset at all).

`./gradlew :app:testDebugUnitTest --tests "com.bitchat.android.nostr.*"` passes locally; the new `Bech32CaseTest` is `tests="4" failures="0"` and covers uppercase decoding to the same payload, mixed case rejected, a corrupted uppercase string still failing on the checksum rather than the charset, and the encode/decode round trip.