### PR TITLE
Fall back when encrypted channel send is unimplemented

### DIFF
--- a/app/src/main/java/com/bitchat/android/ui/ChannelManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChannelManager.kt
@@ -174,8 +174,11 @@ class ChannelManager(
         onEncryptedPayload: (ByteArray) -> Unit,
         onFallback: () -> Unit
     ) {
-        // TODO: REIMPLEMENT – REMOVED FOR NOW
-        return
+        // Channel AES path was removed; never no-op — callers only transmit from
+        // the callbacks, so a bare return permanently drops password-channel sends.
+        // Fall back to the unencrypted channel/mesh send path until encryption
+        // is restored end-to-end.
+        onFallback()
     }
     
     // MARK: - Channel Management


### PR DESCRIPTION
## Summary
- `ChannelManager.sendEncryptedChannelMessage` returned without calling `onEncryptedPayload` or `onFallback`.
- Callers only transmit from those callbacks, so password-protected channel sends never left the device.
- Invoke `onFallback()` until the AES path is restored end-to-end.

## Test plan
- [ ] Send in a password-protected channel — message reaches peers via the fallback path
- [ ] Local echo still appears in the channel timeline

Refs #919