### PR TITLE
Fix CommandProcessor test syntax

### DIFF
--- a/app/src/test/java/com/bitchat/android/ui/CommandProcessorTest.kt
+++ b/app/src/test/java/com/bitchat/android/ui/CommandProcessorTest.kt
@@ -180,6 +180,7 @@ class CommandProcessorTest {
 
     assertEquals("#backchannel", chatState.getCurrentChannelValue())
     assertEquals(ChannelID.Mesh, chatState.selectedLocationChannel.value)
+  }
 
   @Test
   fun `clearSuggestions hides the command suggestion popup`() {


### PR DESCRIPTION
## Summary

- close the join-channel test before the following test declarations
- restore Kotlin unit-test compilation

## Testing

- git diff --check