### PR TITLE
fix(geohash): publish currentGeohash writes to the threads that read it

### DIFF
--- a/app/src/main/java/com/bitchat/android/nostr/GeohashRepository.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/GeohashRepository.kt
@@ -64,10 +64,17 @@ class GeohashRepository(
     // peerID alias -> nostr pubkey mapping for geohash DMs and temp aliases
     private val nostrKeyMapping: MutableMap<String, String> = mutableMapOf()
 
-    // Current geohash in view
+    // Current geohash in view.  Written from the UI thread when the user picks
+    // a channel and read from Nostr handler and timer threads - including from
+    // the @Synchronized methods below, which only see a published write if the
+    // write itself is synchronized.  NotificationManager marks its copy of this
+    // state @Volatile for the same reason.
     private var currentGeohash: String? = null
 
+    @Synchronized
     fun setCurrentGeohash(geo: String?) { currentGeohash = geo }
+
+    @Synchronized
     fun getCurrentGeohash(): String? = currentGeohash
 
     @Synchronized


### PR DESCRIPTION
`GeohashRepository` synchronizes every accessor that touches its shared maps — eighteen of them — but `currentGeohash` is a plain `var` with two unsynchronized accessors:

```kotlin
private var currentGeohash: String? = null

fun setCurrentGeohash(geo: String?) { currentGeohash = geo }
fun getCurrentGeohash(): String? = currentGeohash
```

It is written from the UI thread when the user picks a channel (`GeohashViewModel.selectLocationChannel`, `MainActivity`) and read from Nostr handler and timer threads. Several of those reads are *inside* the `@Synchronized` methods — `refreshGeohashPeople`, `updateParticipant`, `displayNameForNostrPubkey` — and holding the lock on the read side buys nothing when the write side never takes it: there is no happens-before edge, so a stale value can persist indefinitely.

Two places that shows up:

- `startGeoParticipantsTimer` loops `while (repo.getCurrentGeohash() != null)`, so a missed write keeps refreshing participants for a channel the user has left;
- `displayNameForNostrPubkey` uses it to derive the identity that decides whether a pubkey is *us*, so a stale geohash can label someone else's message with your nickname, or drop yours.

Synchronizing the two accessors matches the rest of the class. `NotificationManager` holds the same state and marks it `@Volatile` for this reason, so the codebase already treats it as cross-thread state.

`./gradlew :app:testDebugUnitTest :app:lintDebug` passes locally (rc=0). No behaviour test: a missing happens-before edge cannot be observed reliably from a unit test, and asserting it would only encode a timing accident.