### PR TITLE
Improve Wear layouts for round screens

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         targetSdk = libs.versions.targetSdk.get().toInt()
         // Wear releases use a separate high range because Play requires every artifact in
         // one application ID to have a unique version code across all form factors.
-        versionCode = 1_000_000_002
-        versionName = "0.1.1"
+        versionCode = 1_000_000_003
+        versionName = "0.1.2"
 
         vectorDrawables {
             useSupportLibrary = true

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -22,10 +22,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
@@ -87,35 +88,41 @@ fun ChatScaffold(
         previousCount = messages.size
     }
 
-    // One state drives both overlays: visible at the bottom or when scrolling toward it,
-    // hidden when scrolling up into history. The 24px (~12dp) threshold is deliberately
-    // small so the controls answer every flick immediately.
-    var atNewest by remember { mutableStateOf(true) }
+    // Follow intent is changed only by an actual user scroll away from the newest item or by
+    // reaching the end again. A new item temporarily makes canScrollForward true before layout;
+    // treating that transient range change as user intent breaks automatic following.
+    var followNewest by remember { mutableStateOf(true) }
     val controlsVisible = remember { mutableStateOf(true) }
     LaunchedEffect(columnState) {
         var lastPosition = -1
         snapshotFlow {
             val first = columnState.layoutInfo.visibleItems.firstOrNull()
-            Triple(columnState.canScrollForward, first?.index ?: 0, first?.offset ?: 0)
-        }.collect { (canScrollForward, index, offset) ->
-            val position = index * 100_000 + offset
-            atNewest = !canScrollForward
-            if (!canScrollForward) {
+            ChatScrollSnapshot(
+                canScrollForward = columnState.canScrollForward,
+                isScrollInProgress = columnState.isScrollInProgress,
+                position = (first?.index ?: 0) * 100_000 + (first?.offset ?: 0)
+            )
+        }.collect { snapshot ->
+            followNewest = updatedFollowNewest(
+                current = followNewest,
+                snapshot = snapshot,
+                previousPosition = lastPosition
+            )
+            if (!snapshot.canScrollForward) {
                 controlsVisible.value = true
             } else if (lastPosition >= 0) {
                 when {
-                    position > lastPosition + 24 -> controlsVisible.value = true
-                    position < lastPosition - 24 -> controlsVisible.value = false
+                    snapshot.position > lastPosition + CHAT_SCROLL_DIRECTION_THRESHOLD_PX ->
+                        controlsVisible.value = true
+                    snapshot.position < lastPosition - CHAT_SCROLL_DIRECTION_THRESHOLD_PX ->
+                        controlsVisible.value = false
                 }
             }
-            lastPosition = position
+            lastPosition = snapshot.position
         }
     }
 
-    // Stick to bottom: follow new messages while resting at the newest.
-    // Capture this when the message count changes, before the new layout can temporarily make
-    // canScrollForward true and report that the user is browsing history.
-    val followNewest = remember(messages.size) { atNewest }
+    // Stick to bottom when the user has not intentionally moved into history.
     LaunchedEffect(columnState, messages.size) {
         if (messages.isNotEmpty() && followNewest) {
             val expectedSingleMessageKey = messages.singleOrNull()?.id
@@ -159,6 +166,24 @@ internal data class MeasuredChatLayout(
     val itemCount: Int,
     val singleVisibleItemKey: Any?
 )
+
+internal data class ChatScrollSnapshot(
+    val canScrollForward: Boolean,
+    val isScrollInProgress: Boolean,
+    val position: Int
+)
+
+internal fun updatedFollowNewest(
+    current: Boolean,
+    snapshot: ChatScrollSnapshot,
+    previousPosition: Int
+): Boolean = when {
+    !snapshot.canScrollForward -> true
+    snapshot.isScrollInProgress &&
+        previousPosition >= 0 &&
+        snapshot.position < previousPosition - CHAT_SCROLL_DIRECTION_THRESHOLD_PX -> false
+    else -> current
+}
 
 internal suspend fun scrollToNewestAfterItemsMeasured(
     expectedItemCount: Int,
@@ -268,18 +293,30 @@ private fun ChatBody(
                 state = columnState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(top = 30.dp, bottom = 64.dp)
-                    .clipToBounds(),
+                    // Keep full-screen measurement so Wear's transformation focal point and
+                    // scroll range stay correct. Only drawing is clipped around the overlays.
+                    .drawWithContent {
+                        clipRect(
+                            top = headerBackdropHeight.toPx(),
+                            bottom = size.height - CHAT_ACTION_BAR_CLEARANCE.toPx()
+                        ) {
+                            this@drawWithContent.drawContent()
+                        }
+                    },
                 // Arrangement.Bottom anchors short content to the bottom: the first message
                 // starts just above the action bar and new messages push history upward.
                 // The viewport itself stays between the floating header and action bar, so
-                // rows cannot scroll underneath either control. Its geometry is constant,
-                // so showing or hiding the overlays never disturbs an in-flight gesture.
+                // content stays clear of both controls while the full-screen list geometry keeps
+                // autoscroll and the native transformation focal point intact.
                 verticalArrangement = Arrangement.Bottom,
                 // Wear Material already supplies a responsive 5.2% horizontal inset. Keep it,
-                // but omit the scaffold's vertical inset because the viewport itself reserves
-                // the header and action-bar space. Stacking both made chat narrow and too high.
-                contentPadding = scaffoldPadding.horizontalOnly(layoutDirection)
+                // while replacing its vertical inset with the overlay clearances used before the
+                // shape fix. This avoids both duplicated padding and a shortened list viewport.
+                contentPadding = scaffoldPadding.withVerticalClearance(
+                    layoutDirection = layoutDirection,
+                    top = CHAT_HEADER_CONTENT_CLEARANCE,
+                    bottom = CHAT_ACTION_BAR_CLEARANCE
+                )
             ) {
                 if (messages.isEmpty()) {
                     item {
@@ -356,6 +393,9 @@ private fun ChatBody(
 // Extra finger slack (px, ~28dp at watch density) around the cancel target so the snap
 // engages as the finger approaches, not only on exact contact.
 private const val CANCEL_HOVER_SLANT_PX = 56f
+private const val CHAT_SCROLL_DIRECTION_THRESHOLD_PX = 24
+private val CHAT_HEADER_CONTENT_CLEARANCE = 30.dp
+private val CHAT_ACTION_BAR_CLEARANCE = 64.dp
 // Magnetic zone geometry (px at watch density): the button starts reacting at
 // MAGNET_OUTER_PX from its center and fully blushes at MAGNET_INNER_PX (~the activation
 // boundary); it leans toward the finger by up to MAGNET_PULL_PX.

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -6,12 +6,10 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,15 +20,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
@@ -40,7 +35,6 @@ import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.ScreenScaffold
-import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.lazy.rememberTransformationSpec
 import androidx.wear.compose.material3.lazy.transformedHeight
@@ -215,8 +209,6 @@ private fun ChatBody(
     val palette = LocalBitchatPalette.current
     val context = LocalContext.current
     val transformationSpec = rememberTransformationSpec()
-    val headerBackdropHeight = if (LocalConfiguration.current.isScreenRound) 49.dp else 37.dp
-
     // Slide-to-cancel: while recording, the finger's position is tracked globally; the
     // overlay's mic button reports its bounds and becomes the cancel target when the
     // finger hovers it (with generous slack so the snap engages on approach).
@@ -291,23 +283,16 @@ private fun ChatBody(
             val layoutDirection = LocalLayoutDirection.current
             TransformingLazyColumn(
                 state = columnState,
-                modifier = Modifier
-                    .fillMaxSize()
-                    // Keep full-screen measurement so Wear's transformation focal point and
-                    // scroll range stay correct. Only drawing is clipped around the overlays.
-                    .drawWithContent {
-                        clipRect(
-                            top = headerBackdropHeight.toPx(),
-                            bottom = size.height - CHAT_ACTION_BAR_CLEARANCE.toPx()
-                        ) {
-                            this@drawWithContent.drawContent()
-                        }
-                    },
+                // Keep the list full-screen and unclipped. Wear's transformation spec scales
+                // and fades rows naturally along the round display edge, including underneath
+                // the transparent header and floating action controls.
+                modifier = Modifier.fillMaxSize(),
                 // Arrangement.Bottom anchors short content to the bottom: the first message
                 // starts just above the action bar and new messages push history upward.
-                // The viewport itself stays between the floating header and action bar, so
-                // content stays clear of both controls while the full-screen list geometry keeps
-                // autoscroll and the native transformation focal point intact.
+                // The scroll range reserves resting space for the floating controls while the
+                // full-screen viewport preserves autoscroll and the native transformation focal
+                // point. Rows may travel behind the overlays only after they have begun the Wear
+                // edge scale/fade treatment.
                 verticalArrangement = Arrangement.Bottom,
                 // Wear Material already supplies a responsive 5.2% horizontal inset. Keep it,
                 // while replacing its vertical inset with the overlay clearances used before the
@@ -353,11 +338,7 @@ private fun ChatBody(
         Box(
             modifier = Modifier
                 .align(Alignment.TopCenter)
-                .fillMaxWidth()
-                // Overlap the clipped list viewport enough for each shape so transformed
-                // glyphs cannot leave antialiased remnants exactly on the boundary.
-                .height(headerBackdropHeight)
-                .background(MaterialTheme.colorScheme.background),
+                .fillMaxWidth(),
             contentAlignment = Alignment.TopCenter
         ) {
             header(controlsVisible)

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -6,10 +6,12 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -20,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.graphicsLayer
@@ -35,6 +38,7 @@ import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.lazy.rememberTransformationSpec
 import androidx.wear.compose.material3.lazy.transformedHeight
@@ -262,7 +266,8 @@ private fun ChatBody(
                 state = columnState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(top = 30.dp, bottom = 64.dp),
+                    .padding(top = 30.dp, bottom = 64.dp)
+                    .clipToBounds(),
                 // Arrangement.Bottom anchors short content to the bottom: the first message
                 // starts just above the action bar and new messages push history upward.
                 // The viewport itself stays between the floating header and action bar, so
@@ -304,7 +309,14 @@ private fun ChatBody(
 
         // The header stays put and shrinks to its dense form instead of disappearing;
         // as an overlay its size animation never touches the list's scroll geometry.
-        Box(modifier = Modifier.align(Alignment.TopCenter)) {
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .height(30.dp)
+                .background(MaterialTheme.colorScheme.background),
+            contentAlignment = Alignment.TopCenter
+        ) {
             header(controlsVisible)
         }
 

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -266,11 +266,13 @@ private fun ChatBody(
                 // The padding reserves permanent room for the floating header and action
                 // bar; being constant, it never disturbs an in-flight scroll gesture.
                 verticalArrangement = Arrangement.Bottom,
-                contentPadding = scaffoldPadding.withMinimumVerticalPadding(
-                    layoutDirection = layoutDirection,
-                    top = 30.dp,
-                    bottom = 64.dp
-                )
+                contentPadding = scaffoldPadding
+                    .withRoundScreenPadding(layoutDirection)
+                    .withMinimumVerticalPadding(
+                        layoutDirection = layoutDirection,
+                        top = 30.dp,
+                        bottom = 64.dp
+                    )
             ) {
                 if (messages.isEmpty()) {
                     item {

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -20,12 +20,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
@@ -209,6 +215,7 @@ private fun ChatBody(
     val palette = LocalBitchatPalette.current
     val context = LocalContext.current
     val transformationSpec = rememberTransformationSpec()
+    val isScreenRound = LocalConfiguration.current.isScreenRound
     // Slide-to-cancel: while recording, the finger's position is tracked globally; the
     // overlay's mic button reports its bounds and becomes the cancel target when the
     // finger hovers it (with generous slack so the snap engages on approach).
@@ -283,10 +290,44 @@ private fun ChatBody(
             val layoutDirection = LocalLayoutDirection.current
             TransformingLazyColumn(
                 state = columnState,
-                // Keep the list full-screen and unclipped. Wear's transformation spec scales
-                // and fades rows naturally along the round display edge, including underneath
-                // the transparent header and floating action controls.
-                modifier = Modifier.fillMaxSize(),
+                // Keep the list full-screen and geometrically unclipped. Wear's transformation
+                // spec curves rows along the round display; a soft destination-alpha mask then
+                // makes them fully transparent at the physical edges instead of cutting glyphs.
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        compositingStrategy = CompositingStrategy.Offscreen
+                    }
+                    .drawWithContent {
+                        drawContent()
+                        val edgeMask = if (isScreenRound) {
+                            // Fade toward the actual circular contour so glyphs become
+                            // transparent before the panel can crop their left or right edge.
+                            Brush.radialGradient(
+                                0f to Color.Black,
+                                CHAT_ROUND_EDGE_OPAQUE_STOP to Color.Black,
+                                1f to Color.Transparent,
+                                center = Offset(size.width / 2f, size.height / 2f),
+                                radius = size.minDimension / 2f
+                            )
+                        } else {
+                            val topOpaqueStop =
+                                (CHAT_HEADER_EDGE_FADE.toPx() / size.height).coerceIn(0f, 1f)
+                            val bottomOpaqueStop =
+                                (1f - CHAT_ACTION_BAR_EDGE_FADE.toPx() / size.height)
+                                    .coerceIn(topOpaqueStop, 1f)
+                            Brush.verticalGradient(
+                                0f to Color.Transparent,
+                                topOpaqueStop to Color.Black,
+                                bottomOpaqueStop to Color.Black,
+                                1f to Color.Transparent
+                            )
+                        }
+                        drawRect(
+                            brush = edgeMask,
+                            blendMode = BlendMode.DstIn
+                        )
+                    },
                 // Arrangement.Bottom anchors short content to the bottom: the first message
                 // starts just above the action bar and new messages push history upward.
                 // The scroll range reserves resting space for the floating controls while the
@@ -377,6 +418,9 @@ private const val CANCEL_HOVER_SLANT_PX = 56f
 private const val CHAT_SCROLL_DIRECTION_THRESHOLD_PX = 24
 private val CHAT_HEADER_CONTENT_CLEARANCE = 30.dp
 private val CHAT_ACTION_BAR_CLEARANCE = 64.dp
+private val CHAT_HEADER_EDGE_FADE = 36.dp
+private val CHAT_ACTION_BAR_EDGE_FADE = 72.dp
+private const val CHAT_ROUND_EDGE_OPAQUE_STOP = 0.78f
 // Magnetic zone geometry (px at watch density): the button starts reacting at
 // MAGNET_OUTER_PX from its center and fully blushes at MAGNET_INNER_PX (~the activation
 // boundary); it leans toward the finger by up to MAGNET_PULL_PX.

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.BlendMode
@@ -298,8 +298,7 @@ private fun ChatBody(
                     .graphicsLayer {
                         compositingStrategy = CompositingStrategy.Offscreen
                     }
-                    .drawWithContent {
-                        drawContent()
+                    .drawWithCache {
                         val edgeMask = if (isScreenRound) {
                             // Fade toward the actual circular contour so glyphs become
                             // transparent before the panel can crop their left or right edge.
@@ -323,10 +322,13 @@ private fun ChatBody(
                                 1f to Color.Transparent
                             )
                         }
-                        drawRect(
-                            brush = edgeMask,
-                            blendMode = BlendMode.DstIn
-                        )
+                        onDrawWithContent {
+                            drawContent()
+                            drawRect(
+                                brush = edgeMask,
+                                blendMode = BlendMode.DstIn
+                            )
+                        }
                     },
                 // Arrangement.Bottom anchors short content to the bottom: the first message
                 // starts just above the action bar and new messages push history upward.
@@ -335,9 +337,9 @@ private fun ChatBody(
                 // point. Rows may travel behind the overlays only after they have begun the Wear
                 // edge scale/fade treatment.
                 verticalArrangement = Arrangement.Bottom,
-                // Wear Material already supplies a responsive 5.2% horizontal inset. Keep it,
-                // while replacing its vertical inset with the overlay clearances used before the
-                // shape fix. This avoids both duplicated padding and a shortened list viewport.
+                // Keep Wear Material's responsive horizontal inset while replacing its vertical
+                // inset with the overlay clearances used before the shape fix. This avoids both
+                // duplicated padding and a shortened list viewport.
                 contentPadding = scaffoldPadding.withVerticalClearance(
                     layoutDirection = layoutDirection,
                     top = CHAT_HEADER_CONTENT_CLEARANCE,

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -28,6 +27,7 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
@@ -256,7 +256,8 @@ private fun ChatBody(
                 }
             }
     ) {
-        ScreenScaffold(scrollState = columnState) {
+        ScreenScaffold(scrollState = columnState) { scaffoldPadding ->
+            val layoutDirection = LocalLayoutDirection.current
             TransformingLazyColumn(
                 state = columnState,
                 modifier = Modifier.fillMaxSize(),
@@ -265,7 +266,11 @@ private fun ChatBody(
                 // The padding reserves permanent room for the floating header and action
                 // bar; being constant, it never disturbs an in-flight scroll gesture.
                 verticalArrangement = Arrangement.Bottom,
-                contentPadding = PaddingValues(top = 30.dp, bottom = 64.dp)
+                contentPadding = scaffoldPadding.withMinimumVerticalPadding(
+                    layoutDirection = layoutDirection,
+                    top = 30.dp,
+                    bottom = 64.dp
+                )
             ) {
                 if (messages.isEmpty()) {
                     item {

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -190,7 +190,7 @@ private fun ChatBody(
     val palette = LocalBitchatPalette.current
     val context = LocalContext.current
     val transformationSpec = rememberTransformationSpec()
-    val headerBackdropHeight = if (LocalConfiguration.current.isScreenRound) 35.dp else 37.dp
+    val headerBackdropHeight = if (LocalConfiguration.current.isScreenRound) 49.dp else 37.dp
 
     // Slide-to-cancel: while recording, the finger's position is tracked globally; the
     // overlay's mic button reports its bounds and becomes the cancel target when the
@@ -276,8 +276,10 @@ private fun ChatBody(
                 // rows cannot scroll underneath either control. Its geometry is constant,
                 // so showing or hiding the overlays never disturbs an in-flight gesture.
                 verticalArrangement = Arrangement.Bottom,
-                contentPadding = scaffoldPadding
-                    .withRoundScreenPadding(layoutDirection)
+                // Wear Material already supplies a responsive 5.2% horizontal inset. Keep it,
+                // but omit the scaffold's vertical inset because the viewport itself reserves
+                // the header and action-bar space. Stacking both made chat narrow and too high.
+                contentPadding = scaffoldPadding.horizontalOnly(layoutDirection)
             ) {
                 if (messages.isEmpty()) {
                     item {

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
@@ -189,6 +190,7 @@ private fun ChatBody(
     val palette = LocalBitchatPalette.current
     val context = LocalContext.current
     val transformationSpec = rememberTransformationSpec()
+    val headerBackdropHeight = if (LocalConfiguration.current.isScreenRound) 35.dp else 37.dp
 
     // Slide-to-cancel: while recording, the finger's position is tracked globally; the
     // overlay's mic button reports its bounds and becomes the cancel target when the
@@ -313,9 +315,9 @@ private fun ChatBody(
             modifier = Modifier
                 .align(Alignment.TopCenter)
                 .fillMaxWidth()
-                // Overlap the clipped list viewport by 4dp so transformed glyphs cannot
-                // leave antialiased remnants exactly on the boundary at larger font scales.
-                .height(34.dp)
+                // Overlap the clipped list viewport enough for each shape so transformed
+                // glyphs cannot leave antialiased remnants exactly on the boundary.
+                .height(headerBackdropHeight)
                 .background(MaterialTheme.colorScheme.background),
             contentAlignment = Alignment.TopCenter
         ) {

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -313,7 +313,9 @@ private fun ChatBody(
             modifier = Modifier
                 .align(Alignment.TopCenter)
                 .fillMaxWidth()
-                .height(30.dp)
+                // Overlap the clipped list viewport by 4dp so transformed glyphs cannot
+                // leave antialiased remnants exactly on the boundary at larger font scales.
+                .height(34.dp)
                 .background(MaterialTheme.colorScheme.background),
             contentAlignment = Alignment.TopCenter
         ) {

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -260,19 +260,17 @@ private fun ChatBody(
             val layoutDirection = LocalLayoutDirection.current
             TransformingLazyColumn(
                 state = columnState,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 30.dp, bottom = 64.dp),
                 // Arrangement.Bottom anchors short content to the bottom: the first message
                 // starts just above the action bar and new messages push history upward.
-                // The padding reserves permanent room for the floating header and action
-                // bar; being constant, it never disturbs an in-flight scroll gesture.
+                // The viewport itself stays between the floating header and action bar, so
+                // rows cannot scroll underneath either control. Its geometry is constant,
+                // so showing or hiding the overlays never disturbs an in-flight gesture.
                 verticalArrangement = Arrangement.Bottom,
                 contentPadding = scaffoldPadding
                     .withRoundScreenPadding(layoutDirection)
-                    .withMinimumVerticalPadding(
-                        layoutDirection = layoutDirection,
-                        top = 30.dp,
-                        bottom = 64.dp
-                    )
             ) {
                 if (messages.isEmpty()) {
                     item {

--- a/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/ChatScaffold.kt
@@ -50,6 +50,7 @@ import com.bitchat.watch.ui.theme.ChatVisualTokens
 import com.bitchat.watch.ui.theme.LocalBitchatPalette
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlin.math.sign
 
 /**
  * The shared chat body for global chat and DM threads, following the classic messenger
@@ -95,6 +96,7 @@ fun ChatScaffold(
     val controlsVisible = remember { mutableStateOf(true) }
     LaunchedEffect(columnState) {
         var lastPosition = -1
+        var scrollIntent = ChatScrollIntentState()
         snapshotFlow {
             val first = columnState.layoutInfo.visibleItems.firstOrNull()
             ChatScrollSnapshot(
@@ -103,21 +105,13 @@ fun ChatScaffold(
                 position = (first?.index ?: 0) * 100_000 + (first?.offset ?: 0)
             )
         }.collect { snapshot ->
-            followNewest = updatedFollowNewest(
-                current = followNewest,
+            scrollIntent = updatedChatScrollIntent(
+                current = scrollIntent,
                 snapshot = snapshot,
                 previousPosition = lastPosition
             )
-            if (!snapshot.canScrollForward) {
-                controlsVisible.value = true
-            } else if (lastPosition >= 0) {
-                when {
-                    snapshot.position > lastPosition + CHAT_SCROLL_DIRECTION_THRESHOLD_PX ->
-                        controlsVisible.value = true
-                    snapshot.position < lastPosition - CHAT_SCROLL_DIRECTION_THRESHOLD_PX ->
-                        controlsVisible.value = false
-                }
-            }
+            followNewest = scrollIntent.followsNewest
+            controlsVisible.value = scrollIntent.controlsVisible
             lastPosition = snapshot.position
         }
     }
@@ -173,16 +167,42 @@ internal data class ChatScrollSnapshot(
     val position: Int
 )
 
-internal fun updatedFollowNewest(
-    current: Boolean,
+internal data class ChatScrollIntentState(
+    val followsNewest: Boolean = true,
+    val controlsVisible: Boolean = true,
+    val accumulatedDeltaPx: Int = 0
+)
+
+internal fun updatedChatScrollIntent(
+    current: ChatScrollIntentState,
     snapshot: ChatScrollSnapshot,
     previousPosition: Int
-): Boolean = when {
-    !snapshot.canScrollForward -> true
-    snapshot.isScrollInProgress &&
-        previousPosition >= 0 &&
-        snapshot.position < previousPosition - CHAT_SCROLL_DIRECTION_THRESHOLD_PX -> false
-    else -> current
+): ChatScrollIntentState {
+    if (!snapshot.canScrollForward) return ChatScrollIntentState()
+    if (!snapshot.isScrollInProgress || previousPosition < 0) return current
+
+    val delta = snapshot.position - previousPosition
+    val accumulatedDelta = when {
+        delta == 0 -> current.accumulatedDeltaPx
+        current.accumulatedDeltaPx == 0 ||
+            current.accumulatedDeltaPx.sign == delta.sign ->
+            current.accumulatedDeltaPx + delta
+        else -> delta
+    }
+    val movedAway = accumulatedDelta <= -CHAT_SCROLL_DIRECTION_THRESHOLD_PX
+    val movedTowardNewest = accumulatedDelta >= CHAT_SCROLL_DIRECTION_THRESHOLD_PX
+
+    return current.copy(
+        followsNewest = current.followsNewest && !movedAway,
+        controlsVisible = when {
+            movedAway -> false
+            movedTowardNewest -> true
+            else -> current.controlsVisible
+        },
+        // Keep sub-threshold movement across discrete rotary events. Once intent is clear,
+        // start a fresh accumulator so reversing direction gets the same threshold treatment.
+        accumulatedDeltaPx = if (movedAway || movedTowardNewest) 0 else accumulatedDelta
+    )
 }
 
 internal suspend fun scrollToNewestAfterItemsMeasured(

--- a/wear/src/main/java/com/bitchat/watch/ui/PeerDebugScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/PeerDebugScreen.kt
@@ -46,10 +46,11 @@ fun PeerDebugScreen() {
     val rssi = mesh?.getPeerRSSI() ?: emptyMap()
     val identityRevision by WearPeerIdentityState.revision.collectAsState()
 
-    ScreenScaffold(scrollState = listState) {
+    ScreenScaffold(scrollState = listState) { contentPadding ->
         ScalingLazyColumn(
             state = listState,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/PeerDebugScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/PeerDebugScreen.kt
@@ -46,11 +46,10 @@ fun PeerDebugScreen() {
     val rssi = mesh?.getPeerRSSI() ?: emptyMap()
     val identityRevision by WearPeerIdentityState.revision.collectAsState()
 
-    ScreenScaffold(scrollState = listState) { scaffoldPadding ->
+    ScreenScaffold(scrollState = listState) {
         ScalingLazyColumn(
             state = listState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = scaffoldPadding
+            modifier = Modifier.fillMaxSize()
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/PeerDebugScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/PeerDebugScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -46,11 +47,12 @@ fun PeerDebugScreen() {
     val rssi = mesh?.getPeerRSSI() ?: emptyMap()
     val identityRevision by WearPeerIdentityState.revision.collectAsState()
 
-    ScreenScaffold(scrollState = listState) { contentPadding ->
+    ScreenScaffold(scrollState = listState) { scaffoldPadding ->
+        val layoutDirection = LocalLayoutDirection.current
         ScalingLazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = contentPadding
+            contentPadding = scaffoldPadding.withRoundScreenPadding(layoutDirection)
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/PeerDebugScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/PeerDebugScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -48,11 +47,10 @@ fun PeerDebugScreen() {
     val identityRevision by WearPeerIdentityState.revision.collectAsState()
 
     ScreenScaffold(scrollState = listState) { scaffoldPadding ->
-        val layoutDirection = LocalLayoutDirection.current
         ScalingLazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = scaffoldPadding.withRoundScreenPadding(layoutDirection)
+            contentPadding = scaffoldPadding
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/PeopleScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/PeopleScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -69,11 +68,10 @@ fun PeopleScreen(onOpenDm: (String) -> Unit, onEditNickname: () -> Unit) {
     }
 
     ScreenScaffold(scrollState = listState) { scaffoldPadding ->
-        val layoutDirection = LocalLayoutDirection.current
         ScalingLazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = scaffoldPadding.withRoundScreenPadding(layoutDirection)
+            contentPadding = scaffoldPadding
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/PeopleScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/PeopleScreen.kt
@@ -67,10 +67,11 @@ fun PeopleScreen(onOpenDm: (String) -> Unit, onEditNickname: () -> Unit) {
         )
     }
 
-    ScreenScaffold(scrollState = listState) {
+    ScreenScaffold(scrollState = listState) { contentPadding ->
         ScalingLazyColumn(
             state = listState,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/PeopleScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/PeopleScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -67,11 +68,12 @@ fun PeopleScreen(onOpenDm: (String) -> Unit, onEditNickname: () -> Unit) {
         )
     }
 
-    ScreenScaffold(scrollState = listState) { contentPadding ->
+    ScreenScaffold(scrollState = listState) { scaffoldPadding ->
+        val layoutDirection = LocalLayoutDirection.current
         ScalingLazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = contentPadding
+            contentPadding = scaffoldPadding.withRoundScreenPadding(layoutDirection)
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/UserDetailScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/UserDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.bitchat.watch.ui
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +14,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -48,11 +48,16 @@ fun UserDetailScreen(
     val listState = rememberScalingLazyListState()
     val palette = LocalBitchatPalette.current
 
-    ScreenScaffold(scrollState = listState) {
+    ScreenScaffold(scrollState = listState) { scaffoldPadding ->
+        val layoutDirection = LocalLayoutDirection.current
         ScalingLazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp)
+            contentPadding = scaffoldPadding.withAdditionalPadding(
+                layoutDirection = layoutDirection,
+                horizontal = 10.dp,
+                vertical = 8.dp
+            )
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/UserDetailScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/UserDetailScreen.kt
@@ -53,11 +53,13 @@ fun UserDetailScreen(
         ScalingLazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = scaffoldPadding.withAdditionalPadding(
-                layoutDirection = layoutDirection,
-                horizontal = 10.dp,
-                vertical = 8.dp
-            )
+            contentPadding = scaffoldPadding
+                .withRoundScreenPadding(layoutDirection)
+                .withAdditionalPadding(
+                    layoutDirection = layoutDirection,
+                    horizontal = 10.dp,
+                    vertical = 8.dp
+                )
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/UserDetailScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/UserDetailScreen.kt
@@ -54,7 +54,6 @@ fun UserDetailScreen(
             state = listState,
             modifier = Modifier.fillMaxSize(),
             contentPadding = scaffoldPadding
-                .withRoundScreenPadding(layoutDirection)
                 .withAdditionalPadding(
                     layoutDirection = layoutDirection,
                     horizontal = 10.dp,

--- a/wear/src/main/java/com/bitchat/watch/ui/VerificationCodeScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/VerificationCodeScreen.kt
@@ -48,11 +48,13 @@ fun VerificationCodeScreen(peerID: String) {
         ScalingLazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = scaffoldPadding.withAdditionalPadding(
-                layoutDirection = layoutDirection,
-                horizontal = 10.dp,
-                vertical = 8.dp
-            )
+            contentPadding = scaffoldPadding
+                .withRoundScreenPadding(layoutDirection)
+                .withAdditionalPadding(
+                    layoutDirection = layoutDirection,
+                    horizontal = 10.dp,
+                    vertical = 8.dp
+                )
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/VerificationCodeScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/VerificationCodeScreen.kt
@@ -49,7 +49,6 @@ fun VerificationCodeScreen(peerID: String) {
             state = listState,
             modifier = Modifier.fillMaxSize(),
             contentPadding = scaffoldPadding
-                .withRoundScreenPadding(layoutDirection)
                 .withAdditionalPadding(
                     layoutDirection = layoutDirection,
                     horizontal = 10.dp,

--- a/wear/src/main/java/com/bitchat/watch/ui/VerificationCodeScreen.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/VerificationCodeScreen.kt
@@ -2,7 +2,6 @@ package com.bitchat.watch.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,6 +13,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -43,11 +43,16 @@ fun VerificationCodeScreen(peerID: String) {
     val listState = rememberScalingLazyListState()
     val palette = LocalBitchatPalette.current
 
-    ScreenScaffold(scrollState = listState) {
+    ScreenScaffold(scrollState = listState) { scaffoldPadding ->
+        val layoutDirection = LocalLayoutDirection.current
         ScalingLazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp)
+            contentPadding = scaffoldPadding.withAdditionalPadding(
+                layoutDirection = layoutDirection,
+                horizontal = 10.dp,
+                vertical = 8.dp
+            )
         ) {
             item {
                 ListHeader {

--- a/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
@@ -1,0 +1,52 @@
+package com.bitchat.watch.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+
+/**
+ * Preserve the responsive, shape-aware padding supplied by Wear Material while allowing a
+ * screen to reserve additional room for its own content or floating controls.
+ */
+internal fun PaddingValues.withAdditionalPadding(
+    layoutDirection: LayoutDirection,
+    horizontal: Dp = 0.dp,
+    vertical: Dp = 0.dp
+): PaddingValues {
+    val start = when (layoutDirection) {
+        LayoutDirection.Ltr -> calculateLeftPadding(layoutDirection)
+        LayoutDirection.Rtl -> calculateRightPadding(layoutDirection)
+    }
+    val end = when (layoutDirection) {
+        LayoutDirection.Ltr -> calculateRightPadding(layoutDirection)
+        LayoutDirection.Rtl -> calculateLeftPadding(layoutDirection)
+    }
+    return PaddingValues(
+        start = start + horizontal,
+        top = calculateTopPadding() + vertical,
+        end = end + horizontal,
+        bottom = calculateBottomPadding() + vertical
+    )
+}
+
+internal fun PaddingValues.withMinimumVerticalPadding(
+    layoutDirection: LayoutDirection,
+    top: Dp,
+    bottom: Dp
+): PaddingValues {
+    val start = when (layoutDirection) {
+        LayoutDirection.Ltr -> calculateLeftPadding(layoutDirection)
+        LayoutDirection.Rtl -> calculateRightPadding(layoutDirection)
+    }
+    val end = when (layoutDirection) {
+        LayoutDirection.Ltr -> calculateRightPadding(layoutDirection)
+        LayoutDirection.Rtl -> calculateLeftPadding(layoutDirection)
+    }
+    return PaddingValues(
+        start = start,
+        top = maxOf(calculateTopPadding(), top),
+        end = end,
+        bottom = maxOf(calculateBottomPadding(), bottom)
+    )
+}

--- a/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
@@ -31,12 +31,14 @@ internal fun PaddingValues.withAdditionalPadding(
 }
 
 /**
- * Keep the responsive horizontal inset supplied by Wear Material without also reserving its
- * vertical list padding. Chat owns its fixed header and action-bar clearances, so stacking the
- * scaffold's vertical padding on top would unnecessarily shorten the message viewport.
+ * Keep the responsive horizontal inset supplied by Wear Material while replacing its vertical
+ * padding with screen-owned clearances. This keeps the lazy list full-screen for correct Wear
+ * transformation and scroll calculations without stacking duplicate vertical insets.
  */
-internal fun PaddingValues.horizontalOnly(
-    layoutDirection: LayoutDirection
+internal fun PaddingValues.withVerticalClearance(
+    layoutDirection: LayoutDirection,
+    top: Dp,
+    bottom: Dp
 ): PaddingValues {
     val start = when (layoutDirection) {
         LayoutDirection.Ltr -> calculateLeftPadding(layoutDirection)
@@ -46,5 +48,5 @@ internal fun PaddingValues.horizontalOnly(
         LayoutDirection.Ltr -> calculateRightPadding(layoutDirection)
         LayoutDirection.Rtl -> calculateLeftPadding(layoutDirection)
     }
-    return PaddingValues(start = start, end = end)
+    return PaddingValues(start = start, top = top, end = end, bottom = bottom)
 }

--- a/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
@@ -1,9 +1,12 @@
 package com.bitchat.watch.ui
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import kotlin.math.ceil
 
 /**
  * Preserve the responsive, shape-aware padding supplied by Wear Material while allowing a
@@ -50,3 +53,25 @@ internal fun PaddingValues.withMinimumVerticalPadding(
         bottom = maxOf(calculateBottomPadding(), bottom)
     )
 }
+
+@Composable
+internal fun PaddingValues.withRoundScreenPadding(
+    layoutDirection: LayoutDirection
+): PaddingValues = withAdditionalPadding(
+    layoutDirection = layoutDirection,
+    horizontal = additionalRoundScreenPadding(
+        screenWidthDp = LocalConfiguration.current.screenWidthDp,
+        isScreenRound = LocalConfiguration.current.isScreenRound
+    )
+)
+
+internal fun additionalRoundScreenPadding(
+    screenWidthDp: Int,
+    isScreenRound: Boolean
+): Dp = if (isScreenRound) {
+    ceil(screenWidthDp * ROUND_SCREEN_ADDITIONAL_PADDING_FRACTION).toInt().dp
+} else {
+    0.dp
+}
+
+private const val ROUND_SCREEN_ADDITIONAL_PADDING_FRACTION = 0.10f

--- a/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
@@ -33,27 +33,6 @@ internal fun PaddingValues.withAdditionalPadding(
     )
 }
 
-internal fun PaddingValues.withMinimumVerticalPadding(
-    layoutDirection: LayoutDirection,
-    top: Dp,
-    bottom: Dp
-): PaddingValues {
-    val start = when (layoutDirection) {
-        LayoutDirection.Ltr -> calculateLeftPadding(layoutDirection)
-        LayoutDirection.Rtl -> calculateRightPadding(layoutDirection)
-    }
-    val end = when (layoutDirection) {
-        LayoutDirection.Ltr -> calculateRightPadding(layoutDirection)
-        LayoutDirection.Rtl -> calculateLeftPadding(layoutDirection)
-    }
-    return PaddingValues(
-        start = start,
-        top = maxOf(calculateTopPadding(), top),
-        end = end,
-        bottom = maxOf(calculateBottomPadding(), bottom)
-    )
-}
-
 @Composable
 internal fun PaddingValues.withRoundScreenPadding(
     layoutDirection: LayoutDirection

--- a/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
@@ -14,18 +14,10 @@ internal fun PaddingValues.withAdditionalPadding(
     horizontal: Dp = 0.dp,
     vertical: Dp = 0.dp
 ): PaddingValues {
-    val start = when (layoutDirection) {
-        LayoutDirection.Ltr -> calculateLeftPadding(layoutDirection)
-        LayoutDirection.Rtl -> calculateRightPadding(layoutDirection)
-    }
-    val end = when (layoutDirection) {
-        LayoutDirection.Ltr -> calculateRightPadding(layoutDirection)
-        LayoutDirection.Rtl -> calculateLeftPadding(layoutDirection)
-    }
     return PaddingValues(
-        start = start + horizontal,
+        start = calculateStartPadding(layoutDirection) + horizontal,
         top = calculateTopPadding() + vertical,
-        end = end + horizontal,
+        end = calculateEndPadding(layoutDirection) + horizontal,
         bottom = calculateBottomPadding() + vertical
     )
 }
@@ -40,13 +32,22 @@ internal fun PaddingValues.withVerticalClearance(
     top: Dp,
     bottom: Dp
 ): PaddingValues {
-    val start = when (layoutDirection) {
+    return PaddingValues(
+        start = calculateStartPadding(layoutDirection),
+        top = top,
+        end = calculateEndPadding(layoutDirection),
+        bottom = bottom
+    )
+}
+
+private fun PaddingValues.calculateStartPadding(layoutDirection: LayoutDirection): Dp =
+    when (layoutDirection) {
         LayoutDirection.Ltr -> calculateLeftPadding(layoutDirection)
         LayoutDirection.Rtl -> calculateRightPadding(layoutDirection)
     }
-    val end = when (layoutDirection) {
+
+private fun PaddingValues.calculateEndPadding(layoutDirection: LayoutDirection): Dp =
+    when (layoutDirection) {
         LayoutDirection.Ltr -> calculateRightPadding(layoutDirection)
         LayoutDirection.Rtl -> calculateLeftPadding(layoutDirection)
     }
-    return PaddingValues(start = start, top = top, end = end, bottom = bottom)
-}

--- a/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
+++ b/wear/src/main/java/com/bitchat/watch/ui/WearContentPadding.kt
@@ -1,12 +1,9 @@
 package com.bitchat.watch.ui
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import kotlin.math.ceil
 
 /**
  * Preserve the responsive, shape-aware padding supplied by Wear Material while allowing a
@@ -33,24 +30,21 @@ internal fun PaddingValues.withAdditionalPadding(
     )
 }
 
-@Composable
-internal fun PaddingValues.withRoundScreenPadding(
+/**
+ * Keep the responsive horizontal inset supplied by Wear Material without also reserving its
+ * vertical list padding. Chat owns its fixed header and action-bar clearances, so stacking the
+ * scaffold's vertical padding on top would unnecessarily shorten the message viewport.
+ */
+internal fun PaddingValues.horizontalOnly(
     layoutDirection: LayoutDirection
-): PaddingValues = withAdditionalPadding(
-    layoutDirection = layoutDirection,
-    horizontal = additionalRoundScreenPadding(
-        screenWidthDp = LocalConfiguration.current.screenWidthDp,
-        isScreenRound = LocalConfiguration.current.isScreenRound
-    )
-)
-
-internal fun additionalRoundScreenPadding(
-    screenWidthDp: Int,
-    isScreenRound: Boolean
-): Dp = if (isScreenRound) {
-    ceil(screenWidthDp * ROUND_SCREEN_ADDITIONAL_PADDING_FRACTION).toInt().dp
-} else {
-    0.dp
+): PaddingValues {
+    val start = when (layoutDirection) {
+        LayoutDirection.Ltr -> calculateLeftPadding(layoutDirection)
+        LayoutDirection.Rtl -> calculateRightPadding(layoutDirection)
+    }
+    val end = when (layoutDirection) {
+        LayoutDirection.Ltr -> calculateRightPadding(layoutDirection)
+        LayoutDirection.Rtl -> calculateLeftPadding(layoutDirection)
+    }
+    return PaddingValues(start = start, end = end)
 }
-
-private const val ROUND_SCREEN_ADDITIONAL_PADDING_FRACTION = 0.10f

--- a/wear/src/test/java/com/bitchat/watch/ui/ChatAutoScrollTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/ChatAutoScrollTest.kt
@@ -11,6 +11,46 @@ import org.junit.Test
 class ChatAutoScrollTest {
 
     @Test
+    fun `new scroll range from appended message keeps follow intent`() {
+        val updated = updatedFollowNewest(
+            current = true,
+            snapshot = ChatScrollSnapshot(
+                canScrollForward = true,
+                isScrollInProgress = false,
+                position = 100
+            ),
+            previousPosition = 100
+        )
+
+        assertEquals(true, updated)
+    }
+
+    @Test
+    fun `user scroll away disables follow until list reaches newest again`() {
+        val browsingHistory = updatedFollowNewest(
+            current = true,
+            snapshot = ChatScrollSnapshot(
+                canScrollForward = true,
+                isScrollInProgress = true,
+                position = 60
+            ),
+            previousPosition = 100
+        )
+        assertFalse(browsingHistory)
+
+        val dockedAgain = updatedFollowNewest(
+            current = browsingHistory,
+            snapshot = ChatScrollSnapshot(
+                canScrollForward = false,
+                isScrollInProgress = false,
+                position = 200
+            ),
+            previousPosition = 60
+        )
+        assertEquals(true, dockedAgain)
+    }
+
+    @Test
     fun `newest scroll waits until appended message is measured`() = runTest {
         val measuredLayouts = MutableStateFlow(MeasuredChatLayout(3, null))
         var scrollCount = 0

--- a/wear/src/test/java/com/bitchat/watch/ui/ChatAutoScrollTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/ChatAutoScrollTest.kt
@@ -12,8 +12,8 @@ class ChatAutoScrollTest {
 
     @Test
     fun `new scroll range from appended message keeps follow intent`() {
-        val updated = updatedFollowNewest(
-            current = true,
+        val updated = updatedChatScrollIntent(
+            current = ChatScrollIntentState(),
             snapshot = ChatScrollSnapshot(
                 canScrollForward = true,
                 isScrollInProgress = false,
@@ -22,13 +22,13 @@ class ChatAutoScrollTest {
             previousPosition = 100
         )
 
-        assertEquals(true, updated)
+        assertEquals(ChatScrollIntentState(), updated)
     }
 
     @Test
     fun `user scroll away disables follow until list reaches newest again`() {
-        val browsingHistory = updatedFollowNewest(
-            current = true,
+        val browsingHistory = updatedChatScrollIntent(
+            current = ChatScrollIntentState(),
             snapshot = ChatScrollSnapshot(
                 canScrollForward = true,
                 isScrollInProgress = true,
@@ -36,9 +36,10 @@ class ChatAutoScrollTest {
             ),
             previousPosition = 100
         )
-        assertFalse(browsingHistory)
+        assertFalse(browsingHistory.followsNewest)
+        assertFalse(browsingHistory.controlsVisible)
 
-        val dockedAgain = updatedFollowNewest(
+        val dockedAgain = updatedChatScrollIntent(
             current = browsingHistory,
             snapshot = ChatScrollSnapshot(
                 canScrollForward = false,
@@ -47,7 +48,62 @@ class ChatAutoScrollTest {
             ),
             previousPosition = 60
         )
-        assertEquals(true, dockedAgain)
+        assertEquals(ChatScrollIntentState(), dockedAgain)
+    }
+
+    @Test
+    fun `slow scroll away accumulates intent across sub-threshold updates`() {
+        var state = ChatScrollIntentState()
+        var previousPosition = 100
+
+        listOf(94, 88, 82, 76).forEach { position ->
+            state = updatedChatScrollIntent(
+                current = state,
+                snapshot = ChatScrollSnapshot(
+                    canScrollForward = true,
+                    isScrollInProgress = true,
+                    position = position
+                ),
+                previousPosition = previousPosition
+            )
+            previousPosition = position
+            state = updatedChatScrollIntent(
+                current = state,
+                snapshot = ChatScrollSnapshot(
+                    canScrollForward = true,
+                    isScrollInProgress = false,
+                    position = position
+                ),
+                previousPosition = previousPosition
+            )
+        }
+
+        assertFalse(state.followsNewest)
+        assertFalse(state.controlsVisible)
+        assertEquals(0, state.accumulatedDeltaPx)
+    }
+
+    @Test
+    fun `slow scroll toward newest reveals controls without restoring follow early`() {
+        var state = ChatScrollIntentState(followsNewest = false, controlsVisible = false)
+        var previousPosition = 60
+
+        listOf(66, 72, 78, 84).forEach { position ->
+            state = updatedChatScrollIntent(
+                current = state,
+                snapshot = ChatScrollSnapshot(
+                    canScrollForward = true,
+                    isScrollInProgress = true,
+                    position = position
+                ),
+                previousPosition = previousPosition
+            )
+            previousPosition = position
+        }
+
+        assertFalse(state.followsNewest)
+        assertEquals(true, state.controlsVisible)
+        assertEquals(0, state.accumulatedDeltaPx)
     }
 
     @Test

--- a/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
@@ -24,13 +24,17 @@ class WearContentPaddingTest {
     }
 
     @Test
-    fun `horizontal only padding preserves width inset and restores vertical space`() {
+    fun `vertical clearance preserves responsive width and replaces scaffold height inset`() {
         val resolved = PaddingValues(start = 10.dp, top = 20.dp, end = 12.dp, bottom = 20.dp)
-            .horizontalOnly(LayoutDirection.Ltr)
+            .withVerticalClearance(
+                layoutDirection = LayoutDirection.Ltr,
+                top = 30.dp,
+                bottom = 64.dp
+            )
 
         assertEquals(10.dp, resolved.calculateLeftPadding(LayoutDirection.Ltr))
         assertEquals(12.dp, resolved.calculateRightPadding(LayoutDirection.Ltr))
-        assertEquals(0.dp, resolved.calculateTopPadding())
-        assertEquals(0.dp, resolved.calculateBottomPadding())
+        assertEquals(30.dp, resolved.calculateTopPadding())
+        assertEquals(64.dp, resolved.calculateBottomPadding())
     }
 }

--- a/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
@@ -1,0 +1,40 @@
+package com.bitchat.watch.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WearContentPaddingTest {
+
+    @Test
+    fun `additional padding preserves scaffold insets`() {
+        val resolved = PaddingValues(start = 10.dp, top = 18.dp, end = 12.dp, bottom = 20.dp)
+            .withAdditionalPadding(
+                layoutDirection = LayoutDirection.Ltr,
+                horizontal = 10.dp,
+                vertical = 8.dp
+            )
+
+        assertEquals(20.dp, resolved.calculateLeftPadding(LayoutDirection.Ltr))
+        assertEquals(22.dp, resolved.calculateRightPadding(LayoutDirection.Ltr))
+        assertEquals(26.dp, resolved.calculateTopPadding())
+        assertEquals(28.dp, resolved.calculateBottomPadding())
+    }
+
+    @Test
+    fun `chat padding keeps responsive sides and overlay clearances`() {
+        val resolved = PaddingValues(start = 10.dp, top = 18.dp, end = 12.dp, bottom = 20.dp)
+            .withMinimumVerticalPadding(
+                layoutDirection = LayoutDirection.Ltr,
+                top = 30.dp,
+                bottom = 64.dp
+            )
+
+        assertEquals(10.dp, resolved.calculateLeftPadding(LayoutDirection.Ltr))
+        assertEquals(12.dp, resolved.calculateRightPadding(LayoutDirection.Ltr))
+        assertEquals(30.dp, resolved.calculateTopPadding())
+        assertEquals(64.dp, resolved.calculateBottomPadding())
+    }
+}

--- a/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
@@ -37,4 +37,34 @@ class WearContentPaddingTest {
         assertEquals(30.dp, resolved.calculateTopPadding())
         assertEquals(64.dp, resolved.calculateBottomPadding())
     }
+
+    @Test
+    fun `additional padding preserves logical start and end in rtl`() {
+        val resolved = PaddingValues(start = 10.dp, top = 18.dp, end = 12.dp, bottom = 20.dp)
+            .withAdditionalPadding(
+                layoutDirection = LayoutDirection.Rtl,
+                horizontal = 10.dp,
+                vertical = 8.dp
+            )
+
+        assertEquals(22.dp, resolved.calculateLeftPadding(LayoutDirection.Rtl))
+        assertEquals(20.dp, resolved.calculateRightPadding(LayoutDirection.Rtl))
+        assertEquals(26.dp, resolved.calculateTopPadding())
+        assertEquals(28.dp, resolved.calculateBottomPadding())
+    }
+
+    @Test
+    fun `vertical clearance preserves logical start and end in rtl`() {
+        val resolved = PaddingValues(start = 10.dp, top = 20.dp, end = 12.dp, bottom = 20.dp)
+            .withVerticalClearance(
+                layoutDirection = LayoutDirection.Rtl,
+                top = 30.dp,
+                bottom = 64.dp
+            )
+
+        assertEquals(12.dp, resolved.calculateLeftPadding(LayoutDirection.Rtl))
+        assertEquals(10.dp, resolved.calculateRightPadding(LayoutDirection.Rtl))
+        assertEquals(30.dp, resolved.calculateTopPadding())
+        assertEquals(64.dp, resolved.calculateBottomPadding())
+    }
 }

--- a/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
@@ -24,9 +24,13 @@ class WearContentPaddingTest {
     }
 
     @Test
-    fun `round screens receive an additional ten percent inset`() {
-        assertEquals(20.dp, additionalRoundScreenPadding(192, isScreenRound = true))
-        assertEquals(22.dp, additionalRoundScreenPadding(220, isScreenRound = true))
-        assertEquals(0.dp, additionalRoundScreenPadding(192, isScreenRound = false))
+    fun `horizontal only padding preserves width inset and restores vertical space`() {
+        val resolved = PaddingValues(start = 10.dp, top = 20.dp, end = 12.dp, bottom = 20.dp)
+            .horizontalOnly(LayoutDirection.Ltr)
+
+        assertEquals(10.dp, resolved.calculateLeftPadding(LayoutDirection.Ltr))
+        assertEquals(12.dp, resolved.calculateRightPadding(LayoutDirection.Ltr))
+        assertEquals(0.dp, resolved.calculateTopPadding())
+        assertEquals(0.dp, resolved.calculateBottomPadding())
     }
 }

--- a/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
@@ -37,4 +37,11 @@ class WearContentPaddingTest {
         assertEquals(30.dp, resolved.calculateTopPadding())
         assertEquals(64.dp, resolved.calculateBottomPadding())
     }
+
+    @Test
+    fun `round screens receive an additional ten percent inset`() {
+        assertEquals(20.dp, additionalRoundScreenPadding(192, isScreenRound = true))
+        assertEquals(22.dp, additionalRoundScreenPadding(220, isScreenRound = true))
+        assertEquals(0.dp, additionalRoundScreenPadding(192, isScreenRound = false))
+    }
 }

--- a/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
+++ b/wear/src/test/java/com/bitchat/watch/ui/WearContentPaddingTest.kt
@@ -24,21 +24,6 @@ class WearContentPaddingTest {
     }
 
     @Test
-    fun `chat padding keeps responsive sides and overlay clearances`() {
-        val resolved = PaddingValues(start = 10.dp, top = 18.dp, end = 12.dp, bottom = 20.dp)
-            .withMinimumVerticalPadding(
-                layoutDirection = LayoutDirection.Ltr,
-                top = 30.dp,
-                bottom = 64.dp
-            )
-
-        assertEquals(10.dp, resolved.calculateLeftPadding(LayoutDirection.Ltr))
-        assertEquals(12.dp, resolved.calculateRightPadding(LayoutDirection.Ltr))
-        assertEquals(30.dp, resolved.calculateTopPadding())
-        assertEquals(64.dp, resolved.calculateBottomPadding())
-    }
-
-    @Test
     fun `round screens receive an additional ten percent inset`() {
         assertEquals(20.dp, additionalRoundScreenPadding(192, isScreenRound = true))
         assertEquals(22.dp, additionalRoundScreenPadding(220, isScreenRound = true))


### PR DESCRIPTION
## Summary

- preserve responsive shape-aware insets across Wear chat and list surfaces
- fade chat history naturally toward the circular contour while keeping overlay controls readable
- keep newest-message autoscroll stable and prevent focal scaling of the final row
- centralize direction-aware content padding and cover both LTR and RTL behavior
- increment the Wear release version to 0.1.2

## Validation

- Wear unit tests
- Wear lint
- 192 dp round emulator at default and 1.3x font scales with alternating synthetic messages
- focused cleanup produced byte-identical screenshots before and after refactoring

<img width="384" height="384" alt="after-wear-chat-messages-192dp-normal-font" src="https://github.com/user-attachments/assets/6e602f16-f786-4a5f-bd09-e8bf92af0f51" />
<img width="384" height="384" alt="after-wear-chat-messages-192dp-large-font" src="https://github.com/user-attachments/assets/c7606977-7c42-43cc-9af8-3e318c8eb095" />

