### PR TITLE
Reject odd-length and 0x-prefixed hex the way iOS does

### DIFF
--- a/app/src/main/java/com/bitchat/android/util/BinaryEncodingUtils.kt
+++ b/app/src/main/java/com/bitchat/android/util/BinaryEncodingUtils.kt
@@ -19,16 +19,27 @@ fun ByteArray.hexEncodedString(): String {
 }
 
 fun String.dataFromHexString(): ByteArray? {
-    val len = this.length / 2
-    val data = ByteArray(len)
-    var index = 0
-    
-    for (i in 0 until len) {
-        val hexByte = this.substring(i * 2, i * 2 + 2)
-        val byte = hexByte.toIntOrNull(16)?.toByte() ?: return null
-        data[index++] = byte
+    // Match iOS Data(hexString:): trim, optional 0x/0X prefix, reject odd length.
+    var hex = this.trim()
+    if (hex.startsWith("0x", ignoreCase = true)) {
+        hex = hex.substring(2)
     }
-    
+    if (hex.isEmpty()) {
+        return ByteArray(0)
+    }
+    if (hex.length % 2 != 0) {
+        return null
+    }
+
+    val len = hex.length / 2
+    val data = ByteArray(len)
+
+    for (i in 0 until len) {
+        val hexByte = hex.substring(i * 2, i * 2 + 2)
+        val byte = hexByte.toIntOrNull(16)?.toByte() ?: return null
+        data[i] = byte
+    }
+
     return data
 }
 

--- a/app/src/main/java/com/bitchat/android/util/BinaryEncodingUtils.kt
+++ b/app/src/main/java/com/bitchat/android/util/BinaryEncodingUtils.kt
@@ -27,7 +27,8 @@ fun String.dataFromHexString(): ByteArray? {
     if (hex.isEmpty()) {
         return ByteArray(0)
     }
-    if (hex.length % 2 != 0) {
+    // Radix parsing accepts signs and Unicode digits; encoded bytes require ASCII hex.
+    if (hex.length % 2 != 0 || hex.any { it !in '0'..'9' && it !in 'a'..'f' && it !in 'A'..'F' }) {
         return null
     }
 

--- a/app/src/test/java/com/bitchat/android/util/HexStringTest.kt
+++ b/app/src/test/java/com/bitchat/android/util/HexStringTest.kt
@@ -1,0 +1,58 @@
+package com.bitchat.android.util
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HexStringTest {
+
+    @Test
+    fun `decodes even-length lowercase hex`() {
+        assertArrayEquals(
+            byteArrayOf(0x0a, 0xbc.toByte()),
+            "0abc".dataFromHexString()
+        )
+    }
+
+    @Test
+    fun `rejects odd-length hex instead of truncating`() {
+        // Previously length/2 silently dropped the trailing nibble.
+        assertNull("abc".dataFromHexString())
+        assertNull("0ab".dataFromHexString())
+    }
+
+    @Test
+    fun `strips optional 0x prefix like iOS`() {
+        assertArrayEquals(
+            byteArrayOf(0xde.toByte(), 0xad.toByte()),
+            "0xdead".dataFromHexString()
+        )
+        assertArrayEquals(
+            byteArrayOf(0xbe.toByte(), 0xef.toByte()),
+            "0Xbeef".dataFromHexString()
+        )
+    }
+
+    @Test
+    fun `empty string and empty after prefix yield empty array`() {
+        assertArrayEquals(ByteArray(0), "".dataFromHexString())
+        assertArrayEquals(ByteArray(0), "0x".dataFromHexString())
+        assertTrue("  ".dataFromHexString()!!.isEmpty())
+    }
+
+    @Test
+    fun `rejects non-hex characters`() {
+        assertNull("zz".dataFromHexString())
+        assertNull("0xgg".dataFromHexString())
+    }
+
+    @Test
+    fun `round-trips with hexEncodedString`() {
+        val original = byteArrayOf(0x00, 0x7f, 0xff.toByte())
+        val encoded = original.hexEncodedString()
+        assertEquals("007fff", encoded)
+        assertArrayEquals(original, encoded.dataFromHexString())
+    }
+}

--- a/app/src/test/java/com/bitchat/android/util/HexStringTest.kt
+++ b/app/src/test/java/com/bitchat/android/util/HexStringTest.kt
@@ -49,6 +49,13 @@ class HexStringTest {
     }
 
     @Test
+    fun `rejects signed byte chunks and non-ascii digits`() {
+        for (invalid in listOf("0x-1", "0x+1", "-1", "+1", "00-1", "0X+100", "０１")) {
+            assertNull(invalid.dataFromHexString())
+        }
+    }
+
+    @Test
     fun `round-trips with hexEncodedString`() {
         val original = byteArrayOf(0x00, 0x7f, 0xff.toByte())
         val encoded = original.hexEncodedString()


### PR DESCRIPTION
## Summary
- Match iOS hex parsing: trim whitespace, remove an optional `0x`/`0X` prefix, reject odd lengths, and preserve empty input as empty bytes.
- Reject signed and non-ASCII chunks before radix conversion so inputs such as `0x-1`, `+1`, and full-width digits cannot decode as hex bytes.

## Validation
- Compiled the production Kotlin utility and its focused JUnit class on the JVM: all 7 tests pass.
- The new signed/non-ASCII regression fails against the previous implementation.
- Android CI is running. The full Android build and physical Mesh Lab validation were not performed locally.
