### PR TITLE
fix(ui): register the chat back handler once instead of per recomposition

### DIFF
--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -313,15 +313,11 @@ class MainActivity : OrientationAwareActivity() {
             }
 
             OnboardingState.CHECKING, OnboardingState.INITIALIZING, OnboardingState.COMPLETE -> {
-                // Intercept Back only while the chat has navigation state to
-                // unwind. Staying disabled otherwise lets the dispatcher fall
-                // through to the system, which exits the app.
                 val canHandleBack by chatViewModel.canHandleBack.collectAsState()
+                // Disabled rather than always-on so predictive back can preview
+                // the exit instead of the app claiming every gesture.
                 BackHandler(enabled = canHandleBack) {
-                    // enabled reaches this handler a dispatch and a recomposition
-                    // after the state changes, so a second press can arrive while
-                    // it is still true but there is no longer anything to unwind.
-                    // Forward that press instead of swallowing it.
+                    // enabled trails the state by a dispatch and a recomposition.
                     if (!chatViewModel.handleBackPressed()) finish()
                 }
                 ChatScreen(viewModel = chatViewModel)

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.OnBackPressedCallback
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -313,23 +313,13 @@ class MainActivity : OrientationAwareActivity() {
             }
 
             OnboardingState.CHECKING, OnboardingState.INITIALIZING, OnboardingState.COMPLETE -> {
-                // Set up back navigation handling for the chat screen
-                val backCallback = object : OnBackPressedCallback(true) {
-                    override fun handleOnBackPressed() {
-                        // Let ChatViewModel handle navigation state
-                        val handled = chatViewModel.handleBackPressed()
-                        if (!handled) {
-                            // If ChatViewModel doesn't handle it, disable this callback
-                            // and let the system handle it (which will exit the app)
-                            this.isEnabled = false
-                            onBackPressedDispatcher.onBackPressed()
-                            this.isEnabled = true
-                        }
-                    }
+                // Intercept Back only while the chat has navigation state to
+                // unwind. Staying disabled otherwise lets the dispatcher fall
+                // through to the system, which exits the app.
+                val canHandleBack by chatViewModel.canHandleBack.collectAsState()
+                BackHandler(enabled = canHandleBack) {
+                    chatViewModel.handleBackPressed()
                 }
-
-                // Add the callback - this will be automatically removed when the activity is destroyed
-                onBackPressedDispatcher.addCallback(this, backCallback)
                 ChatScreen(viewModel = chatViewModel)
             }
             

--- a/app/src/main/java/com/bitchat/android/MainActivity.kt
+++ b/app/src/main/java/com/bitchat/android/MainActivity.kt
@@ -318,7 +318,11 @@ class MainActivity : OrientationAwareActivity() {
                 // through to the system, which exits the app.
                 val canHandleBack by chatViewModel.canHandleBack.collectAsState()
                 BackHandler(enabled = canHandleBack) {
-                    chatViewModel.handleBackPressed()
+                    // enabled reaches this handler a dispatch and a recomposition
+                    // after the state changes, so a second press can arrive while
+                    // it is still true but there is no longer anything to unwind.
+                    // Forward that press instead of swallowing it.
+                    if (!chatViewModel.handleBackPressed()) finish()
                 }
                 ChatScreen(viewModel = chatViewModel)
             }

--- a/app/src/main/java/com/bitchat/android/ui/ChatState.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatState.kt
@@ -170,6 +170,28 @@ class ChatState(
             initialValue = false
         )
     
+    // True while some in-app navigation state is open for Back to unwind.
+    // Mirrors the branches of ChatViewModel.handleBackPressed: the back
+    // handler is enabled from this, the press is consumed by that, and the
+    // two drifting apart is what makes Back feel broken.
+    val canHandleBack: StateFlow<Boolean> = combine(
+        _showAppInfo,
+        _showPasswordPrompt,
+        _selectedPrivateChatPeer,
+        _privateChatSheetPeer,
+        _currentChannel
+    ) { showAppInfo, showPasswordPrompt, privateChatPeer, privateChatSheetPeer, channel ->
+        showAppInfo ||
+            showPasswordPrompt ||
+            privateChatPeer != null ||
+            privateChatSheetPeer != null ||
+            channel != null
+    }.stateIn(
+        scope = scope,
+        started = WhileSubscribed(5_000),
+        initialValue = false
+    )
+
     // Getters for internal state access
     fun getMessagesValue() = _messages.value
     fun getConnectedPeersValue() = _connectedPeers.value

--- a/app/src/main/java/com/bitchat/android/ui/ChatState.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatState.kt
@@ -170,10 +170,8 @@ class ChatState(
             initialValue = false
         )
     
-    // True while some in-app navigation state is open for Back to unwind.
-    // Mirrors the branches of ChatViewModel.handleBackPressed: the back
-    // handler is enabled from this, the press is consumed by that, and the
-    // two drifting apart is what makes Back feel broken.
+    // Mirrors the branches of ChatViewModel.handleBackPressed. The back handler
+    // is enabled from this and the press consumed by that, so they must agree.
     val canHandleBack: StateFlow<Boolean> = combine(
         _showAppInfo,
         _showPasswordPrompt,

--- a/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatViewModel.kt
@@ -377,6 +377,7 @@ class ChatViewModel(
     val passwordPromptChannel: StateFlow<String?> = state.passwordPromptChannel
     val hasUnreadChannels = state.hasUnreadChannels
     val hasUnreadPrivateMessages = state.hasUnreadPrivateMessages
+    val canHandleBack = state.canHandleBack
     val showCommandSuggestions: StateFlow<Boolean> = state.showCommandSuggestions
     val commandSuggestions: StateFlow<List<CommandSuggestion>> = state.commandSuggestions
     val showMentionSuggestions: StateFlow<Boolean> = state.showMentionSuggestions

--- a/app/src/test/kotlin/com/bitchat/android/ui/ChatStateBackNavigationTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/ui/ChatStateBackNavigationTest.kt
@@ -12,10 +12,9 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * `canHandleBack` tells the chat screen's back handler whether there is any
- * in-app navigation state left to unwind. It has to agree with the branches of
- * [ChatViewModel.handleBackPressed], because the handler is enabled from one
- * and the press is consumed by the other.
+ * `canHandleBack` must agree with the branches of
+ * [ChatViewModel.handleBackPressed]: the back handler is enabled from one and
+ * the press consumed by the other.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ChatStateBackNavigationTest {
@@ -28,9 +27,7 @@ class ChatStateBackNavigationTest {
     fun setUp() {
         scope = TestScope(UnconfinedTestDispatcher())
         state = ChatState(scope)
-        // canHandleBack is shared WhileSubscribed, so it only tracks its
-        // sources while something collects it. The composable does that in
-        // production; the test has to do it explicitly.
+        // Shared WhileSubscribed, so it only tracks its sources while collected.
         subscription = scope.launch { state.canHandleBack.collect { } }
     }
 

--- a/app/src/test/kotlin/com/bitchat/android/ui/ChatStateBackNavigationTest.kt
+++ b/app/src/test/kotlin/com/bitchat/android/ui/ChatStateBackNavigationTest.kt
@@ -1,0 +1,93 @@
+package com.bitchat.android.ui
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * `canHandleBack` tells the chat screen's back handler whether there is any
+ * in-app navigation state left to unwind. It has to agree with the branches of
+ * [ChatViewModel.handleBackPressed], because the handler is enabled from one
+ * and the press is consumed by the other.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatStateBackNavigationTest {
+
+    private lateinit var scope: TestScope
+    private lateinit var state: ChatState
+    private lateinit var subscription: Job
+
+    @Before
+    fun setUp() {
+        scope = TestScope(UnconfinedTestDispatcher())
+        state = ChatState(scope)
+        // canHandleBack is shared WhileSubscribed, so it only tracks its
+        // sources while something collects it. The composable does that in
+        // production; the test has to do it explicitly.
+        subscription = scope.launch { state.canHandleBack.collect { } }
+    }
+
+    @After
+    fun tearDown() {
+        subscription.cancel()
+    }
+
+    @Test
+    fun `is false on the bare chat screen`() {
+        assertFalse(state.canHandleBack.value)
+    }
+
+    @Test
+    fun `is true while the app info dialog is open`() {
+        state.setShowAppInfo(true)
+
+        assertTrue(state.canHandleBack.value)
+    }
+
+    @Test
+    fun `is true while the password prompt is open`() {
+        state.setShowPasswordPrompt(true)
+
+        assertTrue(state.canHandleBack.value)
+    }
+
+    @Test
+    fun `is true while a private chat is selected`() {
+        state.setSelectedPrivateChatPeer("peer-a")
+
+        assertTrue(state.canHandleBack.value)
+    }
+
+    @Test
+    fun `is true while the private chat sheet is open`() {
+        state.setPrivateChatSheetPeer("peer-a")
+
+        assertTrue(state.canHandleBack.value)
+    }
+
+    @Test
+    fun `is true while a channel is open`() {
+        state.setCurrentChannel("#bitchat")
+
+        assertTrue(state.canHandleBack.value)
+    }
+
+    @Test
+    fun `returns to false once the last overlay closes`() {
+        state.setCurrentChannel("#bitchat")
+        state.setShowAppInfo(true)
+
+        state.setShowAppInfo(false)
+        assertTrue("the channel is still open", state.canHandleBack.value)
+
+        state.setCurrentChannel(null)
+        assertFalse("nothing is left to unwind", state.canHandleBack.value)
+    }
+}


### PR DESCRIPTION
# Description

The chat branch of `OnboardingFlowScreen` built an `OnBackPressedCallback` and called `addCallback(this, …)` **from inside a composable body**. Composable bodies re-run on recomposition, and that function observes eight `MainViewModel` StateFlows, so every Bluetooth or location change registered another one. They were bound to the activity, so none were released until `onDestroy`.

Each accumulated callback also multiplied an unhandled Back press: the callback disabled itself, re-dispatched, and the next one down consulted `ChatViewModel` again.

## Measured on a Pixel 9a

Launch, toggle Bluetooth three times, press Back once — one process throughout, no restart:

| | before | after |
|---|---|---|
| back callbacks alive | **9** | **1** |
| `handleBackPressed()` calls per Back press | **9** | **0** |

Zero rather than one because `canHandleBack` was false, so the handler stayed disabled and the dispatcher went straight to the system. (Probe instrumentation was temporary and is not in this diff.)

## The fix

`BackHandler` keeps one registration across recompositions and disposes it when the branch leaves composition.

```kotlin
val canHandleBack by chatViewModel.canHandleBack.collectAsState()
// Disabled rather than always-on so predictive back can preview
// the exit instead of the app claiming every gesture.
BackHandler(enabled = canHandleBack) {
    // enabled trails the state by a dispatch and a recomposition.
    if (!chatViewModel.handleBackPressed()) finish()
}
```

`ChatState.canHandleBack` combines the five flows `handleBackPressed()` already branches on. Two notes on the shape:

- `enabled` is a variable rather than `true` for predictive back. With `targetSdk 37` and no opt-out, a permanently-enabled callback would claim every gesture and the exit preview would never show. The callback this replaces had that flaw.
- `enabled` reaches the handler a dispatch and a recomposition after the state changes, so a fast second press can arrive while it is still true with nothing left to unwind. `finish()` forwards that press, which is where the dispatcher ended up before.

No behaviour change otherwise: overlays close in the same order, and Back from the bare chat screen still exits.

## Verification

`:app:assembleDebug` and **598 unit tests** (3 pre-existing skips), including 7 new ones covering `canHandleBack` against each condition and the return-to-false transition. They pin the contract that the handler is enabled from one place and the press consumed by another, rather than the wiring.

## Checklist

- [x] I have read the contribution guidelines
- [x] I have performed a self-review of my code
- [ ] I have mentioned the corresponding issue — no existing issue; happy to open one
- [x] If it is a core feature, I have added automated tests
