### PR TITLE
fix: stop fragmentation eating a signature byte off an unpadded frame

### DIFF
--- a/app/src/main/java/com/bitchat/android/mesh/FragmentManager.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/FragmentManager.kt
@@ -3,7 +3,6 @@ package com.bitchat.android.mesh
 import android.util.Log
 import com.bitchat.android.protocol.BitchatPacket
 import com.bitchat.android.protocol.MessageType
-import com.bitchat.android.protocol.MessagePadding
 import com.bitchat.android.model.FragmentPayload
 import kotlinx.coroutines.*
 import java.util.concurrent.ConcurrentHashMap
@@ -66,17 +65,16 @@ class FragmentManager {
                 Log.w(TAG, "Rejecting invalid outbound fragment limit: $maxFragments")
                 return emptyList()
             }
-            val encoded = packet.toBinaryData()
-            if (encoded == null) {
+            // Fragment the unpadded frame; each fragment will be encoded (and padded) independently - iOS fix.
+            // Ask the encoder to skip padding rather than un-padding afterwards:
+            // pad() declines a request needing more than 255 bytes and
+            // optimalBlockSize() returns the input size above 2048, so frames of
+            // 513-768, 1009-1792 and >=2033 bytes are never padded. Those end
+            // with the last byte of the signature, and unpad() reads a value of
+            // 0x01 as a one-byte pad and strips a real signature byte.
+            val fullData = packet.toBinaryData(padding = false)
+            if (fullData == null) {
                 Log.e(TAG, "Failed to encode packet to binary data")
-                return emptyList()
-            }
-
-            // Fragment the unpadded frame; each fragment will be encoded (and padded) independently - iOS fix
-            val fullData = try {
-                MessagePadding.unpad(encoded)
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to unpad data: ${e.message}", e)
                 return emptyList()
             }
 

--- a/app/src/test/java/com/bitchat/android/mesh/FragmentManagerTest.kt
+++ b/app/src/test/java/com/bitchat/android/mesh/FragmentManagerTest.kt
@@ -3,6 +3,7 @@ package com.bitchat.android.mesh
 import com.bitchat.android.protocol.BitchatPacket
 import com.bitchat.android.protocol.MessageType
 import com.bitchat.android.model.FragmentPayload
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -242,6 +243,68 @@ class FragmentManagerTest {
         }
 
         assertEquals(257, plan(low).size)
+    }
+
+    /**
+     * pad() declines any request needing more than 255 bytes and
+     * optimalBlockSize() returns the input size unchanged above 2048, so frames
+     * of 513-768, 1009-1792 and >=2033 bytes are emitted unpadded. The frame
+     * then ends with the last byte of the signature, which is uniformly random,
+     * and a value of 0x01 reads as a one-byte PKCS#7 pad.
+     */
+    @Test
+    fun `an unpadded frame keeps every byte through fragmentation`() {
+        for (payloadSize in listOf(600, 1500, 2400)) {
+            val packet = BitchatPacket(
+                version = 1u,
+                type = MessageType.MESSAGE.value,
+                senderID = hexStringToByteArray(senderID),
+                recipientID = hexStringToByteArray(recipientID),
+                timestamp = 1u,
+                payload = ByteArray(payloadSize).also { Random(payloadSize.toLong()).nextBytes(it) },
+                signature = ByteArray(64) { index -> if (index == 63) 0x01 else 0x7F },
+                ttl = 7u
+            )
+
+            val frame = packet.toBinaryData(padding = false)!!
+            val padded = packet.toBinaryData()!!
+            assertEquals("frame of $payloadSize should not be padded", frame.size, padded.size)
+
+            val fragments = fragmentManager.createFragments(packet)
+            assertTrue("frame of $payloadSize should fragment", fragments.size > 1)
+
+            val reassembled = fragments
+                .map { FragmentPayload.decode(it.payload)!!.data }
+                .reduce { acc, next -> acc + next }
+            assertArrayEquals(
+                "fragments of a $payloadSize-byte payload must carry the whole frame",
+                frame,
+                reassembled
+            )
+        }
+    }
+
+    /** A frame that really was padded must still fragment unpadded. */
+    @Test
+    fun `a padded frame is fragmented without its padding`() {
+        val packet = BitchatPacket(
+            version = 1u,
+            type = MessageType.MESSAGE.value,
+            senderID = hexStringToByteArray(senderID),
+            recipientID = hexStringToByteArray(recipientID),
+            timestamp = 1u,
+            payload = ByteArray(900).also { Random(900).nextBytes(it) },
+            signature = ByteArray(64) { 0x7F },
+            ttl = 7u
+        )
+
+        val frame = packet.toBinaryData(padding = false)!!
+        assertTrue("frame should be padded", packet.toBinaryData()!!.size > frame.size)
+
+        val reassembled = fragmentManager.createFragments(packet)
+            .map { FragmentPayload.decode(it.payload)!!.data }
+            .reduce { acc, next -> acc + next }
+        assertArrayEquals(frame, reassembled)
     }
 
     private fun hexStringToByteArray(hexString: String): ByteArray {


### PR DESCRIPTION
Fixes #903.

`createFragments` encodes the packet with `toBinaryData()` — padding on — and then calls `MessagePadding.unpad()` to strip the padding again before splitting. Across most of the fragmentation range no padding was ever applied:

- `pad()` returns the data unchanged when `paddingNeeded > 255`, and
- `optimalBlockSize()` returns the input size unchanged above 2048.

So frames of 513-768, 1009-1792 and >=2033 bytes come back from the encoder untouched. Such a frame ends with the last byte of the Ed25519 signature, which `encode` writes last and which is uniformly random. `unpad()` reads it as a PKCS#7 pad length, and a value of `0x01` satisfies the tail check trivially — one byte, equal to itself — so a real signature byte is stripped.

Every receiver then reassembles the fragments faithfully and fails the size check in `decodeCore`, which is why the message dies on all of them at once with nothing in the sender's log.

The fix is to ask the encoder for the unpadded frame instead of un-padding afterwards. For frames that really were padded the two are byte-identical, so nothing changes on the wire.

iOS does not have this: `BLEOutboundFragmentPlanner` passes the padding flag into `toBinaryData(padding:)` and never un-pads.

### Evidence

The new test walks the three unpadded bands with a signature ending in `0x01` and compares the reassembled fragment payloads against `toBinaryData(padding = false)`. On `main` it fails exactly as the issue describes:

```
array lengths differed, expected.length=694 actual.length=693;
arrays first differed at element [693]; expected:<1> but was:<end of array>
```

One byte, the trailing `0x01`. The second test pins the padded case so the frame keeps being fragmented without its padding.

`testDebugUnitTest lintDebug` is green. Measured per-class with `--rerun-tasks` on both sides rather than by total, since gradle leaves stale result XMLs behind: `main` is 594 tests in 90 classes, this branch is 596 in 90, and `FragmentManagerTest` is the only class that moved (7 -> 9). No other class changed and there are no failures.

### What I did not run

`AGENTS.md` requires Mesh Lab validation on two physical devices for anything touching fragmentation. I have no devices, so that gate is unmet — someone with the rig should run it before this merges. I also have not reproduced the original symptom over the air; the unit test drives the same call sequence `createFragments` uses, which is the level I can actually verify.

No spec under `docs/` describes the fragment padding step, and the wire format is unchanged, so there is nothing to update there.

This was AI-assisted. The diagnosis in #903 did the hard part, including the one-line fix.