### PR TITLE
fix(sync): reject out-of-range GCS parameters instead of decoding garbage

### DIFF
--- a/app/src/main/java/com/bitchat/android/sync/GCSFilter.kt
+++ b/app/src/main/java/com/bitchat/android/sync/GCSFilter.kt
@@ -18,6 +18,14 @@ import kotlin.math.ln
  * - Bitstream is packed MSB-first in each byte.
  */
 object GCSFilter {
+    /**
+     * Highest Golomb-Rice parameter accepted from the wire. P maps to an FPR of
+     * ~1/2^P; beyond 32 the remainder width exceeds any practical filter, and
+     * the shifts in decode silently wrap (Kotlin shifts use the low 6 bits of
+     * the count) into garbage values.
+     */
+    const val MAX_P = 32
+
     data class Params(
         val p: Int,         // Golomb-Rice parameter (>= 1)
         val m: Long,        // Range M = N * 2^P
@@ -70,6 +78,11 @@ object GCSFilter {
     }
 
     fun decodeToSortedSet(p: Int, m: Long, data: ByteArray): LongArray {
+        // p and m arrive off the wire. Reject out-of-range parameters rather
+        // than decoding garbage: callers read the result as "peer has nothing"
+        // and fall back to sending the data, which is the safe direction.
+        // Matches the iOS guard in GCSFilter.decodeToSortedSet.
+        if (p < 1 || p > MAX_P || m <= 1L) return LongArray(0)
         val values = ArrayList<Long>()
         val reader = BitReader(data)
         var acc = 0L

--- a/app/src/test/kotlin/com/bitchat/android/sync/GCSFilterParameterTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/sync/GCSFilterParameterTest.kt
@@ -1,0 +1,53 @@
+package com.bitchat.android.sync
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Random
+
+/**
+ * `p` and `m` arrive off the wire — a REQUEST_SYNC carries P as a uint8 — and
+ * the decoded set decides which packets a peer is told it already has. Decoding
+ * garbage from an out-of-range parameter therefore withholds real packets, so
+ * out-of-range parameters have to decode to "peer has nothing" instead.
+ */
+class GCSFilterParameterTest {
+
+    private fun ids(n: Int): List<ByteArray> {
+        val random = Random(42)
+        return List(n) {
+            val bytes = ByteArray(16)
+            random.nextBytes(bytes)
+            bytes
+        }
+    }
+
+    @Test
+    fun `a filter round-trips with the parameters it was built with`() {
+        val params = GCSFilter.buildFilter(ids(20), maxBytes = 400, targetFpr = 0.01)
+        val decoded = GCSFilter.decodeToSortedSet(params.p, params.m, params.data)
+
+        assertTrue("expected a non-empty decode", decoded.isNotEmpty())
+        assertTrue("values must stay in range", decoded.all { it in 1 until params.m })
+        assertEquals(decoded.toList(), decoded.sorted())
+    }
+
+    @Test
+    fun `an out-of-range p decodes to nothing rather than to garbage`() {
+        val params = GCSFilter.buildFilter(ids(20), maxBytes = 400, targetFpr = 0.01)
+
+        // 64 and above wrap Kotlin's shift operators; 255 is what the byte allows.
+        for (p in listOf(0, 33, 64, 200, 255)) {
+            val decoded = GCSFilter.decodeToSortedSet(p, params.m, params.data)
+            assertTrue("p=$p should decode to nothing, got ${decoded.size} values", decoded.isEmpty())
+        }
+    }
+
+    @Test
+    fun `a degenerate m decodes to nothing`() {
+        val params = GCSFilter.buildFilter(ids(20), maxBytes = 400, targetFpr = 0.01)
+
+        assertTrue(GCSFilter.decodeToSortedSet(params.p, 0L, params.data).isEmpty())
+        assertTrue(GCSFilter.decodeToSortedSet(params.p, 1L, params.data).isEmpty())
+    }
+}


### PR DESCRIPTION
`GCSFilter.decodeToSortedSet` takes `p` and `m` straight off the wire — a REQUEST_SYNC carries P as a uint8, so anything from 0 to 255 arrives — and decodes with them regardless.

- Kotlin's shift operators use the low 6 bits of the shift count, so `p >= 64` wraps and the decoder emits values that were never in the filter;
- `p = 0` makes every remainder a zero-width read, so the decoder manufactures a value per bit. On a 20-id filter that is **105 fabricated values**.

The decoded set is what `GossipSyncManager.handleRequestSync` consults to decide whether a peer already has a packet, so fabricated values mean the responder **withholds packets the peer actually lacks** — the direction that loses messages.

iOS already guards this, with the reasoning spelled out in `GCSFilter.swift`:

```swift
// Reject out-of-range parameters rather than decoding garbage: callers
// treat the result as "peer has nothing" and fall back to sending data.
guard p >= 1, p <= maxP, m > 1 else { return [] }
```

This is the same guard, with the same bound (`MAX_P = 32`), so both platforms agree on what a filter means.

Verified locally with `./gradlew :app:testDebugUnitTest --tests "com.bitchat.android.sync.*"`:

- before the guard, the new `an out-of-range p decodes to nothing rather than to garbage` fails with `p=0 should decode to nothing, got 105 values`;
- after it, `GCSFilterParameterTest` is `tests="3" failures="0"` and the existing `GCSFilterTest` still passes `tests="3" failures="0"`.