### PR TITLE
Bump Android version to 2.0.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ android {
         applicationId = "com.bitchat.droid"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 38
-        versionName = "2.0.1"
+        versionCode = 39
+        versionName = "2.0.2"
         buildConfigField(
             "String",
             "GITHUB_RELEASE_CERT_SHA256",


### PR DESCRIPTION
Updates the Android release metadata to 2.0.2 (code 39). Wear remains 0.1.2 (code 1000000003).

Tests: `:app:testDebugUnitTest`, `:wear:testDebugUnitTest`, `:app:lintDebug`, and `:wear:lintDebug`.