### PR TITLE
fix: stop nickname truncation cutting a character in half

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChatUIConstants.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatUIConstants.kt
@@ -1,9 +1,19 @@
 package com.bitchat.android.ui
 
+import java.text.BreakIterator
+
 /**
  * UI constants/utilities for nickname rendering.
  */
 fun truncateNickname(name: String, maxLen: Int = com.bitchat.android.util.AppConstants.UI.MAX_NICKNAME_LENGTH): String {
-    return if (name.length <= maxLen) name else name.take(maxLen)
-}
+    if (name.length <= maxLen) return name
 
+    // The limit counts UTF-16 code units, so cutting at it can land inside a
+    // surrogate pair and leave a lone surrogate that renders as a tofu box, or
+    // split a ZWJ sequence into its parts. Step back to the last grapheme
+    // boundary at or before the limit so what is shown is always whole.
+    val boundaries = BreakIterator.getCharacterInstance()
+    boundaries.setText(name)
+    val end = boundaries.preceding(maxLen + 1)
+    return if (end == BreakIterator.DONE) "" else name.substring(0, end)
+}

--- a/app/src/test/java/com/bitchat/android/ui/ChatUIConstantsTest.kt
+++ b/app/src/test/java/com/bitchat/android/ui/ChatUIConstantsTest.kt
@@ -1,0 +1,79 @@
+package com.bitchat.android.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatUIConstantsTest {
+
+    @Test
+    fun `a name inside the limit is returned unchanged`() {
+        assertEquals("alice", truncateNickname("alice", maxLen = 15))
+        assertEquals("exactlyfifteen!", truncateNickname("exactlyfifteen!", maxLen = 15))
+    }
+
+    @Test
+    fun `an ascii name is still cut at the limit`() {
+        assertEquals("hello world thi", truncateNickname("hello world this is long", maxLen = 15))
+    }
+
+    /**
+     * The limit counts UTF-16 code units, so the 15th unit of this name is the
+     * high surrogate of the emoji. Cutting there leaves a lone surrogate that
+     * renders as a tofu box.
+     */
+    @Test
+    fun `a surrogate pair is never split`() {
+        val truncated = truncateNickname("abcdefghijklmn😀", maxLen = 15)
+
+        assertEquals("abcdefghijklmn", truncated)
+        assertTrue(
+            "truncated name must not end in a lone surrogate",
+            truncated.none { Character.isSurrogate(it) }
+        )
+    }
+
+    @Test
+    fun `an emoji that fits is kept whole`() {
+        assertEquals("abcdefghijkl😀m", truncateNickname("abcdefghijkl😀mno", maxLen = 15))
+    }
+
+    /** A ZWJ sequence is one grapheme, so it is kept or dropped as a whole. */
+    @Test
+    fun `a zwj sequence is not split into its parts`() {
+        val family = "👨‍👩‍👧"
+        val truncated = truncateNickname(family + " family chat", maxLen = 15)
+
+        assertEquals(family + " family", truncated)
+        assertTrue("the family must survive whole", truncated.startsWith(family))
+    }
+
+    @Test
+    fun `a name made only of one long grapheme truncates to empty rather than half a character`() {
+        val family = "👨‍👩‍👧‍👦"
+        val truncated = truncateNickname(family, maxLen = 5)
+
+        assertEquals("", truncated)
+    }
+
+    @Test
+    fun `every truncation stays within the limit and holds no partial character`() {
+        val samples = listOf(
+            "abcdefghijklmn😀",
+            "🇮🇳 india mesh",
+            "👍🏽 thumbs up all round",
+            "plain long nickname here"
+        )
+        for (name in samples) {
+            for (limit in 1..20) {
+                val truncated = truncateNickname(name, maxLen = limit)
+                assertTrue("$name at $limit exceeded the limit", truncated.length <= limit)
+                assertTrue("$name at $limit is not a prefix of the name", name.startsWith(truncated))
+                assertTrue(
+                    "$name at $limit ended in a lone surrogate",
+                    truncated.isEmpty() || !Character.isHighSurrogate(truncated.last())
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
`truncateNickname` compares with `String.length` and cuts with `take`, and both count UTF-16 code units. `MAX_NICKNAME_LENGTH` is 15, so a name whose 15th unit is the high surrogate of an emoji loses its low surrogate and ends in a lone `U+D83D`, which renders as a tofu box.

```
in : abcdefghijklmn😀   (length 16)
out: abcdefghijklmn?   code points: … U+6E U+D83D
```

That is the name shown in the mesh peer list, the geohash people list, and every inline mention, so one emoji in a slightly-long nickname breaks the name everywhere it appears.

The fix steps back to the last grapheme boundary at or before the limit with `BreakIterator`, so what is shown is always whole. The limit itself is unchanged — an ASCII name truncates exactly as before, which the tests pin.

A ZWJ sequence is one grapheme, so it is now kept or dropped as a unit rather than split into its parts. That is the same rule, and it is the reason a name made only of one long grapheme can now truncate to empty at a small limit rather than to half a character.

### Evidence

Seven cases in a new `ChatUIConstantsTest`: the ASCII behaviour (so the limit is provably unchanged), a split surrogate pair, an emoji that fits, a ZWJ sequence, a single-grapheme name, and a sweep over four names at every limit from 1 to 20 asserting the result is always a prefix of the input, always inside the limit, and never ends in a lone surrogate.

Three of the seven fail without the fix — the surrogate case, the single-grapheme case, and the sweep — so they have teeth.

`testDebugUnitTest lintDebug` is green. Measured per-class with `--rerun-tasks` on both sides rather than by total, since gradle leaves stale result XMLs behind: `main` is 594 tests in 90 classes, this branch is 601 in 91, and `ChatUIConstantsTest` is the only class that moved (0 -> 7). No other class changed, no failures.

### What I did not run

This is a rendering change and I have no device, so I have not looked at the peer list on a phone — the evidence is the unit tests over the pure function, not a screenshot. `BreakIterator.getCharacterInstance()` uses the default locale; grapheme boundaries for the cases here do not vary by locale, but I have only exercised it under the test JVM's default.