### PR TITLE
Bump Wear OS version to 0.1.3

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -19,8 +19,8 @@ android {
         targetSdk = libs.versions.targetSdk.get().toInt()
         // Wear releases use a separate high range because Play requires every artifact in
         // one application ID to have a unique version code across all form factors.
-        versionCode = 1_000_000_003
-        versionName = "0.1.2"
+        versionCode = 1_000_000_004
+        versionName = "0.1.3"
 
         vectorDrawables {
             useSupportLibrary = true


### PR DESCRIPTION
## Summary

- Bump Wear OS to 0.1.3 (version code 1000000004) for the round-screen layout and chat-scrolling fixes merged in #931.
- Keep the phone version at 2.0.2 (39); no phone update is included in this release preparation.

## Validation

- Version-only change; no runtime source changes after #931.
- #931 passed unit tests, lint, debug builds, and independent canonical release byte comparison.
- Wear unit tests and release-bundle build checked for this version bump.

## Risk

Low: two release metadata values change. The new code is in the dedicated Wear range and replaces 1000000003; the phone version and release track remain unchanged.
