### PR TITLE
Raise NIP-17 gift-wrap fetch limit from 100 to 1000

### DIFF
--- a/app/src/main/java/com/bitchat/android/nostr/NostrFilter.kt
+++ b/app/src/main/java/com/bitchat/android/nostr/NostrFilter.kt
@@ -23,11 +23,15 @@ data class NostrFilter(
          * Create filter for NIP-17 gift wraps
          */
         fun giftWrapsFor(pubkey: String, since: Long? = null): NostrFilter {
+            // Each delivered+read DM is typically three gift wraps (message, delivery
+            // ack, read receipt). A limit of 100 therefore covers only ~33 messages
+            // inside the lookback, and NIP-01 returns the newest-by-created_at which
+            // is randomized — so loss is permanent. Match the geohash fetch budget.
             return NostrFilter(
                 kinds = listOf(NostrKind.GIFT_WRAP),
                 since = since?.let { (it / 1000).toInt() },
                 tagFilters = mapOf("p" to listOf(pubkey)),
-                limit = 100
+                limit = 1000
             )
         }
         


### PR DESCRIPTION
## Summary
- `NostrFilter.giftWrapsFor` used `limit = 100`. Relays return at most that many stored events, newest by randomized `created_at`.
- One delivered+read DM is typically three gift wraps, so 100 ≈ 33 messages inside the lookback — and loss is permanent across restarts.
- Raise to 1000 (same budget as geohash message fetches).

## Test plan
- [ ] Cold-start with a busy DM inbox; more historical gift wraps arrive than before
- [ ] Live gift wraps after EOSE still flow

Refs #858