### PR TITLE
fix: destroy conversation database files when panic wipe throws

### DIFF
--- a/app/src/main/java/com/bitchat/android/services/ConversationRepository.kt
+++ b/app/src/main/java/com/bitchat/android/services/ConversationRepository.kt
@@ -317,6 +317,7 @@ class ConversationRepository internal constructor(
             true
         } catch (error: Exception) {
             Log.e(TAG, "Unable to synchronously clear private conversations", error)
+            database.destroyStorage()
             _storeState.value = ConversationStoreState.Error(
                 error.message ?: "Unable to erase conversations"
             )
@@ -1095,6 +1096,22 @@ internal class ConversationDatabase(
         }
         writableDatabase.rawQuery("PRAGMA wal_checkpoint(TRUNCATE)", null).use { }
         writableDatabase.rawQuery("PRAGMA incremental_vacuum", null).use { }
+    }
+
+    /**
+     * Last-resort panic cleanup when [clearAll] throws: drop the encrypted database
+     * files so a later reload cannot resurrect erased conversations (#699).
+     */
+    fun destroyStorage() {
+        try {
+            clearAll()
+        } catch (error: Exception) {
+            Log.e(TAG, "clearAll failed during destroyStorage; deleting database files", error)
+        }
+        try {
+            close()
+        } catch (_: Exception) { }
+        applicationContext.deleteDatabase(databaseName)
     }
 
     fun pruneToRetentionLimits(): Set<String> {

--- a/app/src/test/kotlin/com/bitchat/android/services/ConversationDatabaseTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/services/ConversationDatabaseTest.kt
@@ -434,6 +434,22 @@ class ConversationDatabaseTest {
     }
 
     @Test
+    fun `destroy storage deletes database files so history cannot reload`() {
+        database.upsertMessage(
+            "contact_alice",
+            setOf("contact_alice"),
+            "alice",
+            message("survives-failure", "alice", 1L),
+            true
+        )
+        assertTrue(context.databaseList().contains(databaseName))
+
+        database.destroyStorage()
+
+        assertFalse(context.databaseList().contains(databaseName))
+    }
+
+    @Test
     fun `version one plaintext database migrates without losing history`() {
         database.close()
         context.deleteDatabase(databaseName)


### PR DESCRIPTION
## Summary
- Panic wipe already cleared in-memory conversation state, then called SQLite `clearAll()`. If that throw happened after the UI was emptied, a process restart could reload the encrypted database files (#699).
- On that failure path, close the database and delete its files so history cannot come back.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests com.bitchat.android.services.ConversationDatabaseTest` locally (includes `destroy storage deletes database files so history cannot reload`)
- [ ] remaining unit tests / lint on CI

Made with [Cursor](https://cursor.com)